### PR TITLE
chore(groups): add adminIds and picksRestricted to Group schema

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/route.spec.ts
@@ -51,6 +51,8 @@ describe("PATCH /api/groups/[id]/categories/[categoryId]", () => {
       createdAt: new Date("2025-01-01T00:00:00.000Z"),
       creatorId: "user-1",
       memberIds: ["user-1", "user-2"],
+      adminIds: ["user-1"],
+      picksRestricted: false,
     });
     mockGetCategoryById.mockResolvedValue({
       id: "cat-1",

--- a/src/app/api/groups/route.ts
+++ b/src/app/api/groups/route.ts
@@ -35,6 +35,8 @@ export async function POST(request: Request) {
     name,
     createdAt: new Date(),
     creatorId: uid,
+    adminIds: [uid],
+    picksRestricted: false,
   });
 
   await db.ref("/").update({

--- a/src/app/groups/[id]/GroupDetailView.spec.tsx
+++ b/src/app/groups/[id]/GroupDetailView.spec.tsx
@@ -20,6 +20,8 @@ function makeGroup() {
     createdAt: new Date("2025-01-15T12:00:00.000Z"),
     creatorId: "user-123",
     memberIds: ["user-123", "user-456"],
+    adminIds: ["user-123"],
+    picksRestricted: false,
   };
 }
 

--- a/src/app/groups/[id]/GroupDetailView.stories.tsx
+++ b/src/app/groups/[id]/GroupDetailView.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof GroupDetailView> = {
       createdAt: new Date("2025-01-15T12:00:00.000Z"),
       creatorId: "user-123",
       memberIds: ["user-123", "user-456", "user-789"],
+      adminIds: ["user-123"],
+      picksRestricted: false,
     },
     categories: [],
     currentUserId: "user-123",

--- a/src/lib/firebase/schema/group.spec.ts
+++ b/src/lib/firebase/schema/group.spec.ts
@@ -15,6 +15,8 @@ function makeFirebaseGroupPublic(
     name: "Test Group",
     createdAt: FIXED_TIMESTAMP,
     creatorId: "user-123",
+    adminIds: { "user-123": true },
+    picksRestricted: false,
     ...overrides,
   };
 }
@@ -25,11 +27,49 @@ describe("groupToFirebase", () => {
       name: "My Group",
       createdAt: FIXED_DATE,
       creatorId: "user-abc",
+      adminIds: ["user-abc"],
+      picksRestricted: false,
     });
 
     expect(result.name).toBe("My Group");
     expect(result.createdAt).toBe(FIXED_TIMESTAMP);
     expect(result.creatorId).toBe("user-abc");
+  });
+
+  it("converts adminIds array to Firebase map", () => {
+    const result = groupToFirebase({
+      name: "My Group",
+      createdAt: FIXED_DATE,
+      creatorId: "user-abc",
+      adminIds: ["user-abc", "user-def"],
+      picksRestricted: false,
+    });
+
+    expect(result.adminIds).toEqual({ "user-abc": true, "user-def": true });
+  });
+
+  it("preserves picksRestricted=true", () => {
+    const result = groupToFirebase({
+      name: "My Group",
+      createdAt: FIXED_DATE,
+      creatorId: "user-abc",
+      adminIds: ["user-abc"],
+      picksRestricted: true,
+    });
+
+    expect(result.picksRestricted).toBe(true);
+  });
+
+  it("preserves picksRestricted=false", () => {
+    const result = groupToFirebase({
+      name: "My Group",
+      createdAt: FIXED_DATE,
+      creatorId: "user-abc",
+      adminIds: ["user-abc"],
+      picksRestricted: false,
+    });
+
+    expect(result.picksRestricted).toBe(false);
   });
 });
 
