### PR TITLE
fix(groups): restore atomic last-member check in removeMember

### DIFF
--- a/src/server/data/groups.spec.ts
+++ b/src/server/data/groups.spec.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockTransaction, mockUpdate, mockRef } = vi.hoisted(() => ({
+  mockTransaction: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockRef: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/admin", () => ({
+  getAdminApp: () => ({}),
+  getAdminAuth: () => ({}),
+}));
+
+vi.mock("firebase-admin/database", () => ({
+  getDatabase: () => ({
+    ref: mockRef,
+  }),
+}));
+
+const { removeMember } = await import("./groups");
+
+describe("removeMember last-member transaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRef.mockImplementation((path: string) => {
+      if (path === `groups/group-1/members`) {
+        return { transaction: mockTransaction };
+      }
+      if (path === "/") {
+        return { update: mockUpdate };
+      }
+      throw new Error(`Unexpected ref path: ${path}`);
+    });
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it("aborts the transaction (returns undefined) when the calling user is the only member", async () => {
+    let capturedUpdate:
+      | ((m: Record<string, unknown> | null) => unknown)
+      | undefined;
+    mockTransaction.mockImplementation(
+      (update: (m: Record<string, unknown> | null) => unknown) => {
+        capturedUpdate = update;
+        return Promise.resolve({ committed: false });
+      },
+    );
+
+    await removeMember("group-1", "user-1");
+
+    expect(capturedUpdate).toBeDefined();
+    expect(capturedUpdate?.({ "user-1": true })).toBeUndefined();
+  });
+
+  it("returns members minus the calling uid when there are multiple members", async () => {
+    let capturedUpdate:
+      | ((m: Record<string, unknown> | null) => unknown)
+      | undefined;
+    mockTransaction.mockImplementation(
+      (update: (m: Record<string, unknown> | null) => unknown) => {
+        capturedUpdate = update;
+        return Promise.resolve({ committed: true });
+      },
+    );
+
+    await removeMember("group-1", "user-1");
+
+    expect(capturedUpdate?.({ "user-1": true, "user-2": true })).toEqual({
+      "user-2": true,
+    });
+  });
+
+  it("preserves the original members value when the snapshot is null (group already gone)", async () => {
+    let capturedUpdate:
+      | ((m: Record<string, unknown> | null) => unknown)
+      | undefined;
+    mockTransaction.mockImplementation(
+      (update: (m: Record<string, unknown> | null) => unknown) => {
+        capturedUpdate = update;
+        return Promise.resolve({ committed: false });
+      },
+    );
+
+    await removeMember("group-1", "user-1");
+
+    expect(capturedUpdate?.(null)).toBeNull();
+  });
+
+  it("reports lastMember=true when the transaction did not commit", async () => {
+    mockTransaction.mockResolvedValue({ committed: false });
+
+    const result = await removeMember("group-1", "user-1");
+
+    expect(result).toEqual({ lastMember: true });
+  });
+
+  it("reports lastMember=false when the transaction committed", async () => {
+    mockTransaction.mockResolvedValue({ committed: true });
+
+    const result = await removeMember("group-1", "user-1");
+
+    expect(result).toEqual({ lastMember: false });
+  });
+
+  it("cleans up the user-index entry after the transaction commits", async () => {
+    mockTransaction.mockResolvedValue({ committed: true });
+
+    await removeMember("group-1", "user-1");
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      "users/user-1/groups/group-1": null,
+    });
+  });
+
+  it("does not write a user-index cleanup when the transaction did not commit", async () => {
+    mockTransaction.mockResolvedValue({ committed: false });
+
+    await removeMember("group-1", "user-1");
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/data/groups.ts
+++ b/src/server/data/groups.ts
@@ -52,12 +52,28 @@ export async function removeMember(
   uid: string,
 ): Promise<{ lastMember: boolean }> {
   const db = getDatabase(getAdminApp());
-  const snap = await db.ref(`groups/${groupId}/members`).get();
-  if (!snap.exists()) return { lastMember: true };
-  const members = snap.val() as Record<string, unknown>;
-  if (Object.keys(members).length <= 1) return { lastMember: true };
+  // Atomically check-and-remove the calling member: if they are the last
+  // member, abort the transaction (returning undefined leaves the data
+  // untouched and result.committed === false). Otherwise, write back the
+  // members object with the calling uid removed in a single atomic step.
+  // Concurrency-safety matters here: without the transaction, two concurrent
+  // calls in a two-member group can both pass the last-member guard and
+  // both delete their own uid, leaving the group with an empty members map.
+  const result = await db
+    .ref(`groups/${groupId}/members`)
+    .transaction((members: Record<string, unknown> | null) => {
+      if (!members) return members;
+      if (Object.keys(members).length <= 1) return undefined;
+      return Object.fromEntries(
+        Object.entries(members).filter(([key]) => key !== uid),
+      );
+    });
+  if (!result.committed) return { lastMember: true };
+  // Best-effort follow-up: clean up the user-index entry. The transaction
+  // already removed the user from the group (which is the user-facing
+  // change), so a failure here would leave a dangling user-index entry but
+  // would not affect group membership.
   await db.ref("/").update({
-    [`groups/${groupId}/members/${uid}`]: null,
     [`users/${uid}/groups/${groupId}`]: null,
   });
   return { lastMember: false };


### PR DESCRIPTION
Restore the atomic last-member guard in `removeMember` that [#86](https://github.com/rmartz/group-picks/pull/86) traded away when fixing the user-index cleanup. Without atomicity, two members of a two-member group could each pass the `> 1` count check and then both delete their own uid via the multi-path update, leaving an orphaned empty members map.

The fix puts the read-and-remove back inside an RTDB transaction on `groups/${groupId}/members` (returns `undefined` to abort when the caller is the last member, otherwise returns the members map minus that uid). The user-index cleanup that #86 added is preserved as a follow-up write after the transaction commits — RTDB transactions can't span paths, but this write only runs once the membership change is confirmed, so a failure leaves no half-written group state.

## Acceptance Criteria

- [x] `removeMember` uses an RTDB transaction so concurrent calls cannot both pass the last-member guard
- [x] User-index entry at `users/${uid}/groups/${groupId}` is still cleaned up when a non-last member leaves
- [x] Last-member case still reports `lastMember: true` (route still returns 409)

## Tests

7 unit tests added in `src/server/data/groups.spec.ts`, all passing. Full suite (174 tests) green.

Closes #108

---
*Created by Claude Sonnet 4.6*