### PR TITLE
chore: bump vercel-deploy-scripts from v1.7.0 to v2.3.3

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,4 @@
+{
+  "projectId": "prj_rCP7hdLP717j2H0a70tIEDVfTCD6",
+  "orgId": "team_kVIsLOZBHQLTMtnVSltoDb1g"
+}

--- a/deployment/environments.yml
+++ b/deployment/environments.yml
@@ -14,7 +14,7 @@
 # Re-add "- staging" below and set single_environment: false once the RTDB is
 # provisioned and staging credentials are ready.
 
-environments:
+active:
   - production
 
 single_environment: true

--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -24,6 +24,7 @@ variables:
   # Firebase Admin SDK — project identifiers only, not credentials
   FIREBASE_PROJECT_ID: "group-picks"
   FIREBASE_DATABASE_URL: "https://group-picks-default-rtdb.firebaseio.com"
+  FIREBASE_SA_EMAIL: "firebase-adminsdk-fbsvc@group-picks.iam.gserviceaccount.com"
 
   # Sentry — slugs only, not credentials
   SENTRY_ORG: ""

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "onlyBuiltDependencies": [
       "@firebase/util",
       "esbuild",
-      "protobufjs",
-      "vercel-deploy-scripts"
+      "protobufjs"
     ]
   },
   "dependencies": {
@@ -56,7 +55,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v2.1.0",
+    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v2.3.3",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/nextjs-vite": "^10.3.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v1.7.0",
+    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v2.1.0",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/nextjs-vite": "^10.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^52.0.0
         version: 52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.2)(typescript@6.0.3)
       vercel-deploy-scripts:
-        specifier: github:rmartz/vercel-deploy-scripts#v1.7.0
-        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a
+        specifier: github:rmartz/vercel-deploy-scripts#v2.1.0
+        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -5691,10 +5691,10 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a:
-    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a}
+  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a:
+    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a}
     version: 0.0.0
-    engines: {node: '>=18'}
+    engines: {node: '>=18', pnpm: '>=9'}
     hasBin: true
 
   vercel@52.0.0:
@@ -11796,7 +11796,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/90461fa5b408c4c307cd701123522f475f139a6a:
+  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a:
     dependencies:
       js-yaml: 4.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^52.0.0
         version: 52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.2)(typescript@6.0.3)
       vercel-deploy-scripts:
-        specifier: github:rmartz/vercel-deploy-scripts#v2.1.0
-        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a
+        specifier: github:rmartz/vercel-deploy-scripts#v2.3.3
+        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/73b3ca9c88d8a8ee7da1dc7ab5898bab5c37623a
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -5691,8 +5691,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a:
-    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a}
+  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/73b3ca9c88d8a8ee7da1dc7ab5898bab5c37623a:
+    resolution: {tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/73b3ca9c88d8a8ee7da1dc7ab5898bab5c37623a}
     version: 0.0.0
     engines: {node: '>=18', pnpm: '>=9'}
     hasBin: true
@@ -11796,7 +11796,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/414b1478311a9dd40cca3f88c5260a48d169858a:
+  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/73b3ca9c88d8a8ee7da1dc7ab5898bab5c37623a:
     dependencies:
       js-yaml: 4.1.1
 


### PR DESCRIPTION
Bumps `vercel-deploy-scripts` from `v1.7.0` to `v2.3.3` and wires up the new `sync-env` tooling.

## Changes

**`package.json` / `pnpm-lock.yaml`**
- Version bumped from `v1.7.0` to `v2.3.3`
- `vercel-deploy-scripts` removed from `onlyBuiltDependencies` — v2.3.3 fixes the prepare-phase infinite recursion that caused Vercel builds in consuming repos to regress, so the workaround is no longer needed

**`.vercel/project.json`** *(new)*
- Links the repo to the Vercel project and team so `sync-env` (and the Vercel CLI) can auto-detect the project without requiring `VERCEL_PROJECT_ID`/`VERCEL_TEAM_ID` to be set in the shell

**`deployment/environments.yml`**
- Top-level key renamed from `environments` to `active` to match the schema `sync-env` expects when reading the list of active environments

**`deployment/production.yml`**
- Added `FIREBASE_SA_EMAIL` — the Firebase Admin SDK service account email; required by `sync-env --rotate-keys` and `sync-env --init firebase` to know which GCP service account to create/rotate keys for

---
*Created by Claude Sonnet 4.6*