### PR TITLE
feat(observability): configure Sentry source map uploads

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -50,3 +50,5 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - run: pnpm build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -52,3 +52,5 @@ jobs:
       - run: pnpm build
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,16 @@ export default withSentryConfig(nextConfig, {
   // Upload wider set of client source files for better stack trace resolution
   widenClientFileUpload: true,
 
+  // Delete source maps from the build output after upload to prevent end-user exposure
+  sourcemaps: {
+    deleteSourcemapsAfterUpload: true,
+  },
+
+  // Strip debug logging statements from the production bundle
+  bundleSizeOptimizations: {
+    excludeDebugStatements: true,
+  },
+
   // Create a proxy API route to bypass ad-blockers
   tunnelRoute: "/monitoring",
 

--- a/src/next-config.spec.ts
+++ b/src/next-config.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+
+const mockWithSentryConfig = vi
+  .fn()
+  .mockImplementation((config: object) => config);
+
+vi.mock("@sentry/nextjs", () => ({
+  withSentryConfig: mockWithSentryConfig,
+}));
+
+async function loadNextConfig() {
+  await import("../next.config");
+  return mockWithSentryConfig.mock.calls[0]?.[1] as Record<string, unknown>;
+}
+
+describe("Source maps: deleteSourcemapsAfterUpload is enabled", () => {
+  it("calls withSentryConfig with sourcemaps.deleteSourcemapsAfterUpload: true to prevent end-user exposure", async () => {
+    const options = await loadNextConfig();
+    expect(options).toMatchObject({
+      sourcemaps: { deleteSourcemapsAfterUpload: true },
+    });
+  });
+});
+
+describe("Source maps: debug statements are excluded from bundle", () => {
+  it("calls withSentryConfig with bundleSizeOptimizations.excludeDebugStatements: true", async () => {
+    const options = await loadNextConfig();
+    expect(options).toMatchObject({
+      bundleSizeOptimizations: { excludeDebugStatements: true },
+    });
+  });
+});
+
+describe("Source maps: widenClientFileUpload is enabled", () => {
+  it("calls withSentryConfig with widenClientFileUpload: true for broader source map coverage", async () => {
+    const options = await loadNextConfig();
+    expect(options).toMatchObject({
+      widenClientFileUpload: true,
+    });
+  });
+});

--- a/src/next-config.spec.ts
+++ b/src/next-config.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockWithSentryConfig = vi
   .fn()
@@ -7,6 +7,11 @@ const mockWithSentryConfig = vi
 vi.mock("@sentry/nextjs", () => ({
   withSentryConfig: mockWithSentryConfig,
 }));
+
+beforeEach(() => {
+  mockWithSentryConfig.mockClear();
+  vi.resetModules();
+});
 
 async function loadNextConfig() {
   await import("../next.config");


### PR DESCRIPTION
Configures `withSentryConfig` to upload source maps at build time, strip them from the client bundle after upload, and exclude debug logging from the production bundle. Threads `SENTRY_AUTH_TOKEN` through the CI build job so the Sentry webpack plugin can authenticate.

Uses the current Sentry SDK API (`sourcemaps.deleteSourcemapsAfterUpload` and `bundleSizeOptimizations.excludeDebugStatements`) rather than the deprecated `hideSourceMaps`/`disableLogger` options from the issue spec.

## Acceptance Criteria
- [x] Source maps uploaded automatically on every production build
- [x] Sentry stack traces resolve to TypeScript file/line
- [x] `SENTRY_AUTH_TOKEN` in CI and Vercel (not committed to the repo)
- [x] Client bundle does not expose source maps to end users (`sourcemaps.deleteSourcemapsAfterUpload: true`)

## Tests
3 tests added, all passing.

Closes #102

---
*Created by Claude Sonnet 4.6*