### PR TITLE
chore: ignore .claude/ in Prettier and ESLint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 .next
 src/components/ui
 pnpm-lock.yaml
+.claude

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import storybook from "eslint-plugin-storybook";
 export default tseslint.config(
   {
     ignores: [
+      "**/.claude/**",
       "**/dist/**",
       "**/node_modules/**",
       "**/.next/**",


### PR DESCRIPTION
Adds `.claude/` to both linter/formatter ignore lists so that Claude Code session files, memory, and scripts don't get flagged by `pnpm lint` or `pnpm format`.

- `.prettierignore`: added `.claude`
- `eslint.config.js` `ignores`: added `**/.claude/**`

---
*Created by Claude Sonnet 4.6*