### PR TITLE
chore(ui): install ShadCN base components and migrate existing UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.1",
     "@reduxjs/toolkit": "^2.11.2",
     "@sentry/nextjs": "^10.50.0",
     "@tanstack/react-query": "^5.100.5",
@@ -55,7 +56,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v3.1.0",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/nextjs-vite": "^10.3.5",
@@ -80,6 +80,7 @@
     "typescript": "^6",
     "typescript-eslint": "^8.59.1",
     "vercel": "^52.0.0",
+    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v3.1.0",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.4.1
+        version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@reduxjs/toolkit':
         specifier: ^2.11.2
         version: 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
@@ -280,6 +283,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bytecodealliance/preview2-shim@0.17.6':
     resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
@@ -895,6 +925,21 @@ packages:
 
   '@firebase/webchannel-wrapper@1.0.5':
     resolution: {integrity: sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@google-cloud/firestore@7.11.6':
     resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
@@ -6179,6 +6224,29 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@bytecodealliance/preview2-shim@0.17.6': {}
 
   '@dotenvx/dotenvx@1.64.0':
@@ -6749,6 +6817,23 @@ snapshots:
       tslib: 2.8.1
 
   '@firebase/webchannel-wrapper@1.0.5': {}
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@google-cloud/firestore@7.11.6':
     dependencies:

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import Link from "next/link";
 import type { FirebaseError } from "firebase/app";
 import { sendPasswordReset } from "@/services/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { FORGOT_PASSWORD_COPY } from "./copy";
 
 export default function ForgotPasswordPage() {
@@ -45,10 +48,8 @@ export default function ForgotPasswordPage() {
             className="space-y-4"
           >
             <div className="space-y-1">
-              <label htmlFor="email" className="text-sm font-medium">
-                {FORGOT_PASSWORD_COPY.emailLabel}
-              </label>
-              <input
+              <Label htmlFor="email">{FORGOT_PASSWORD_COPY.emailLabel}</Label>
+              <Input
                 id="email"
                 type="email"
                 autoComplete="email"
@@ -58,17 +59,13 @@ export default function ForgotPasswordPage() {
                   setEmail(e.target.value);
                 }}
                 placeholder={FORGOT_PASSWORD_COPY.emailPlaceholder}
-                className="w-full rounded border px-3 py-2 text-sm"
+                className="w-full"
               />
             </div>
             {error && <p className="text-sm text-red-600">{error}</p>}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-            >
+            <Button type="submit" disabled={loading} className="w-full">
               {FORGOT_PASSWORD_COPY.submitButton}
-            </button>
+            </Button>
           </form>
         </>
       )}

