### PR TITLE
feat(options): heart toggle for pick option ownership

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/options/[optionId]/owners/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/options/[optionId]/owners/route.spec.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetVerifiedUid,
+  mockGetGroupById,
+  mockGetCategoryById,
+  mockJoinOption,
+  mockUnjoinOption,
+} = vi.hoisted(() => ({
+  mockGetVerifiedUid: vi.fn(),
+  mockGetGroupById: vi.fn(),
+  mockGetCategoryById: vi.fn(),
+  mockJoinOption: vi.fn(),
+  mockUnjoinOption: vi.fn(),
+}));
+
+vi.mock("@/server/utils/auth", () => ({
+  getVerifiedUid: mockGetVerifiedUid,
+}));
+
+vi.mock("@/server/data/groups", () => ({
+  getGroupById: mockGetGroupById,
+}));
+
+vi.mock("@/server/data/categories", () => ({
+  getCategoryById: mockGetCategoryById,
+}));
+
+vi.mock("@/server/data/options", () => ({
+  joinOption: mockJoinOption,
+  unjoinOption: mockUnjoinOption,
+}));
+
+const { POST, DELETE } = await import("./route");
+
+const baseParams = {
+  id: "group-1",
+  categoryId: "cat-1",
+  pickId: "pick-1",
+  optionId: "opt-1",
+};
+
+function makeRequest(method: "POST" | "DELETE") {
+  return new Request(
+    "http://localhost/api/groups/group-1/categories/cat-1/picks/pick-1/options/opt-1/owners",
+    { method },
+  );
+}
+
+describe("POST /api/.../options/[optionId]/owners", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVerifiedUid.mockResolvedValue("user-1");
+    mockGetGroupById.mockResolvedValue({
+      id: "group-1",
+      name: "G",
+      createdAt: new Date(),
+      creatorId: "user-1",
+      memberIds: ["user-1", "user-2"],
+    });
+    mockGetCategoryById.mockResolvedValue({
+      id: "cat-1",
+      groupId: "group-1",
+      name: "C",
+      description: "",
+      createdAt: new Date(),
+      creatorId: "user-1",
+    });
+    mockJoinOption.mockResolvedValue(undefined);
+  });
+
+  it("returns 401 when no user is signed in", async () => {
+    mockGetVerifiedUid.mockResolvedValue(undefined);
+
+    const response = await POST(makeRequest("POST"), {
+      params: Promise.resolve(baseParams),
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockJoinOption).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user is not a group member", async () => {
+    mockGetVerifiedUid.mockResolvedValue("user-3");
+
+    const response = await POST(makeRequest("POST"), {
+      params: Promise.resolve(baseParams),
+    });
+
+    expect(response.status).toBe(403);
+    expect(mockJoinOption).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the category does not belong to the group", async () => {
+    mockGetCategoryById.mockResolvedValue({
+      id: "cat-1",
+      groupId: "other-group",
+      name: "C",
+      description: "",
+      createdAt: new Date(),
+      creatorId: "user-1",
+    });
+
+    const response = await POST(makeRequest("POST"), {
+      params: Promise.resolve(baseParams),
+    });
+
+    expect(response.status).toBe(404);
+    expect(mockJoinOption).not.toHaveBeenCalled();
+  });
+
+  it("calls joinOption with the verified uid", async () => {
+    const response = await POST(makeRequest("POST"), {
+      params: Promise.resolve(baseParams),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockJoinOption).toHaveBeenCalledWith("pick-1", "opt-1", "user-1");
+  });
+});
+
+describe("DELETE /api/.../options/[optionId]/owners", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVerifiedUid.mockResolvedValue("user-1");
+    mockGetGroupById.mockResolvedValue({
+      id: "group-1",
+      name: "G",
+      createdAt: new Date(),
+      creatorId: "user-1",
+      memberIds: ["user-1", "user-2"],
+    });
+    mockGetCategoryById.mockResolvedValue({
+      id: "cat-1",
+      groupId: "group-1",
+      name: "C",
+      description: "",
+      createdAt: new Date(),
+      creatorId: "user-1",
+    });
+    mockUnjoinOption.mockResolvedValue({ deleted: false });
+  });
+
+  it("returns 401 when no user is signed in", async () => {
+    mockGetVerifiedUid.mockResolvedValue(undefined);
+
+    const response = await DELETE(makeRequest("DELETE"), {
+      params: Promise.resolve(baseParams),
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockUnjoinOption).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user is not a group member", async () => {
+    mockGetVerifiedUid.mockResolvedValue("user-3");
+
+    const response = await DELETE(makeRequest("DELETE"), {
+      params: Promise.resolve(baseParams),
+    });
+
+    expect(response.status).toBe(403);
+    expect(mockUnjoinOption).not.toHaveBeenCalled();
+  });
+
+  it("calls unjoinOption and returns the deleted flag", async () => {
+    mockUnjoinOption.mockResolvedValue({ deleted: true });
+
+    const response = await DELETE(makeRequest("DELETE"), {
+      params: Promise.resolve(baseParams),
+    });
+    const body = (await response.json()) as { ok: true; deleted: boolean };
+
+    expect(response.status).toBe(200);
+    expect(body.deleted).toBe(true);
+    expect(mockUnjoinOption).toHaveBeenCalledWith("pick-1", "opt-1", "user-1");
+  });
+
+  it("returns deleted: false when other owners remain", async () => {
+    mockUnjoinOption.mockResolvedValue({ deleted: false });
+
+    const response = await DELETE(makeRequest("DELETE"), {
+      params: Promise.resolve(baseParams),
+    });
+    const body = (await response.json()) as { ok: true; deleted: boolean };
+
+    expect(body.deleted).toBe(false);
+  });
+});

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/options/[optionId]/owners/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/options/[optionId]/owners/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { getVerifiedUid } from "@/server/utils/auth";
+import { getGroupById } from "@/server/data/groups";
+import { getCategoryById } from "@/server/data/categories";
+import { joinOption, unjoinOption } from "@/server/data/options";
+
+interface RouteParams {
+  id: string;
+  categoryId: string;
+  pickId: string;
+  optionId: string;
+}
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<RouteParams> },
+) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: groupId, categoryId, pickId, optionId } = await params;
+  const [group, category] = await Promise.all([
+    getGroupById(groupId),
+    getCategoryById(categoryId),
+  ]);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (category?.groupId !== groupId) {
+    return NextResponse.json({ error: "Category not found" }, { status: 404 });
+  }
+
+  await joinOption(pickId, optionId, uid);
+  return NextResponse.json({ ok: true }, { status: 200 });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<RouteParams> },
+) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: groupId, categoryId, pickId, optionId } = await params;
+  const [group, category] = await Promise.all([
+    getGroupById(groupId),
+    getCategoryById(categoryId),
+  ]);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (category?.groupId !== groupId) {
+    return NextResponse.json({ error: "Category not found" }, { status: 404 });
+  }
+
+  const { deleted } = await unjoinOption(pickId, optionId, uid);
+  return NextResponse.json({ ok: true, deleted }, { status: 200 });
+}