@@ -53,5 +93,42 @@ describe("firebaseToGroup", () => {
     const result = firebaseToGroup("group-2", data, []);
 
     expect(result.memberIds).toEqual([]);
+  });
+
+  it("converts adminIds map to array", () => {
+    const data = makeFirebaseGroupPublic({
+      adminIds: { "user-123": true, "user-789": true },
+    });
+
+    const result = firebaseToGroup("group-1", data, ["user-123"]);
+
+    expect(result.adminIds).toEqual(["user-123", "user-789"]);
+  });
+
+  it("falls back to [creatorId] when adminIds is absent", () => {
+    const data = makeFirebaseGroupPublic({
+      creatorId: "user-creator",
+      adminIds: undefined,
+    });
+
+    const result = firebaseToGroup("group-1", data, ["user-creator"]);
+
+    expect(result.adminIds).toEqual(["user-creator"]);
+  });
+
+  it("preserves picksRestricted=true", () => {
+    const data = makeFirebaseGroupPublic({ picksRestricted: true });
+
+    const result = firebaseToGroup("group-1", data, ["user-123"]);
+
+    expect(result.picksRestricted).toBe(true);
+  });
+
+  it("falls back to picksRestricted=false when absent", () => {
+    const data = makeFirebaseGroupPublic({ picksRestricted: undefined });
+
+    const result = firebaseToGroup("group-1", data, ["user-123"]);
+
+    expect(result.picksRestricted).toBe(false);
   });
 });

--- a/src/lib/firebase/schema/group.ts
+++ b/src/lib/firebase/schema/group.ts
@@ -4,15 +4,22 @@ export interface FirebaseGroupPublic {
   name: string;
   createdAt: number;
   creatorId: string;
+  adminIds?: Record<string, true>;
+  picksRestricted?: boolean;
 }
 
 export function groupToFirebase(
-  group: Pick<Group, "name" | "createdAt" | "creatorId">,
+  group: Pick<
+    Group,
+    "name" | "createdAt" | "creatorId" | "adminIds" | "picksRestricted"
+  >,
 ): FirebaseGroupPublic {
   return {
     name: group.name,
     createdAt: group.createdAt.getTime(),
     creatorId: group.creatorId,
+    adminIds: Object.fromEntries(group.adminIds.map((uid) => [uid, true])),
+    picksRestricted: group.picksRestricted,
   };
 }
 
@@ -21,11 +28,16 @@ export function firebaseToGroup(
   data: FirebaseGroupPublic,
   memberIds: string[],
 ): Group {
+  const adminIds = data.adminIds
+    ? Object.keys(data.adminIds)
+    : [data.creatorId];
   return {
     id,
     name: data.name,
     createdAt: new Date(data.createdAt),
     creatorId: data.creatorId,
     memberIds,
+    adminIds,
+    picksRestricted: data.picksRestricted ?? false,
   };
 }

--- a/src/lib/fixtures/group.ts
+++ b/src/lib/fixtures/group.ts
@@ -7,6 +7,8 @@ export function makeGroup(overrides?: Partial<Group>): Group {
     createdAt: new Date("2024-01-01"),
     creatorId: "user-1",
     memberIds: ["user-1"],
+    adminIds: ["user-1"],
+    picksRestricted: false,
     ...overrides,
   };
 }

--- a/src/lib/types/group.ts
+++ b/src/lib/types/group.ts
@@ -4,4 +4,6 @@ export interface Group {
   createdAt: Date;
   creatorId: string;
   memberIds: string[];
+  adminIds: string[];
+  picksRestricted: boolean;
 }


### PR DESCRIPTION
Foundation for the group permissions model. Adds `adminIds: string[]` and `picksRestricted: boolean` to the `Group` type and Firebase schema, and seeds `adminIds: [uid]` on group creation. All downstream permission features ([#111](https://github.com/rmartz/group-picks/issues/111)–[#115](https://github.com/rmartz/group-picks/issues/115)) depend on these fields.

`adminIds` is stored as `Record<string, true>` in Firebase (mirroring `Option.ownerIds`) and exposed as `string[]` in the app type. The `firebaseToGroup` converter falls back to `[creatorId]` for `adminIds` and `false` for `picksRestricted` so existing records remain readable.

## Acceptance Criteria
- [x] Add `adminIds: string[]` to the `Group` TypeScript type
- [x] Add `picksRestricted: boolean` to the `Group` TypeScript type (default `false`)
- [x] Update `FirebaseGroupPublic` to include both fields
- [x] Update `firebaseToGroup()` and `groupToFirebase()` with safe defaults for legacy records
- [x] Seed `adminIds: [uid]` on group creation
- [x] Add/update serializer tests in `group.spec.ts`

## Tests
7 new serializer tests added; full suite of 174 tests passing.

Closes #110

---
*Created by Claude Sonnet 4.6*