### PR TITLE
chore(deps): bump vercel-deploy-scripts from v1.2.0 to v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "onlyBuiltDependencies": [
       "@firebase/util",
       "esbuild",
-      "protobufjs"
+      "protobufjs",
+      "vercel-deploy-scripts"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v1.2.0",
+    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v1.7.0",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/nextjs-vite": "^10.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^52.0.0
         version: 52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.2)(typescript@6.0.3)
       vercel-deploy-scripts:
-        specifier: github:rmartz/vercel-deploy-scripts#v1.2.0
-        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/7748cf9a004b5c990fa51123592f6f3b96328031
+        specifier: github:rmartz/vercel-deploy-scripts#v1.7.0
+        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -5691,8 +5691,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/7748cf9a004b5c990fa51123592f6f3b96328031:
-    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/7748cf9a004b5c990fa51123592f6f3b96328031}
+  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a:
+    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a}
     version: 0.0.0
     engines: {node: '>=18'}
     hasBin: true
@@ -11796,7 +11796,9 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/7748cf9a004b5c990fa51123592f6f3b96328031: {}
+  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a:
+    dependencies:
+      js-yaml: 4.1.1
 
   vercel@52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.2)(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
Bumps `vercel-deploy-scripts` from v1.2.0 to v1.7.0.

---
*Created by Claude Sonnet 4.6*