--- a/src/app/(auth)/sign-in/SignInForm.tsx
+++ b/src/app/(auth)/sign-in/SignInForm.tsx
@@ -10,6 +10,9 @@ import {
   signInWithApple,
   signInWithGoogle,
 } from "@/services/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { SIGN_IN_COPY } from "./copy";
 
 export default function SignInForm() {
@@ -67,13 +70,14 @@ export default function SignInForm() {
   return (
     <div className="w-full max-w-sm space-y-6">
       <h1 className="text-2xl font-semibold">{SIGN_IN_COPY.title}</h1>
-      <button
+      <Button
         type="button"
+        variant="outline"
         onClick={() => {
           void handleOAuthSignIn(signInWithGoogle);
         }}
         disabled={loading}
-        className="flex w-full items-center justify-center gap-2 rounded border px-4 py-2 text-sm font-medium disabled:opacity-50"
+        className="w-full"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -100,15 +104,16 @@ export default function SignInForm() {
           <path fill="none" d="M0 0h48v48H0z" />
         </svg>
         {SIGN_IN_COPY.googleButton}
-      </button>
+      </Button>
       {appleEnabled && (
-        <button
+        <Button
           type="button"
+          variant="outline"
           onClick={() => {
             void handleOAuthSignIn(signInWithApple);
           }}
           disabled={loading}
-          className="flex w-full items-center justify-center gap-2 rounded border px-4 py-2 text-sm font-medium disabled:opacity-50"
+          className="w-full"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -119,7 +124,7 @@ export default function SignInForm() {
             <path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-37.3-150.3-93.2c-52.3-65.3-95.9-166.3-95.9-262.6 0-175.1 114.4-267.3 227.2-267.3 59.7 0 109.4 39.5 147.2 39.5 35.8 0 92.1-42.2 160.9-42.2 25.9 0 108.2 2.6 168.1 80.1zm-128.5-111.3c26.5-31.7 45.4-75.8 45.4-119.9 0-6.1-.5-12.2-1.6-17.3-42.8 1.6-93.5 28.5-124.1 64.8-22.4 25.2-44.7 68.7-44.7 113.4 0 6.7 1.1 13.4 1.6 15.5 2.7.5 7 1.1 11.3 1.1 38.4 0 86.2-25.8 112.1-57.6z" />
           </svg>
           {SIGN_IN_COPY.appleButton}
-        </button>
+        </Button>
       )}
       <div className="flex items-center gap-3 text-sm text-gray-400">
         <hr className="flex-1" />
@@ -133,10 +138,8 @@ export default function SignInForm() {
         className="space-y-4"
       >
         <div className="space-y-1">
-          <label htmlFor="email" className="text-sm font-medium">
-            {SIGN_IN_COPY.emailLabel}
-          </label>
-          <input
+          <Label htmlFor="email">{SIGN_IN_COPY.emailLabel}</Label>
+          <Input
             id="email"
             type="email"
             autoComplete="email"
@@ -146,14 +149,12 @@ export default function SignInForm() {
               setEmail(e.target.value);
             }}
             placeholder={SIGN_IN_COPY.emailPlaceholder}
-            className="w-full rounded border px-3 py-2 text-sm"
+            className="w-full"
           />
         </div>
         <div className="space-y-1">
-          <label htmlFor="password" className="text-sm font-medium">
-            {SIGN_IN_COPY.passwordLabel}
-          </label>
-          <input
+          <Label htmlFor="password">{SIGN_IN_COPY.passwordLabel}</Label>
+          <Input
             id="password"
             type="password"
             autoComplete="current-password"
@@ -162,17 +163,13 @@ export default function SignInForm() {
             onChange={(e) => {
               setPassword(e.target.value);
             }}
-            className="w-full rounded border px-3 py-2 text-sm"
+            className="w-full"
           />
         </div>
         {error && <p className="text-sm text-red-600">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-        >
+        <Button type="submit" disabled={loading} className="w-full">
           {SIGN_IN_COPY.submitButton}
-        </button>
+        </Button>
       </form>
       <div className="flex items-center justify-between text-sm">
         <Link href="/forgot-password" className="underline">

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -5,6 +5,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { FirebaseError } from "firebase/app";
 import { createSession, signUp } from "@/services/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { SIGN_UP_COPY } from "./copy";
 
 export default function SignUpPage() {
@@ -41,10 +44,8 @@ export default function SignUpPage() {
         className="space-y-4"
       >
         <div className="space-y-1">
-          <label htmlFor="email" className="text-sm font-medium">
-            {SIGN_UP_COPY.emailLabel}
-          </label>
-          <input
+          <Label htmlFor="email">{SIGN_UP_COPY.emailLabel}</Label>
+          <Input
             id="email"
             type="email"
             autoComplete="email"
@@ -54,14 +55,12 @@ export default function SignUpPage() {
               setEmail(e.target.value);
             }}
             placeholder={SIGN_UP_COPY.emailPlaceholder}
-            className="w-full rounded border px-3 py-2 text-sm"
+            className="w-full"
           />
         </div>
         <div className="space-y-1">
-          <label htmlFor="password" className="text-sm font-medium">
-            {SIGN_UP_COPY.passwordLabel}
-          </label>
-          <input
+          <Label htmlFor="password">{SIGN_UP_COPY.passwordLabel}</Label>
+          <Input
             id="password"
             type="password"
             autoComplete="new-password"
@@ -70,17 +69,13 @@ export default function SignUpPage() {
             onChange={(e) => {
               setPassword(e.target.value);
             }}
-            className="w-full rounded border px-3 py-2 text-sm"
+            className="w-full"
           />
         </div>
         {error && <p className="text-sm text-red-600">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-        >
+        <Button type="submit" disabled={loading} className="w-full">
           {SIGN_UP_COPY.submitButton}
-        </button>
+        </Button>
       </form>
       <p className="text-sm">
         {SIGN_UP_COPY.signInPrompt}{" "}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,22 +1,82 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.985 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --destructive-foreground: oklch(0.985 0 0);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+  }
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/app/groups/join/JoinGroupFormView.tsx
+++ b/src/app/groups/join/JoinGroupFormView.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { JOIN_GROUP_COPY } from "./copy";
 
 interface JoinGroupFormViewProps {
@@ -21,14 +22,9 @@ export function JoinGroupFormView({
         <span className="font-medium text-gray-900">{groupName}</span>.
       </p>
       {error && <p className="text-sm text-red-600">{error}</p>}
-      <button
-        type="button"
-        onClick={onJoin}
-        disabled={loading}
-        className="rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-      >
+      <Button type="button" onClick={onJoin} disabled={loading}>
         {loading ? JOIN_GROUP_COPY.joiningButton : JOIN_GROUP_COPY.joinButton}
-      </button>
+      </Button>
     </main>
   );
 }

--- a/src/app/groups/new/CreateGroupFormView.tsx
+++ b/src/app/groups/new/CreateGroupFormView.tsx
@@ -1,3 +1,6 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { CREATE_GROUP_COPY } from "./copy";
 
 interface CreateGroupFormViewProps {
@@ -24,10 +27,8 @@ export function CreateGroupFormView({
         className="space-y-4"
       >
         <div className="space-y-1">
-          <label htmlFor="name" className="text-sm font-medium">
-            {CREATE_GROUP_COPY.nameLabel}
-          </label>
-          <input
+          <Label htmlFor="name">{CREATE_GROUP_COPY.nameLabel}</Label>
+          <Input
             id="name"
             type="text"
             required
@@ -36,17 +37,13 @@ export function CreateGroupFormView({
               onNameChange(e.target.value);
             }}
             placeholder={CREATE_GROUP_COPY.namePlaceholder}
-            className="w-full rounded border px-3 py-2 text-sm"
+            className="w-full"
           />
         </div>
         {error && <p className="text-sm text-red-600">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-        >
+        <Button type="submit" disabled={loading} className="w-full">
           {CREATE_GROUP_COPY.submitButton}
-        </button>
+        </Button>
       </form>
     </div>
   );

--- a/src/app/profile/UserProfileView.tsx
+++ b/src/app/profile/UserProfileView.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { USER_PROFILE_COPY } from "./copy";
 
 interface UserProfileViewProps {
@@ -44,10 +47,10 @@ export function UserProfileView({
         className="space-y-4"
       >
         <div className="space-y-1">
-          <label htmlFor="displayName" className="text-sm font-medium">
+          <Label htmlFor="displayName">
             {USER_PROFILE_COPY.displayNameLabel}
-          </label>
-          <input
+          </Label>
+          <Input
             id="displayName"
             type="text"
             autoComplete="name"
@@ -58,7 +61,7 @@ export function UserProfileView({
               setSuccess(false);
             }}
             placeholder={USER_PROFILE_COPY.displayNamePlaceholder}
-            className="w-full rounded border px-3 py-2 text-sm"
+            className="w-full"
           />
         </div>
         {error && <p className="text-sm text-red-600">{error}</p>}
@@ -67,13 +70,9 @@ export function UserProfileView({
             {USER_PROFILE_COPY.successMessage}
           </p>
         )}
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-        >
+        <Button type="submit" disabled={loading} className="w-full">
           {USER_PROFILE_COPY.saveButton}
-        </button>
+        </Button>
       </form>
       <section className="space-y-2">
         <h2 className="text-sm font-medium">

--- a/src/components/auth/SignOutButton.tsx
+++ b/src/components/auth/SignOutButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { deleteSession, signOut } from "@/services/auth";
+import { Button } from "@/components/ui/button";
 import { SIGN_OUT_BUTTON_COPY } from "./SignOutButton.copy";
 
 export function SignOutButton() {
@@ -28,16 +29,16 @@ export function SignOutButton() {
 
   return (
     <div>
-      <button
+      <Button
         type="button"
+        variant="outline"
         onClick={() => {
           void handleSignOut();
         }}
         disabled={loading}
-        className="rounded border px-4 py-2 text-sm font-medium disabled:opacity-50"
       >
         {SIGN_OUT_BUTTON_COPY.button}
-      </button>
+      </Button>
       {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
     </div>
   );

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }


### PR DESCRIPTION
Install the ShadCN `base-nova` component primitives and migrate all hand-rolled UI elements to use them, closing the gap between the project's declared UI library and actual usage.

## Changes

- **Added** ShadCN `button`, `input`, `label`, `badge`, and `card` components under `src/components/ui/`
- **Added** `@base-ui/react` dependency (peer dep of the base-nova style)
- **Updated** `src/app/globals.css` with the ShadCN design token palette (neutral oklch colors + radius variables) for Tailwind v4
- **Migrated** all auth pages (`sign-in`, `sign-up`, `forgot-password`), profile view, group forms, join group form, and sign-out button to use `Button`, `Input`, and `Label` from `@/components/ui`

## Acceptance Criteria

- [x] ShadCN base components (`button`, `input`, `card`, `label`, `badge`) installed under `src/components/ui/`
- [x] Existing hand-rolled buttons and inputs migrated to ShadCN equivalents
- [x] All ShadCN-generated files remain unmodified beyond what the CLI outputs
- [x] All 81 existing tests continue to pass (`pnpm test`)
- [x] Lint and type check pass (`pnpm lint && pnpm tsc`)

Closes #77

---
*Created by Claude Sonnet 4.6*