--- a/src/app/categories/[id]/picks/[pickId]/HeartButton.spec.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/HeartButton.spec.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { HeartButton } from "./HeartButton";
+import { PICK_DETAIL_COPY } from "./copy";
+
+afterEach(cleanup);
+
+describe("HeartButton", () => {
+  it("renders with the remove-ownership label when hearted", () => {
+    render(<HeartButton hearted={true} onClick={() => undefined} />);
+
+    expect(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.removeOwnership,
+      }),
+    ).toBeDefined();
+  });
+
+  it("renders with the add-ownership label when not hearted", () => {
+    render(<HeartButton hearted={false} onClick={() => undefined} />);
+
+    expect(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    ).toBeDefined();
+  });
+
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<HeartButton hearted={false} onClick={onClick} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    );
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(<HeartButton hearted={false} disabled={true} onClick={onClick} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    );
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("is marked disabled in the DOM when disabled", () => {
+    render(
+      <HeartButton hearted={false} disabled={true} onClick={() => undefined} />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: PICK_DETAIL_COPY.heart.addOwnership,
+    });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("reflects the hearted state via aria-pressed", () => {
+    render(<HeartButton hearted={true} onClick={() => undefined} />);
+
+    const button = screen.getByRole("button", {
+      name: PICK_DETAIL_COPY.heart.removeOwnership,
+    });
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/src/app/categories/[id]/picks/[pickId]/HeartButton.stories.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/HeartButton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { HeartButton } from "./HeartButton";
+
+const meta: Meta<typeof HeartButton> = {
+  title: "Picks/HeartButton",
+  component: HeartButton,
+  args: {
+    hearted: false,
+    disabled: false,
+    onClick: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HeartButton>;
+
+export const NotHearted: Story = {};
+
+export const Hearted: Story = {
+  args: {
+    hearted: true,
+  },
+};
+
+export const DisabledNotHearted: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisabledHearted: Story = {
+  args: {
+    hearted: true,
+    disabled: true,
+  },
+};

--- a/src/app/categories/[id]/picks/[pickId]/HeartButton.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/HeartButton.tsx
@@ -1,0 +1,56 @@
+import { PICK_DETAIL_COPY } from "./copy";
+
+export interface HeartButtonProps {
+  hearted: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export function HeartButton({ hearted, disabled, onClick }: HeartButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={
+        hearted
+          ? PICK_DETAIL_COPY.heart.removeOwnership
+          : PICK_DETAIL_COPY.heart.addOwnership
+      }
+      aria-pressed={hearted}
+      className={[
+        "flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors",
+        hearted
+          ? "bg-black text-white"
+          : "border border-gray-300 bg-transparent text-gray-400",
+        disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+      ].join(" ")}
+    >
+      {hearted ? (
+        <svg
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="h-4 w-4"
+          aria-hidden="true"
+        >
+          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          className="h-4 w-4"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/app/categories/[id]/picks/[pickId]/OptionList.spec.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/OptionList.spec.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import type { Option } from "@/lib/types/option";
+import { OptionList } from "./OptionList";
+import { PICK_DETAIL_COPY } from "./copy";
+
+const { mockJoinOptionOwner, mockUnjoinOptionOwner, mockAdoptOption } =
+  vi.hoisted(() => ({
+    mockJoinOptionOwner: vi.fn(),
+    mockUnjoinOptionOwner: vi.fn(),
+    mockAdoptOption: vi.fn(),
+  }));
+
+vi.mock("@/services/options", () => ({
+  joinOptionOwner: mockJoinOptionOwner,
+  unjoinOptionOwner: mockUnjoinOptionOwner,
+  adoptOption: mockAdoptOption,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeOption(overrides?: Partial<Option>): Option {
+  return {
+    id: "opt-1",
+    title: "Pizza",
+    pickId: "pick-1",
+    ownerIds: ["user-2"],
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  groupId: "group-1",
+  categoryId: "cat-1",
+  pickId: "pick-1",
+  currentUserId: "user-1",
+  initialSuggestions: [],
+};
+
+describe("OptionList heart toggle", () => {
+  it("optimistically adds the user to ownerIds when hearting", async () => {
+    mockJoinOptionOwner.mockResolvedValue(undefined);
+    const option = makeOption({ ownerIds: ["user-2"] });
+
+    render(<OptionList {...baseProps} initialOptions={[option]} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    );
+
+    // The button immediately reflects the new state
+    expect(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.removeOwnership,
+      }),
+    ).toBeDefined();
+    await waitFor(() => {
+      expect(mockJoinOptionOwner).toHaveBeenCalledWith(
+        "group-1",
+        "cat-1",
+        "pick-1",
+        "opt-1",
+      );
+    });
+  });
+
+  it("reverts the optimistic add when the request fails", async () => {
+    mockJoinOptionOwner.mockRejectedValue(new Error("network"));
+    const option = makeOption({ ownerIds: ["user-2"] });
+
+    render(<OptionList {...baseProps} initialOptions={[option]} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(PICK_DETAIL_COPY.errors.default)).toBeDefined();
+    });
+    expect(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    ).toBeDefined();
+  });
+
+  it("optimistically removes the option when the last owner unhearts", async () => {
+    mockUnjoinOptionOwner.mockResolvedValue({ deleted: true });
+    const option = makeOption({ ownerIds: ["user-1"] });
+
+    render(<OptionList {...baseProps} initialOptions={[option]} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.removeOwnership,
+      }),
+    );
+
+    expect(screen.queryByText("Pizza")).toBeNull();
+    await waitFor(() => {
+      expect(mockUnjoinOptionOwner).toHaveBeenCalledWith(
+        "group-1",
+        "cat-1",
+        "pick-1",
+        "opt-1",
+      );
+    });
+  });
+
+  it("restores the option after a failed unheart of the last owner", async () => {
+    mockUnjoinOptionOwner.mockRejectedValue(new Error("network"));
+    const option = makeOption({ ownerIds: ["user-1"] });
+
+    render(<OptionList {...baseProps} initialOptions={[option]} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.removeOwnership,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Pizza")).toBeDefined();
+    });
+    expect(screen.getByText(PICK_DETAIL_COPY.errors.default)).toBeDefined();
+  });
+});

--- a/src/app/categories/[id]/picks/[pickId]/OptionList.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/OptionList.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from "react";
 import type { Option } from "@/lib/types/option";
-import { adoptOption } from "@/services/options";
+import {
+  adoptOption,
+  joinOptionOwner,
+  unjoinOptionOwner,
+} from "@/services/options";
 import { OptionListView } from "./OptionListView";
 import { PICK_DETAIL_COPY } from "./copy";
 
@@ -106,6 +110,54 @@ export function OptionList({
     }
   }
 
+  async function handleToggleOwner(option: Option) {
+    const wasHearted = option.ownerIds.includes(currentUserId);
+    setError(undefined);
+
+    // Optimistic update
+    if (wasHearted) {
+      const willBeEmpty = option.ownerIds.length === 1;
+      setOptions((prev) =>
+        willBeEmpty
+          ? prev.filter((o) => o.id !== option.id)
+          : prev.map((o) =>
+              o.id === option.id
+                ? {
+                    ...o,
+                    ownerIds: o.ownerIds.filter((uid) => uid !== currentUserId),
+                  }
+                : o,
+            ),
+      );
+    } else {
+      setOptions((prev) =>
+        prev.map((o) =>
+          o.id === option.id
+            ? { ...o, ownerIds: [...o.ownerIds, currentUserId] }
+            : o,
+        ),
+      );
+    }
+
+    try {
+      if (wasHearted) {
+        await unjoinOptionOwner(groupId, categoryId, pickId, option.id);
+      } else {
+        await joinOptionOwner(groupId, categoryId, pickId, option.id);
+      }
+    } catch {
+      // Revert on failure
+      setOptions((prev) => {
+        const exists = prev.some((o) => o.id === option.id);
+        if (!exists) {
+          return [...prev, option];
+        }
+        return prev.map((o) => (o.id === option.id ? option : o));
+      });
+      setError(PICK_DETAIL_COPY.errors.default);
+    }
+  }
+
   return (
     <OptionListView
       options={options}
@@ -113,9 +165,11 @@ export function OptionList({
       newTitle={newTitle}
       loading={loading}
       error={error}
+      currentUserId={currentUserId}
       onNewTitleChange={setNewTitle}
       onAddSubmit={(e) => void handleAddSubmit(e)}
       onAdoptSuggestion={(opt) => void handleAdoptSuggestion(opt)}
+      onToggleOwner={(opt) => void handleToggleOwner(opt)}
     />
   );
 }

--- a/src/app/categories/[id]/picks/[pickId]/OptionListView.spec.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/OptionListView.spec.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { OptionListView } from "./OptionListView";
+import { OptionListView, type OptionListViewProps } from "./OptionListView";
 import { PICK_DETAIL_COPY } from "./copy";
 import type { Option } from "@/lib/types/option";
 
@@ -18,73 +18,41 @@ function makeOption(overrides?: Partial<Option>): Option {
   };
 }
 
+const defaultProps: OptionListViewProps = {
+  options: [],
+  suggestions: [],
+  newTitle: "",
+  loading: false,
+  error: undefined,
+  currentUserId: "user-1",
+  onNewTitleChange: () => undefined,
+  onAddSubmit: () => undefined,
+  onAdoptSuggestion: () => undefined,
+  onToggleOwner: () => undefined,
+};
+
 describe("OptionListView", () => {
   it("renders the options heading", () => {
-    render(
-      <OptionListView
-        options={[]}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} />);
 
     expect(screen.getByText(PICK_DETAIL_COPY.optionsHeading)).toBeDefined();
   });
 
   it("renders the empty state when no options", () => {
-    render(
-      <OptionListView
-        options={[]}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} />);
 
     expect(screen.getByText(PICK_DETAIL_COPY.noOptionsMessage)).toBeDefined();
   });
 
   it("renders option titles when options are provided", () => {
     const option = makeOption({ title: "Inception" });
-    render(
-      <OptionListView
-        options={[option]}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} options={[option]} />);
 
     expect(screen.getByText("Inception")).toBeDefined();
   });
 
   it("does not render empty state when options are present", () => {
-    const option = makeOption();
-    render(
-      <OptionListView
-        options={[option]}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} options={[makeOption()]} />);
 
     expect(screen.queryByText(PICK_DETAIL_COPY.noOptionsMessage)).toBeNull();
   });
@@ -94,54 +62,21 @@ describe("OptionListView", () => {
       makeOption({ id: "opt-1", title: "Movie One" }),
       makeOption({ id: "opt-2", title: "Movie Two" }),
     ];
-    render(
-      <OptionListView
-        options={options}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} options={options} />);
 
     expect(screen.getByText("Movie One")).toBeDefined();
     expect(screen.getByText("Movie Two")).toBeDefined();
   });
 
   it("does not render suggestions section when suggestions are empty", () => {
-    render(
-      <OptionListView
-        options={[]}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} />);
 
     expect(screen.queryByText(PICK_DETAIL_COPY.suggestionsHeading)).toBeNull();
   });
 
   it("renders suggestions section when suggestions are present", () => {
     const suggestion = makeOption({ id: "sug-1", title: "The Matrix" });
-    render(
-      <OptionListView
-        options={[]}
-        suggestions={[suggestion]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} suggestions={[suggestion]} />);
 
     expect(screen.getByText(PICK_DETAIL_COPY.suggestionsHeading)).toBeDefined();
     expect(screen.getByText("The Matrix")).toBeDefined();
@@ -153,13 +88,8 @@ describe("OptionListView", () => {
 
     render(
       <OptionListView
-        options={[]}
+        {...defaultProps}
         suggestions={[suggestion]}
-        newTitle=""
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
         onAdoptSuggestion={(opt) => {
           adopted = opt;
         }}
@@ -173,18 +103,7 @@ describe("OptionListView", () => {
   });
 
   it("renders the add option input with the current newTitle value", () => {
-    render(
-      <OptionListView
-        options={[]}
-        suggestions={[]}
-        newTitle="Interstellar"
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} newTitle="Interstellar" />);
 
     const input = screen.getByPlaceholderText(
       PICK_DETAIL_COPY.addOptionPlaceholder,
@@ -197,23 +116,17 @@ describe("OptionListView", () => {
 
     render(
       <OptionListView
-        options={[]}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error={undefined}
+        {...defaultProps}
         onNewTitleChange={(v) => {
           changedValue = v;
         }}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
       />,
     );
 
-    const input = screen.getByPlaceholderText(
-      PICK_DETAIL_COPY.addOptionPlaceholder,
+    fireEvent.change(
+      screen.getByPlaceholderText(PICK_DETAIL_COPY.addOptionPlaceholder),
+      { target: { value: "Interstellar" } },
     );
-    fireEvent.change(input, { target: { value: "Interstellar" } });
 
     expect(changedValue).toBe("Interstellar");
   });
@@ -223,16 +136,11 @@ describe("OptionListView", () => {
 
     render(
       <OptionListView
-        options={[]}
-        suggestions={[]}
+        {...defaultProps}
         newTitle="Interstellar"
-        loading={false}
-        error={undefined}
-        onNewTitleChange={() => undefined}
         onAddSubmit={() => {
           submitted = true;
         }}
-        onAdoptSuggestion={() => undefined}
       />,
     );
 
@@ -242,18 +150,7 @@ describe("OptionListView", () => {
   });
 
   it("renders an error message when error is provided", () => {
-    render(
-      <OptionListView
-        options={[]}
-        suggestions={[]}
-        newTitle=""
-        loading={false}
-        error="Something went wrong"
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
-      />,
-    );
+    render(<OptionListView {...defaultProps} error="Something went wrong" />);
 
     expect(screen.getByText("Something went wrong")).toBeDefined();
   });
@@ -261,14 +158,9 @@ describe("OptionListView", () => {
   it("disables the add button when loading", () => {
     render(
       <OptionListView
-        options={[]}
-        suggestions={[]}
+        {...defaultProps}
         newTitle="Interstellar"
         loading={true}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
       />,
     );
 
@@ -281,18 +173,91 @@ describe("OptionListView", () => {
 
     render(
       <OptionListView
-        options={[]}
+        {...defaultProps}
         suggestions={[suggestion]}
-        newTitle=""
         loading={true}
-        error={undefined}
-        onNewTitleChange={() => undefined}
-        onAddSubmit={() => undefined}
-        onAdoptSuggestion={() => undefined}
       />,
     );
 
     const [adoptButton] = screen.getAllByText(PICK_DETAIL_COPY.adoptButton);
     expect((adoptButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders the heart as filled when the current user owns the option", () => {
+    const option = makeOption({ ownerIds: ["user-1", "user-2"] });
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        currentUserId="user-1"
+        options={[option]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.removeOwnership,
+      }),
+    ).toBeDefined();
+  });
+
+  it("renders the heart as empty when the current user does not own the option", () => {
+    const option = makeOption({ ownerIds: ["user-2"] });
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        currentUserId="user-1"
+        options={[option]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    ).toBeDefined();
+  });
+
+  it("calls onToggleOwner with the option when the heart is clicked", () => {
+    const option = makeOption({ id: "opt-99", ownerIds: ["user-2"] });
+    let toggled: Option | undefined;
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        currentUserId="user-1"
+        options={[option]}
+        onToggleOwner={(o) => {
+          toggled = o;
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    );
+
+    expect(toggled).toEqual(option);
+  });
+
+  it("disables the heart button when loading", () => {
+    const option = makeOption({ ownerIds: ["user-1"] });
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        currentUserId="user-1"
+        options={[option]}
+        loading={true}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: PICK_DETAIL_COPY.heart.removeOwnership,
+    });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/src/app/categories/[id]/picks/[pickId]/OptionListView.stories.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/OptionListView.stories.tsx
@@ -21,9 +21,11 @@ const meta = {
     newTitle: "",
     loading: false,
     error: undefined,
+    currentUserId: "user-1",
     onNewTitleChange: () => undefined,
     onAddSubmit: () => undefined,
     onAdoptSuggestion: () => undefined,
+    onToggleOwner: () => undefined,
   },
 } satisfies Meta<typeof OptionListView>;
 
@@ -35,8 +37,16 @@ export const Empty: Story = {};
 export const WithOptions: Story = {
   args: {
     options: [
-      makeOption({ id: "opt-1", title: "The Shawshank Redemption" }),
-      makeOption({ id: "opt-2", title: "Inception" }),
+      makeOption({
+        id: "opt-1",
+        title: "The Shawshank Redemption",
+        ownerIds: ["user-1", "user-2"],
+      }),
+      makeOption({
+        id: "opt-2",
+        title: "Inception",
+        ownerIds: ["user-2"],
+      }),
     ],
   },
 };

--- a/src/app/categories/[id]/picks/[pickId]/OptionListView.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/OptionListView.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { Option } from "@/lib/types/option";
+import { HeartButton } from "./HeartButton";
 import { PICK_DETAIL_COPY } from "./copy";
 
 export interface OptionListViewProps {
@@ -9,9 +10,11 @@ export interface OptionListViewProps {
   newTitle: string;
   loading: boolean;
   error: string | undefined;
+  currentUserId: string;
   onNewTitleChange: (title: string) => void;
   onAddSubmit: (e: React.SyntheticEvent) => void;
   onAdoptSuggestion: (option: Option) => void;
+  onToggleOwner: (option: Option) => void;
 }
 
 export function OptionListView({
@@ -20,9 +23,11 @@ export function OptionListView({
   newTitle,
   loading,
   error,
+  currentUserId,
   onNewTitleChange,
   onAddSubmit,
   onAdoptSuggestion,
+  onToggleOwner,
 }: OptionListViewProps) {
   return (
     <div className="space-y-6">
@@ -38,8 +43,18 @@ export function OptionListView({
         ) : (
           <ul className="space-y-2">
             {options.map((option) => (
-              <li key={option.id} className="rounded-md border p-3 text-sm">
+              <li
+                key={option.id}
+                className="flex items-center justify-between gap-3 rounded-md border p-3 text-sm"
+              >
                 <p className="font-medium">{option.title}</p>
+                <HeartButton
+                  hearted={option.ownerIds.includes(currentUserId)}
+                  disabled={loading}
+                  onClick={() => {
+                    onToggleOwner(option);
+                  }}
+                />
               </li>
             ))}
           </ul>

--- a/src/app/categories/[id]/picks/[pickId]/copy.ts
+++ b/src/app/categories/[id]/picks/[pickId]/copy.ts
@@ -5,6 +5,10 @@ export const PICK_DETAIL_COPY = {
   addOptionButton: "Add",
   suggestionsHeading: "Suggestions from your prior picks",
   adoptButton: "Use this",
+  heart: {
+    addOwnership: "Add to your options",
+    removeOwnership: "Remove from your options",
+  },
   errors: {
     default: "Something went wrong. Please try again.",
   },

--- a/src/server/data/options.ts
+++ b/src/server/data/options.ts
@@ -45,6 +45,29 @@ export async function joinOption(
     .set(true);
 }
 
+export async function unjoinOption(
+  pickId: string,
+  optionId: string,
+  ownerUid: string,
+): Promise<{ deleted: boolean }> {
+  const db = getDatabase(getAdminApp());
+  const ownersRef = db.ref(`picks/${pickId}/options/${optionId}/ownerIds`);
+  const snap = await ownersRef.get();
+  const remaining = snap.exists()
+    ? Object.keys(snap.val() as Record<string, true>).filter(
+        (uid) => uid !== ownerUid,
+      )
+    : [];
+
+  if (remaining.length === 0) {
+    await db.ref(`picks/${pickId}/options/${optionId}`).remove();
+    return { deleted: true };
+  }
+
+  await ownersRef.child(ownerUid).remove();
+  return { deleted: false };
+}
+
 export async function getOptionsByCategory(
   pickIds: string[],
 ): Promise<Option[]> {

--- a/src/services/options.ts
+++ b/src/services/options.ts
@@ -36,3 +36,31 @@ export async function adoptOption(
 
   return response.json() as Promise<{ optionId: string }>;
 }
+
+export async function joinOptionOwner(
+  groupId: string,
+  categoryId: string,
+  pickId: string,
+  optionId: string,
+): Promise<void> {
+  const response = await fetch(
+    `/api/groups/${groupId}/categories/${categoryId}/picks/${pickId}/options/${optionId}/owners`,
+    { method: "POST" },
+  );
+  if (!response.ok) throw new Error("Failed to join option");
+}
+
+export async function unjoinOptionOwner(
+  groupId: string,
+  categoryId: string,
+  pickId: string,
+  optionId: string,
+): Promise<{ deleted: boolean }> {
+  const response = await fetch(
+    `/api/groups/${groupId}/categories/${categoryId}/picks/${pickId}/options/${optionId}/owners`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) throw new Error("Failed to unjoin option");
+
+  return response.json() as Promise<{ deleted: boolean }>;
+}


### PR DESCRIPTION
Adds a heart toggle on each Pick Option that lets a group member declare "I want to rank this." Hearting an option adds the user to the option's `ownerIds` list; unhearting removes them. If the last owner unhearts an option, the option is auto-deleted.

This builds on top of main's existing `Option { id, title, pickId, ownerIds }` schema and the existing `POST /api/.../options` route (which is the "suggest a new option" path). No parallel Option/Interest schema is introduced — the heart is just a UX wrapper around `ownerIds` membership.

## Technical notes

- New `HeartButton` component (filled when `option.ownerIds.includes(currentUserId)`)
- New `unjoinOption(pickId, optionId, ownerUid)` data function — removes the uid and deletes the option entirely if `ownerIds` becomes empty
- New API route `POST/DELETE /api/groups/[id]/categories/[categoryId]/picks/[pickId]/options/[optionId]/owners` — auth-gated by group membership
- `OptionList` performs an optimistic `ownerIds` update and reverts the option (including last-owner deletion) on request failure

## Tests

29 tests added/updated:
- 6 `HeartButton` UI tests
- 5 new heart-related `OptionListView` UI tests (filled/empty render, click handler, disabled state)
- 4 `OptionList` orchestrator tests (optimistic add, revert, last-owner auto-delete, restore)
- 8 owners route tests (auth gate, success and failure paths, deleted flag)
- Plus 6 retained `OptionListView` tests for existing behavior

Closes #23

---
*Created by Claude Sonnet 4.6*