### PR TITLE
chore(options): remove dead ownerCount copy entries from OPTION_LIST_COPY

### DIFF
--- a/src/app/api/groups/[id]/picks/[pickId]/interests/route.ts
+++ b/src/app/api/groups/[id]/picks/[pickId]/interests/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { getVerifiedUid } from "@/server/utils/auth";
+import { getGroupById } from "@/server/data/groups";
+import {
+  getUserInterestsForPick,
+  toggleOptionInterest,
+} from "@/server/data/interests";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string; pickId: string }> },
+) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, pickId } = await params;
+  const group = await getGroupById(id);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const categoryId = searchParams.get("categoryId");
+
+  if (!categoryId) {
+    return NextResponse.json(
+      { error: "categoryId is required" },
+      { status: 400 },
+    );
+  }
+
+  const interests = await getUserInterestsForPick(categoryId, pickId, uid);
+
+  return NextResponse.json({
+    interestedOptionIds: interests.interestedOptionIds,
+  });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; pickId: string }> },
+) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, pickId } = await params;
+  const group = await getGroupById(id);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let body: { optionId: unknown; categoryId: unknown };
+  try {
+    body = (await request.json()) as { optionId: unknown; categoryId: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (typeof body.optionId !== "string" || !body.optionId.trim()) {
+    return NextResponse.json(
+      { error: "optionId is required" },
+      { status: 400 },
+    );
+  }
+
+  if (typeof body.categoryId !== "string" || !body.categoryId.trim()) {
+    return NextResponse.json(
+      { error: "categoryId is required" },
+      { status: 400 },
+    );
+  }
+
+  const optionId = body.optionId.trim();
+  const categoryId = body.categoryId.trim();
+
+  const interested = await toggleOptionInterest(
+    categoryId,
+    pickId,
+    optionId,
+    uid,
+  );
+
+  return NextResponse.json({ interested });
+}

--- a/src/app/api/groups/[id]/picks/[pickId]/options/route.ts
+++ b/src/app/api/groups/[id]/picks/[pickId]/options/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { getVerifiedUid } from "@/server/utils/auth";
+import { getGroupById } from "@/server/data/groups";
+import { getOptionsByPick, createOption } from "@/server/data/options";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string; pickId: string }> },
+) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, pickId } = await params;
+  const group = await getGroupById(id);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const categoryId = searchParams.get("categoryId");
+
+  if (!categoryId) {
+    return NextResponse.json(
+      { error: "categoryId is required" },
+      { status: 400 },
+    );
+  }
+
+  const options = await getOptionsByPick(categoryId, pickId);
+
+  return NextResponse.json({
+    options: options.map((o) => ({
+      ...o,
+      createdAt: o.createdAt.toISOString(),
+    })),
+  });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; pickId: string }> },
+) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, pickId } = await params;
+  const group = await getGroupById(id);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let body: { name: unknown; categoryId: unknown };
+  try {
+    body = (await request.json()) as { name: unknown; categoryId: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (typeof body.name !== "string" || !body.name.trim()) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+
+  if (typeof body.categoryId !== "string" || !body.categoryId.trim()) {
+    return NextResponse.json(
+      { error: "categoryId is required" },
+      { status: 400 },
+    );
+  }
+
+  const name = body.name.trim();
+  const categoryId = body.categoryId.trim();
+
+  const { id: optionId, createdAt } = await createOption(categoryId, pickId, {
+    name,
+    creatorId: uid,
+  });
+
+  return NextResponse.json(
+    { optionId, createdAt: createdAt.toISOString() },
+    { status: 201 },
+  );
+}

--- a/src/app/groups/[id]/picks/HeartButton.spec.tsx
+++ b/src/app/groups/[id]/picks/HeartButton.spec.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { HeartButton } from "./HeartButton";
+import { OPTION_LIST_COPY } from "./copy";
+
+afterEach(cleanup);
+
+describe("HeartButton", () => {
+  it("renders with aria-label for interested state", () => {
+    render(<HeartButton interested={true} onClick={() => undefined} />);
+
+    const button = screen.getByRole("button", {
+      name: OPTION_LIST_COPY.heart.removeInterest,
+    });
+    expect(button).toBeDefined();
+  });
+
+  it("renders with aria-label for not-interested state", () => {
+    render(<HeartButton interested={false} onClick={() => undefined} />);
+
+    const button = screen.getByRole("button", {
+      name: OPTION_LIST_COPY.heart.markInterested,
+    });
+    expect(button).toBeDefined();
+  });
+
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<HeartButton interested={false} onClick={onClick} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: OPTION_LIST_COPY.heart.markInterested,
+      }),
+    );
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(
+      <HeartButton interested={false} disabled={true} onClick={onClick} />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: OPTION_LIST_COPY.heart.markInterested,
+      }),
+    );
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    render(
+      <HeartButton
+        interested={false}
+        disabled={true}
+        onClick={() => undefined}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: OPTION_LIST_COPY.heart.markInterested,
+    });
+    expect(button.getAttribute("disabled")).toBeDefined();
+  });
+});

--- a/src/app/groups/[id]/picks/HeartButton.stories.tsx
+++ b/src/app/groups/[id]/picks/HeartButton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { HeartButton } from "./HeartButton";
+
+const meta: Meta<typeof HeartButton> = {
+  title: "Picks/HeartButton",
+  component: HeartButton,
+  args: {
+    interested: false,
+    disabled: false,
+    onClick: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HeartButton>;
+
+export const NotInterested: Story = {};
+
+export const Interested: Story = {
+  args: {
+    interested: true,
+  },
+};
+
+export const DisabledNotInterested: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisabledInterested: Story = {
+  args: {
+    interested: true,
+    disabled: true,
+  },
+};

--- a/src/app/groups/[id]/picks/HeartButton.tsx
+++ b/src/app/groups/[id]/picks/HeartButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { OPTION_LIST_COPY } from "./copy";
+
+export interface HeartButtonProps {
+  interested: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export function HeartButton({
+  interested,
+  disabled,
+  onClick,
+}: HeartButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={
+        interested
+          ? OPTION_LIST_COPY.heart.removeInterest
+          : OPTION_LIST_COPY.heart.markInterested
+      }
+      className={[
+        "flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors",
+        interested
+          ? "bg-black text-white"
+          : "border border-gray-300 bg-transparent text-gray-400",
+        disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+      ].join(" ")}
+    >
+      {interested ? (
+        <svg
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="h-4 w-4"
+          aria-hidden="true"
+        >
+          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          className="h-4 w-4"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/app/groups/[id]/picks/OptionList.tsx
+++ b/src/app/groups/[id]/picks/OptionList.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { PickOption } from "@/lib/types/option";
 import { getClientAuth } from "@/lib/firebase/client";
 import { createOption } from "@/services/options";
+import { toggleInterest } from "@/services/interests";
 import { OptionListView } from "./OptionListView";
 import { OPTION_LIST_COPY } from "./copy";
 
@@ -12,6 +13,8 @@ export interface OptionListProps {
   categoryId: string;
   pickId: string;
   initialOptions?: PickOption[];
+  initialInterests?: string[];
+  pickClosed?: boolean;
 }
 
 export function OptionList({
@@ -19,11 +22,16 @@ export function OptionList({
   categoryId,
   pickId,
   initialOptions,
+  initialInterests,
+  pickClosed,
 }: OptionListProps) {
   const [options, setOptions] = useState<PickOption[]>(initialOptions ?? []);
   const [newOptionName, setNewOptionName] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const [interestedOptionIds, setInterestedOptionIds] = useState<string[]>(
+    initialInterests ?? [],
+  );
 
   async function handleSuggest(e: React.SyntheticEvent) {
     e.preventDefault();
@@ -46,6 +54,7 @@ export function OptionList({
         createdAt,
         pickId,
         categoryId,
+        interestedCount: 0,
       };
       setOptions((prev) => [...prev, newOption]);
       setNewOptionName("");
@@ -56,14 +65,57 @@ export function OptionList({
     }
   }
 
+  async function handleToggleInterest(optionId: string) {
+    const wasInterested = interestedOptionIds.includes(optionId);
+    // Optimistic update
+    setInterestedOptionIds((prev) =>
+      wasInterested
+        ? prev.filter((id) => id !== optionId)
+        : [...prev, optionId],
+    );
+    setOptions((prev) =>
+      prev.map((o) =>
+        o.id === optionId
+          ? {
+              ...o,
+              interestedCount: o.interestedCount + (wasInterested ? -1 : 1),
+            }
+          : o,
+      ),
+    );
+    try {
+      await toggleInterest(groupId, categoryId, pickId, optionId);
+    } catch {
+      // Revert on failure
+      setInterestedOptionIds((prev) =>
+        wasInterested
+          ? [...prev, optionId]
+          : prev.filter((id) => id !== optionId),
+      );
+      setOptions((prev) =>
+        prev.map((o) =>
+          o.id === optionId
+            ? {
+                ...o,
+                interestedCount: o.interestedCount + (wasInterested ? 1 : -1),
+              }
+            : o,
+        ),
+      );
+    }
+  }
+
   return (
     <OptionListView
       options={options}
       newOptionName={newOptionName}
       loading={loading}
       error={error}
+      interestedOptionIds={interestedOptionIds}
       onNewOptionNameChange={setNewOptionName}
       onSuggest={(e) => void handleSuggest(e)}
+      onToggleInterest={(optionId) => void handleToggleInterest(optionId)}
+      pickClosed={pickClosed}
     />
   );
 }

--- a/src/app/groups/[id]/picks/OptionList.tsx
+++ b/src/app/groups/[id]/picks/OptionList.tsx
@@ -42,7 +42,7 @@ export function OptionList({
         id: optionId,
         name: trimmedName,
         creatorId,
-        owners: [],
+        owners: creatorId ? [creatorId] : [],
         createdAt,
         pickId,
         categoryId,

--- a/src/app/groups/[id]/picks/OptionList.tsx
+++ b/src/app/groups/[id]/picks/OptionList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { PickOption } from "@/lib/types/option";
+import { getClientAuth } from "@/lib/firebase/client";
 import { createOption } from "@/services/options";
 import { OptionListView } from "./OptionListView";
 import { OPTION_LIST_COPY } from "./copy";
@@ -29,16 +30,18 @@ export function OptionList({
     setError(undefined);
     setLoading(true);
     try {
+      const trimmedName = newOptionName.trim();
+      const creatorId = getClientAuth().currentUser?.uid ?? "";
       const { optionId, createdAt } = await createOption(
         groupId,
         categoryId,
         pickId,
-        newOptionName.trim(),
+        trimmedName,
       );
       const newOption: PickOption = {
         id: optionId,
-        name: newOptionName.trim(),
-        creatorId: "",
+        name: trimmedName,
+        creatorId,
         owners: [],
         createdAt,
         pickId,

--- a/src/app/groups/[id]/picks/OptionList.tsx
+++ b/src/app/groups/[id]/picks/OptionList.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import type { PickOption } from "@/lib/types/option";
+import { createOption } from "@/services/options";
+import { OptionListView } from "./OptionListView";
+import { OPTION_LIST_COPY } from "./copy";
+
+export interface OptionListProps {
+  groupId: string;
+  categoryId: string;
+  pickId: string;
+  initialOptions?: PickOption[];
+}
+
+export function OptionList({
+  groupId,
+  categoryId,
+  pickId,
+  initialOptions,
+}: OptionListProps) {
+  const [options, setOptions] = useState<PickOption[]>(initialOptions ?? []);
+  const [newOptionName, setNewOptionName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  async function handleSuggest(e: React.SyntheticEvent) {
+    e.preventDefault();
+    setError(undefined);
+    setLoading(true);
+    try {
+      const { optionId, createdAt } = await createOption(
+        groupId,
+        categoryId,
+        pickId,
+        newOptionName.trim(),
+      );
+      const newOption: PickOption = {
+        id: optionId,
+        name: newOptionName.trim(),
+        creatorId: "",
+        owners: [],
+        createdAt,
+        pickId,
+        categoryId,
+      };
+      setOptions((prev) => [...prev, newOption]);
+      setNewOptionName("");
+    } catch {
+      setError(OPTION_LIST_COPY.errors.default);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <OptionListView
+      options={options}
+      newOptionName={newOptionName}
+      loading={loading}
+      error={error}
+      onNewOptionNameChange={setNewOptionName}
+      onSuggest={(e) => void handleSuggest(e)}
+    />
+  );
+}

--- a/src/app/groups/[id]/picks/OptionListView.spec.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.spec.tsx
@@ -15,6 +15,7 @@ function makePickOption(overrides?: Partial<PickOption>): PickOption {
     createdAt: new Date("2025-01-01"),
     pickId: "pick-1",
     categoryId: "cat-1",
+    interestedCount: 0,
     ...overrides,
   };
 }
@@ -24,8 +25,10 @@ const defaultProps = {
   newOptionName: "",
   loading: false,
   error: undefined,
+  interestedOptionIds: [],
   onNewOptionNameChange: () => undefined,
   onSuggest: () => undefined,
+  onToggleInterest: () => undefined,
 };
 
 describe("OptionListView", () => {
@@ -41,28 +44,27 @@ describe("OptionListView", () => {
     expect(screen.getByText("Sushi")).toBeDefined();
   });
 
-  it("renders owner count as '1 member' for a single owner", () => {
-    const options = [makePickOption({ owners: ["user-1"] })];
+  it("renders the interest count for a single option", () => {
+    const options = [makePickOption({ interestedCount: 1 })];
 
     render(<OptionListView {...defaultProps} options={options} />);
 
-    expect(screen.getByText(OPTION_LIST_COPY.ownerCount.one)).toBeDefined();
+    expect(screen.getByText(OPTION_LIST_COPY.interestCount(1))).toBeDefined();
   });
 
-  it("renders owner count as 'N members' for multiple owners", () => {
-    const options = [makePickOption({ owners: ["user-1", "user-2"] })];
+  it("renders zero interest count when no one is interested", () => {
+    const options = [makePickOption({ interestedCount: 0 })];
 
     render(<OptionListView {...defaultProps} options={options} />);
 
-    expect(
-      screen.getByText(OPTION_LIST_COPY.ownerCount.other(2)),
-    ).toBeDefined();
+    expect(screen.getByText(OPTION_LIST_COPY.interestCount(0))).toBeDefined();
   });
 
-  it("renders the suggest button", () => {
+  it("renders the suggest buttons", () => {
     render(<OptionListView {...defaultProps} />);
 
-    expect(screen.getByText(OPTION_LIST_COPY.suggestButton)).toBeDefined();
+    const buttons = screen.getAllByText(OPTION_LIST_COPY.suggestButton);
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
   it("calls onSuggest on form submit", () => {
@@ -102,11 +104,15 @@ describe("OptionListView", () => {
     expect(changed).toBe("Tacos");
   });
 
-  it("disables the button while loading", () => {
+  it("disables the form submit button while loading", () => {
     render(<OptionListView {...defaultProps} loading={true} />);
 
-    const button = screen.getByText(OPTION_LIST_COPY.suggestButton);
-    expect((button as HTMLButtonElement).disabled).toBe(true);
+    // The form's submit button is type="submit"
+    const submitButton = screen
+      .getByRole("form")
+      .querySelector('button[type="submit"]');
+    expect(submitButton).toBeDefined();
+    expect(submitButton?.getAttribute("disabled")).toBeDefined();
   });
 
   it("shows error message when error is set", () => {
@@ -118,5 +124,85 @@ describe("OptionListView", () => {
     );
 
     expect(screen.getByText(OPTION_LIST_COPY.errors.default)).toBeDefined();
+  });
+
+  it("renders a heart button for each option", () => {
+    const options = [
+      makePickOption({ id: "opt-1", name: "Pizza" }),
+      makePickOption({ id: "opt-2", name: "Sushi" }),
+    ];
+
+    render(<OptionListView {...defaultProps} options={options} />);
+
+    const heartButtons = screen.getAllByRole("button", {
+      name: OPTION_LIST_COPY.heart.markInterested,
+    });
+    expect(heartButtons).toHaveLength(2);
+  });
+
+  it("renders the interest count for each option", () => {
+    const options = [
+      makePickOption({ id: "opt-1", name: "Pizza", interestedCount: 1 }),
+      makePickOption({ id: "opt-2", name: "Sushi", interestedCount: 0 }),
+    ];
+
+    render(<OptionListView {...defaultProps} options={options} />);
+
+    expect(screen.getByText(OPTION_LIST_COPY.interestCount(1))).toBeDefined();
+    expect(screen.getAllByText(OPTION_LIST_COPY.interestCount(0))).toHaveLength(
+      1,
+    );
+  });
+
+  it("calls onToggleInterest when a heart button is clicked", () => {
+    let toggledId = "";
+    const options = [makePickOption({ id: "opt-42", name: "Pizza" })];
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        options={options}
+        onToggleInterest={(id) => {
+          toggledId = id;
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: OPTION_LIST_COPY.heart.markInterested,
+      }),
+    );
+    expect(toggledId).toBe("opt-42");
+  });
+
+  it("disables heart buttons when pickClosed is true", () => {
+    const options = [makePickOption({ id: "opt-1", name: "Pizza" })];
+
+    render(
+      <OptionListView {...defaultProps} options={options} pickClosed={true} />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: OPTION_LIST_COPY.heart.markInterested,
+    });
+    expect(button.getAttribute("disabled")).toBeDefined();
+  });
+
+  it("renders heart button as interested when optionId is in interestedOptionIds", () => {
+    const options = [makePickOption({ id: "opt-1", name: "Pizza" })];
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        options={options}
+        interestedOptionIds={["opt-1"]}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: OPTION_LIST_COPY.heart.removeInterest,
+    });
+    expect(button).toBeDefined();
   });
 });

--- a/src/app/groups/[id]/picks/OptionListView.spec.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.spec.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { OptionListView } from "./OptionListView";
+import { OPTION_LIST_COPY } from "./copy";
+import type { PickOption } from "@/lib/types/option";
+
+afterEach(cleanup);
+
+function makePickOption(overrides?: Partial<PickOption>): PickOption {
+  return {
+    id: "opt-1",
+    name: "Pizza",
+    creatorId: "user-1",
+    owners: ["user-1"],
+    createdAt: new Date("2025-01-01"),
+    pickId: "pick-1",
+    categoryId: "cat-1",
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  options: [],
+  newOptionName: "",
+  loading: false,
+  error: undefined,
+  onNewOptionNameChange: () => undefined,
+  onSuggest: () => undefined,
+};
+
+describe("OptionListView", () => {
+  it("renders each option name", () => {
+    const options = [
+      makePickOption({ id: "opt-1", name: "Pizza" }),
+      makePickOption({ id: "opt-2", name: "Sushi" }),
+    ];
+
+    render(<OptionListView {...defaultProps} options={options} />);
+
+    expect(screen.getByText("Pizza")).toBeDefined();
+    expect(screen.getByText("Sushi")).toBeDefined();
+  });
+
+  it("renders owner count as '1 member' for a single owner", () => {
+    const options = [makePickOption({ owners: ["user-1"] })];
+
+    render(<OptionListView {...defaultProps} options={options} />);
+
+    expect(screen.getByText(OPTION_LIST_COPY.ownerCount.one)).toBeDefined();
+  });
+
+  it("renders owner count as 'N members' for multiple owners", () => {
+    const options = [makePickOption({ owners: ["user-1", "user-2"] })];
+
+    render(<OptionListView {...defaultProps} options={options} />);
+
+    expect(
+      screen.getByText(OPTION_LIST_COPY.ownerCount.other(2)),
+    ).toBeDefined();
+  });
+
+  it("renders the suggest button", () => {
+    render(<OptionListView {...defaultProps} />);
+
+    expect(screen.getByText(OPTION_LIST_COPY.suggestButton)).toBeDefined();
+  });
+
+  it("calls onSuggest on form submit", () => {
+    let submitted = false;
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        onSuggest={() => {
+          submitted = true;
+        }}
+      />,
+    );
+
+    fireEvent.submit(screen.getByRole("form"));
+    expect(submitted).toBe(true);
+  });
+
+  it("calls onNewOptionNameChange on input change", () => {
+    let changed = "";
+
+    render(
+      <OptionListView
+        {...defaultProps}
+        onNewOptionNameChange={(name) => {
+          changed = name;
+        }}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(OPTION_LIST_COPY.suggestPlaceholder),
+      { target: { value: "Tacos" } },
+    );
+    expect(changed).toBe("Tacos");
+  });
+
+  it("disables the button while loading", () => {
+    render(<OptionListView {...defaultProps} loading={true} />);
+
+    const button = screen.getByText(OPTION_LIST_COPY.suggestButton);
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("shows error message when error is set", () => {
+    render(
+      <OptionListView
+        {...defaultProps}
+        error={OPTION_LIST_COPY.errors.default}
+      />,
+    );
+
+    expect(screen.getByText(OPTION_LIST_COPY.errors.default)).toBeDefined();
+  });
+});

--- a/src/app/groups/[id]/picks/OptionListView.spec.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.spec.tsx
@@ -77,7 +77,9 @@ describe("OptionListView", () => {
       />,
     );
 
-    fireEvent.submit(screen.getByRole("form"));
+    fireEvent.submit(
+      screen.getByRole("form", { name: OPTION_LIST_COPY.suggestFormLabel }),
+    );
     expect(submitted).toBe(true);
   });
 

--- a/src/app/groups/[id]/picks/OptionListView.stories.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.stories.tsx
@@ -12,6 +12,7 @@ const mockOptions: PickOption[] = [
     createdAt: new Date("2025-01-01"),
     pickId: "pick-1",
     categoryId: "cat-1",
+    interestedCount: 2,
   },
   {
     id: "opt-2",
@@ -21,6 +22,7 @@ const mockOptions: PickOption[] = [
     createdAt: new Date("2025-01-02"),
     pickId: "pick-1",
     categoryId: "cat-1",
+    interestedCount: 0,
   },
 ];
 
@@ -32,8 +34,10 @@ const meta: Meta<typeof OptionListView> = {
     newOptionName: "",
     loading: false,
     error: undefined,
+    interestedOptionIds: [],
     onNewOptionNameChange: () => undefined,
     onSuggest: () => undefined,
+    onToggleInterest: () => undefined,
   },
 };
 
@@ -61,5 +65,20 @@ export const WithError: Story = {
     options: mockOptions,
     newOptionName: "Tacos",
     error: OPTION_LIST_COPY.errors.default,
+  },
+};
+
+export const WithInterests: Story = {
+  args: {
+    options: mockOptions,
+    interestedOptionIds: ["opt-1"],
+  },
+};
+
+export const PickClosed: Story = {
+  args: {
+    options: mockOptions,
+    interestedOptionIds: ["opt-1"],
+    pickClosed: true,
   },
 };

--- a/src/app/groups/[id]/picks/OptionListView.stories.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { PickOption } from "@/lib/types/option";
+import { OptionListView } from "./OptionListView";
+import { OPTION_LIST_COPY } from "./copy";
+
+const mockOptions: PickOption[] = [
+  {
+    id: "opt-1",
+    name: "Pizza",
+    creatorId: "user-1",
+    owners: ["user-1", "user-2"],
+    createdAt: new Date("2025-01-01"),
+    pickId: "pick-1",
+    categoryId: "cat-1",
+  },
+  {
+    id: "opt-2",
+    name: "Sushi",
+    creatorId: "user-3",
+    owners: ["user-3"],
+    createdAt: new Date("2025-01-02"),
+    pickId: "pick-1",
+    categoryId: "cat-1",
+  },
+];
+
+const meta: Meta<typeof OptionListView> = {
+  title: "Picks/OptionListView",
+  component: OptionListView,
+  args: {
+    options: [],
+    newOptionName: "",
+    loading: false,
+    error: undefined,
+    onNewOptionNameChange: () => undefined,
+    onSuggest: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OptionListView>;
+
+export const Empty: Story = {};
+
+export const WithOptions: Story = {
+  args: {
+    options: mockOptions,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    options: mockOptions,
+    newOptionName: "Tacos",
+    loading: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    options: mockOptions,
+    newOptionName: "Tacos",
+    error: OPTION_LIST_COPY.errors.default,
+  },
+};

--- a/src/app/groups/[id]/picks/OptionListView.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { PickOption } from "@/lib/types/option";
+import { OPTION_LIST_COPY } from "./copy";
+
+export interface OptionListViewProps {
+  options: PickOption[];
+  newOptionName: string;
+  loading: boolean;
+  error: string | undefined;
+  onNewOptionNameChange: (name: string) => void;
+  onSuggest: (e: React.SyntheticEvent) => void;
+}
+
+export function OptionListView({
+  options,
+  newOptionName,
+  loading,
+  error,
+  onNewOptionNameChange,
+  onSuggest,
+}: OptionListViewProps) {
+  return (
+    <div className="space-y-4">
+      <ul className="space-y-2">
+        {options.map((option) => (
+          <li
+            key={option.id}
+            className="flex items-center justify-between rounded border p-3"
+          >
+            <span className="font-medium">{option.name}</span>
+            <span className="text-sm text-gray-500">
+              {option.owners.length === 1
+                ? OPTION_LIST_COPY.ownerCount.one
+                : OPTION_LIST_COPY.ownerCount.other(option.owners.length)}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <form aria-label="form" onSubmit={onSuggest} className="space-y-2">
+        <div className="flex gap-2">
+          <Input
+            value={newOptionName}
+            onChange={(e) => {
+              onNewOptionNameChange(e.target.value);
+            }}
+            placeholder={OPTION_LIST_COPY.suggestPlaceholder}
+            disabled={loading}
+          />
+          <Button type="submit" disabled={loading}>
+            {OPTION_LIST_COPY.suggestButton}
+          </Button>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </form>
+    </div>
+  );
+}

--- a/src/app/groups/[id]/picks/OptionListView.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { PickOption } from "@/lib/types/option";
+import { HeartButton } from "./HeartButton";
 import { OPTION_LIST_COPY } from "./copy";
 
 export interface OptionListViewProps {
@@ -10,8 +11,11 @@ export interface OptionListViewProps {
   newOptionName: string;
   loading: boolean;
   error: string | undefined;
+  interestedOptionIds: string[];
   onNewOptionNameChange: (name: string) => void;
   onSuggest: (e: React.SyntheticEvent) => void;
+  onToggleInterest: (optionId: string) => void;
+  pickClosed?: boolean;
 }
 
 export function OptionListView({
@@ -19,23 +23,44 @@ export function OptionListView({
   newOptionName,
   loading,
   error,
+  interestedOptionIds,
   onNewOptionNameChange,
   onSuggest,
+  onToggleInterest,
+  pickClosed,
 }: OptionListViewProps) {
   return (
     <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-500">
+          {OPTION_LIST_COPY.headerCaption}
+        </span>
+        <Button
+          type="button"
+          onClick={onSuggest}
+          disabled={loading || pickClosed}
+        >
+          {OPTION_LIST_COPY.suggestButton}
+        </Button>
+      </div>
+
       <ul className="space-y-2">
         {options.map((option) => (
           <li
             key={option.id}
-            className="flex items-center justify-between rounded border p-3"
+            className="flex items-center justify-between gap-2 rounded border p-3"
           >
             <span className="font-medium">{option.name}</span>
             <span className="text-sm text-gray-500">
-              {option.owners.length === 1
-                ? OPTION_LIST_COPY.ownerCount.one
-                : OPTION_LIST_COPY.ownerCount.other(option.owners.length)}
+              {OPTION_LIST_COPY.interestCount(option.interestedCount)}
             </span>
+            <HeartButton
+              interested={interestedOptionIds.includes(option.id)}
+              disabled={loading || pickClosed}
+              onClick={() => {
+                onToggleInterest(option.id);
+              }}
+            />
           </li>
         ))}
       </ul>
@@ -48,9 +73,9 @@ export function OptionListView({
               onNewOptionNameChange(e.target.value);
             }}
             placeholder={OPTION_LIST_COPY.suggestPlaceholder}
-            disabled={loading}
+            disabled={loading || pickClosed}
           />
-          <Button type="submit" disabled={loading}>
+          <Button type="submit" disabled={loading || pickClosed}>
             {OPTION_LIST_COPY.suggestButton}
           </Button>
         </div>

--- a/src/app/groups/[id]/picks/OptionListView.tsx
+++ b/src/app/groups/[id]/picks/OptionListView.tsx
@@ -40,7 +40,7 @@ export function OptionListView({
         ))}
       </ul>
 
-      <form aria-label="form" onSubmit={onSuggest} className="space-y-2">
+      <form aria-label={OPTION_LIST_COPY.suggestFormLabel} onSubmit={onSuggest} className="space-y-2">
         <div className="flex gap-2">
           <Input
             value={newOptionName}

--- a/src/app/groups/[id]/picks/copy.spec.ts
+++ b/src/app/groups/[id]/picks/copy.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { OPTION_LIST_COPY } from "./copy";
+
+describe("ownerCount dead copy entries removed", () => {
+  it("does not have an ownerCount key", () => {
+    expect("ownerCount" in OPTION_LIST_COPY).toBe(false);
+  });
+});
+
+describe("OPTION_LIST_COPY active keys are preserved", () => {
+  it("retains suggestFormLabel", () => {
+    expect(OPTION_LIST_COPY.suggestFormLabel).toBeDefined();
+  });
+
+  it("retains suggestPlaceholder", () => {
+    expect(OPTION_LIST_COPY.suggestPlaceholder).toBeDefined();
+  });
+
+  it("retains suggestButton", () => {
+    expect(OPTION_LIST_COPY.suggestButton).toBeDefined();
+  });
+
+  it("retains errors.default", () => {
+    expect(OPTION_LIST_COPY.errors.default).toBeDefined();
+  });
+
+  it("retains heart.markInterested", () => {
+    expect(OPTION_LIST_COPY.heart.markInterested).toBeDefined();
+  });
+
+  it("retains heart.removeInterest", () => {
+    expect(OPTION_LIST_COPY.heart.removeInterest).toBeDefined();
+  });
+
+  it("retains interestCount", () => {
+    expect(OPTION_LIST_COPY.interestCount).toBeDefined();
+  });
+
+  it("retains headerCaption", () => {
+    expect(OPTION_LIST_COPY.headerCaption).toBeDefined();
+  });
+});

--- a/src/app/groups/[id]/picks/copy.ts
+++ b/src/app/groups/[id]/picks/copy.ts
@@ -1,4 +1,5 @@
 export const OPTION_LIST_COPY = {
+  suggestFormLabel: "Suggest an option",
   suggestPlaceholder: "Option name",
   suggestButton: "Suggest",
   ownerCount: {

--- a/src/app/groups/[id]/picks/copy.ts
+++ b/src/app/groups/[id]/picks/copy.ts
@@ -1,0 +1,11 @@
+export const OPTION_LIST_COPY = {
+  suggestPlaceholder: "Option name",
+  suggestButton: "Suggest",
+  ownerCount: {
+    one: "1 member",
+    other: (n: number) => `${String(n)} members`,
+  },
+  errors: {
+    default: "Something went wrong. Please try again.",
+  },
+} as const;

--- a/src/app/groups/[id]/picks/copy.ts
+++ b/src/app/groups/[id]/picks/copy.ts
@@ -2,10 +2,6 @@ export const OPTION_LIST_COPY = {
   suggestFormLabel: "Suggest an option",
   suggestPlaceholder: "Option name",
   suggestButton: "+ Suggest",
-  ownerCount: {
-    one: "1 member",
-    other: (n: number) => `${String(n)} members`,
-  },
   errors: {
     default: "Something went wrong. Please try again.",
   },

--- a/src/app/groups/[id]/picks/copy.ts
+++ b/src/app/groups/[id]/picks/copy.ts
@@ -1,7 +1,7 @@
 export const OPTION_LIST_COPY = {
   suggestFormLabel: "Suggest an option",
   suggestPlaceholder: "Option name",
-  suggestButton: "Suggest",
+  suggestButton: "+ Suggest",
   ownerCount: {
     one: "1 member",
     other: (n: number) => `${String(n)} members`,
@@ -9,4 +9,10 @@ export const OPTION_LIST_COPY = {
   errors: {
     default: "Something went wrong. Please try again.",
   },
+  heart: {
+    markInterested: "Mark interested",
+    removeInterest: "Remove interest",
+  },
+  interestCount: (count: number) => `${String(count)} interested`,
+  headerCaption: "Tap a heart to mark interest",
 } as const;

--- a/src/lib/firebase/schema/interest.spec.ts
+++ b/src/lib/firebase/schema/interest.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  firebaseToInterests,
+  interestsToFirebase,
+  type FirebaseInterests,
+} from "./interest";
+
+describe("firebaseToInterests", () => {
+  it("converts Firebase interests map to UserPickInterests", () => {
+    const data: FirebaseInterests = {
+      "opt-1": true,
+      "opt-3": true,
+    };
+
+    const result = firebaseToInterests("pick-1", "cat-1", data);
+
+    expect(result.pickId).toBe("pick-1");
+    expect(result.categoryId).toBe("cat-1");
+    expect(result.interestedOptionIds).toContain("opt-1");
+    expect(result.interestedOptionIds).toContain("opt-3");
+    expect(result.interestedOptionIds).toHaveLength(2);
+  });
+
+  it("returns empty interestedOptionIds for empty data", () => {
+    const result = firebaseToInterests("pick-2", "cat-2", {});
+
+    expect(result.interestedOptionIds).toEqual([]);
+  });
+});
+
+describe("interestsToFirebase", () => {
+  it("converts option id array to Firebase boolean map", () => {
+    const result = interestsToFirebase(["opt-1", "opt-2"]);
+
+    expect(result["opt-1"]).toBe(true);
+    expect(result["opt-2"]).toBe(true);
+  });
+
+  it("returns empty object for empty array", () => {
+    const result = interestsToFirebase([]);
+
+    expect(result).toEqual({});
+  });
+
+  it("round-trips through Firebase format", () => {
+    const ids = ["opt-a", "opt-b", "opt-c"];
+    const firebase = interestsToFirebase(ids);
+    const result = firebaseToInterests("pick-1", "cat-1", firebase);
+
+    expect(result.interestedOptionIds).toHaveLength(3);
+    for (const id of ids) {
+      expect(result.interestedOptionIds).toContain(id);
+    }
+  });
+});

--- a/src/lib/firebase/schema/interest.ts
+++ b/src/lib/firebase/schema/interest.ts
@@ -1,0 +1,25 @@
+import type { UserPickInterests } from "@/lib/types/option";
+
+export type FirebaseInterests = Record<string, true>;
+
+export function firebaseToInterests(
+  pickId: string,
+  categoryId: string,
+  data: FirebaseInterests,
+): UserPickInterests {
+  return {
+    pickId,
+    categoryId,
+    interestedOptionIds: Object.keys(data),
+  };
+}
+
+export function interestsToFirebase(
+  interestedOptionIds: string[],
+): FirebaseInterests {
+  const result: FirebaseInterests = {};
+  for (const optionId of interestedOptionIds) {
+    result[optionId] = true;
+  }
+  return result;
+}

--- a/src/lib/firebase/schema/option.spec.ts
+++ b/src/lib/firebase/schema/option.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  optionToFirebase,
+  firebaseToOption,
+  type FirebaseOptionPublic,
+} from "./option";
+
+const FIXED_DATE = new Date("2025-04-01T12:00:00.000Z");
+const FIXED_TIMESTAMP = FIXED_DATE.getTime();
+
+function makeFirebaseOptionPublic(
+  overrides?: Partial<FirebaseOptionPublic>,
+): FirebaseOptionPublic {
+  return {
+    name: "Pizza",
+    creatorId: "user-1",
+    owners: { "user-1": true },
+    createdAt: FIXED_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+describe("optionToFirebase", () => {
+  it("converts an option to Firebase format", () => {
+    const result = optionToFirebase({
+      name: "Pizza",
+      creatorId: "user-1",
+      owners: ["user-1", "user-2"],
+      createdAt: FIXED_DATE,
+    });
+
+    expect(result.name).toBe("Pizza");
+    expect(result.creatorId).toBe("user-1");
+    expect(result.createdAt).toBe(FIXED_TIMESTAMP);
+    expect(result.owners).toEqual({ "user-1": true, "user-2": true });
+  });
+
+  it("converts empty owners array to empty record", () => {
+    const result = optionToFirebase({
+      name: "Sushi",
+      creatorId: "user-2",
+      owners: [],
+      createdAt: FIXED_DATE,
+    });
+
+    expect(result.owners).toEqual({});
+  });
+});
+
+describe("firebaseToOption", () => {
+  it("converts Firebase data to a PickOption", () => {
+    const data = makeFirebaseOptionPublic();
+    const result = firebaseToOption("opt-1", "cat-1", "pick-1", data);
+
+    expect(result.id).toBe("opt-1");
+    expect(result.categoryId).toBe("cat-1");
+    expect(result.pickId).toBe("pick-1");
+    expect(result.name).toBe("Pizza");
+    expect(result.creatorId).toBe("user-1");
+    expect(result.owners).toEqual(["user-1"]);
+    expect(result.createdAt).toEqual(FIXED_DATE);
+  });
+
+  it("converts multiple owners from record to array", () => {
+    const data = makeFirebaseOptionPublic({
+      owners: { "user-1": true, "user-2": true, "user-3": true },
+    });
+    const result = firebaseToOption("opt-2", "cat-1", "pick-1", data);
+
+    expect(result.owners).toHaveLength(3);
+    expect(result.owners).toContain("user-1");
+    expect(result.owners).toContain("user-2");
+    expect(result.owners).toContain("user-3");
+  });
+
+  it("handles missing owners field gracefully", () => {
+    const data = makeFirebaseOptionPublic({ owners: {} });
+    const result = firebaseToOption("opt-3", "cat-1", "pick-1", data);
+
+    expect(result.owners).toEqual([]);
+  });
+
+  it("round-trips through Firebase format", () => {
+    const original = {
+      name: "Tacos",
+      creatorId: "user-5",
+      owners: ["user-5"],
+      createdAt: FIXED_DATE,
+    };
+
+    const firebase = optionToFirebase(original);
+    const result = firebaseToOption("opt-4", "cat-2", "pick-2", firebase);
+
+    expect(result.name).toBe(original.name);
+    expect(result.creatorId).toBe(original.creatorId);
+    expect(result.owners).toEqual(original.owners);
+    expect(result.createdAt).toEqual(original.createdAt);
+  });
+});

--- a/src/lib/firebase/schema/option.spec.ts
+++ b/src/lib/firebase/schema/option.spec.ts
@@ -59,6 +59,14 @@ describe("firebaseToOption", () => {
     expect(result.creatorId).toBe("user-1");
     expect(result.owners).toEqual(["user-1"]);
     expect(result.createdAt).toEqual(FIXED_DATE);
+    expect(result.interestedCount).toBe(0);
+  });
+
+  it("reads interestedCount from Firebase data when present", () => {
+    const data = makeFirebaseOptionPublic({ interestedCount: 3 });
+    const result = firebaseToOption("opt-1", "cat-1", "pick-1", data);
+
+    expect(result.interestedCount).toBe(3);
   });
 
   it("converts multiple owners from record to array", () => {

--- a/src/lib/firebase/schema/option.ts
+++ b/src/lib/firebase/schema/option.ts
@@ -1,0 +1,40 @@
+import type { PickOption } from "@/lib/types/option";
+
+export interface FirebaseOptionPublic {
+  name: string;
+  creatorId: string;
+  owners: Record<string, true>;
+  createdAt: number;
+}
+
+export function optionToFirebase(
+  option: Pick<PickOption, "name" | "creatorId" | "owners" | "createdAt">,
+): FirebaseOptionPublic {
+  const owners: Record<string, true> = {};
+  for (const uid of option.owners) {
+    owners[uid] = true;
+  }
+  return {
+    name: option.name,
+    creatorId: option.creatorId,
+    owners,
+    createdAt: option.createdAt.getTime(),
+  };
+}
+
+export function firebaseToOption(
+  id: string,
+  categoryId: string,
+  pickId: string,
+  data: FirebaseOptionPublic,
+): PickOption {
+  return {
+    id,
+    name: data.name,
+    creatorId: data.creatorId,
+    owners: Object.keys(data.owners),
+    createdAt: new Date(data.createdAt),
+    pickId,
+    categoryId,
+  };
+}

--- a/src/lib/firebase/schema/option.ts
+++ b/src/lib/firebase/schema/option.ts
@@ -5,6 +5,7 @@ export interface FirebaseOptionPublic {
   creatorId: string;
   owners: Record<string, true>;
   createdAt: number;
+  interestedCount?: number;
 }
 
 export function optionToFirebase(
@@ -36,5 +37,6 @@ export function firebaseToOption(
     createdAt: new Date(data.createdAt),
     pickId,
     categoryId,
+    interestedCount: data.interestedCount ?? 0,
   };
 }

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -6,4 +6,11 @@ export interface PickOption {
   createdAt: Date;
   pickId: string;
   categoryId: string;
+  interestedCount: number;
+}
+
+export interface UserPickInterests {
+  pickId: string;
+  categoryId: string;
+  interestedOptionIds: string[];
 }

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -1,0 +1,9 @@
+export interface PickOption {
+  id: string;
+  name: string;
+  creatorId: string;
+  owners: string[];
+  createdAt: Date;
+  pickId: string;
+  categoryId: string;
+}

--- a/src/server/data/interests.ts
+++ b/src/server/data/interests.ts
@@ -1,0 +1,76 @@
+import { getDatabase } from "firebase-admin/database";
+import { getAdminApp } from "@/lib/firebase/admin";
+import {
+  firebaseToInterests,
+  type FirebaseInterests,
+} from "@/lib/firebase/schema/interest";
+import type { UserPickInterests } from "@/lib/types/option";
+
+export async function getUserInterestsForPick(
+  categoryId: string,
+  pickId: string,
+  userId: string,
+): Promise<UserPickInterests> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db
+    .ref(`categories/${categoryId}/picks/${pickId}/interests/${userId}`)
+    .get();
+
+  if (!snap.exists()) {
+    return { pickId, categoryId, interestedOptionIds: [] };
+  }
+
+  const data = snap.val() as FirebaseInterests;
+  return firebaseToInterests(pickId, categoryId, data);
+}
+
+interface PickInterestData {
+  interests?: Record<string, Record<string, true>>;
+  options?: Record<string, { interestedCount?: number }>;
+}
+
+export async function toggleOptionInterest(
+  categoryId: string,
+  pickId: string,
+  optionId: string,
+  userId: string,
+): Promise<boolean> {
+  const db = getDatabase(getAdminApp());
+  const pickRef = db.ref(`categories/${categoryId}/picks/${pickId}`);
+
+  let nowInterested = false;
+
+  await pickRef.transaction((current: PickInterestData | null) => {
+    if (current === null) return current;
+
+    const wasInterested = current.interests?.[userId]?.[optionId] === true;
+    nowInterested = !wasInterested;
+
+    const existingUserInterests = current.interests?.[userId] ?? {};
+    const withoutOption = Object.fromEntries(
+      Object.entries(existingUserInterests).filter(([k]) => k !== optionId),
+    ) as Record<string, true>;
+    const userInterests: Record<string, true> = wasInterested
+      ? withoutOption
+      : { ...existingUserInterests, [optionId]: true };
+
+    const currentCount = current.options?.[optionId]?.interestedCount ?? 0;
+
+    return {
+      ...current,
+      interests: {
+        ...(current.interests ?? {}),
+        [userId]: userInterests,
+      },
+      options: {
+        ...(current.options ?? {}),
+        [optionId]: {
+          ...(current.options?.[optionId] ?? {}),
+          interestedCount: currentCount + (wasInterested ? -1 : 1),
+        },
+      },
+    };
+  });
+
+  return nowInterested;
+}

--- a/src/server/data/options.ts
+++ b/src/server/data/options.ts
@@ -1,0 +1,53 @@
+import { getDatabase } from "firebase-admin/database";
+import { getAdminApp } from "@/lib/firebase/admin";
+import {
+  optionToFirebase,
+  firebaseToOption,
+  type FirebaseOptionPublic,
+} from "@/lib/firebase/schema/option";
+import type { PickOption } from "@/lib/types/option";
+
+export async function getOptionsByPick(
+  categoryId: string,
+  pickId: string,
+): Promise<PickOption[]> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db
+    .ref(`categories/${categoryId}/picks/${pickId}/options`)
+    .get();
+
+  if (!snap.exists()) return [];
+
+  const options: PickOption[] = [];
+  snap.forEach((child) => {
+    const id = child.key;
+    if (!id) return;
+    const data = child.val() as FirebaseOptionPublic;
+    options.push(firebaseToOption(id, categoryId, pickId, data));
+  });
+
+  return options;
+}
+
+export async function createOption(
+  categoryId: string,
+  pickId: string,
+  option: { name: string; creatorId: string },
+): Promise<{ id: string; createdAt: Date }> {
+  const db = getDatabase(getAdminApp());
+  const ref = db.ref(`categories/${categoryId}/picks/${pickId}/options`).push();
+  const id = ref.key;
+  if (!id) throw new Error("Failed to generate option ID");
+
+  const createdAt = new Date();
+  const data = optionToFirebase({
+    name: option.name,
+    creatorId: option.creatorId,
+    owners: [option.creatorId],
+    createdAt,
+  });
+
+  await ref.set(data);
+
+  return { id, createdAt };
+}

--- a/src/services/interests.ts
+++ b/src/services/interests.ts
@@ -1,0 +1,39 @@
+import type { UserPickInterests } from "@/lib/types/option";
+
+export async function toggleInterest(
+  groupId: string,
+  categoryId: string,
+  pickId: string,
+  optionId: string,
+): Promise<{ interested: boolean }> {
+  const response = await fetch(
+    `/api/groups/${groupId}/picks/${pickId}/interests`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ optionId, categoryId }),
+    },
+  );
+  if (!response.ok) throw new Error("Failed to toggle interest");
+
+  const data = (await response.json()) as { interested: boolean };
+  return data;
+}
+
+export async function getUserInterests(
+  groupId: string,
+  categoryId: string,
+  pickId: string,
+): Promise<UserPickInterests> {
+  const response = await fetch(
+    `/api/groups/${groupId}/picks/${pickId}/interests?categoryId=${categoryId}`,
+  );
+  if (!response.ok) throw new Error("Failed to fetch interests");
+
+  const data = (await response.json()) as { interestedOptionIds: string[] };
+  return {
+    pickId,
+    categoryId,
+    interestedOptionIds: data.interestedOptionIds,
+  };
+}

--- a/src/services/options.ts
+++ b/src/services/options.ts
@@ -1,0 +1,51 @@
+import type { PickOption } from "@/lib/types/option";
+
+export async function createOption(
+  groupId: string,
+  categoryId: string,
+  pickId: string,
+  name: string,
+): Promise<{ optionId: string; createdAt: Date }> {
+  const response = await fetch(
+    `/api/groups/${groupId}/picks/${pickId}/options`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, categoryId }),
+    },
+  );
+  if (!response.ok) throw new Error("Failed to create option");
+
+  const contentType = response.headers.get("content-type");
+  if (response.redirected || !contentType?.includes("application/json")) {
+    throw new Error("Failed to create option");
+  }
+
+  const data = (await response.json()) as {
+    optionId: string;
+    createdAt: string;
+  };
+  return {
+    optionId: data.optionId,
+    createdAt: new Date(data.createdAt),
+  };
+}
+
+export async function getOptions(
+  groupId: string,
+  categoryId: string,
+  pickId: string,
+): Promise<PickOption[]> {
+  const response = await fetch(
+    `/api/groups/${groupId}/picks/${pickId}/options?categoryId=${categoryId}`,
+  );
+  if (!response.ok) throw new Error("Failed to fetch options");
+
+  const data = (await response.json()) as {
+    options: (Omit<PickOption, "createdAt"> & { createdAt: string })[];
+  };
+  return data.options.map((o) => ({
+    ...o,
+    createdAt: new Date(o.createdAt),
+  }));
+}


### PR DESCRIPTION
Removes the `ownerCount.one` and `ownerCount.other` keys from `OPTION_LIST_COPY` in `src/app/groups/[id]/picks/copy.ts`. These keys were introduced when per-option owner display was added but became dead code once the display was replaced with an `interestedCount` label.

Adds a `copy.spec.ts` asserting the dead keys are absent and all active keys are preserved, to prevent similar drift in the future.

## Acceptance Criteria
- [x] `ownerCount.one` is removed from `OPTION_LIST_COPY`
- [x] `ownerCount.other` is removed from `OPTION_LIST_COPY`
- [x] No other references to these keys exist in the codebase
- [x] All active copy keys (`suggestFormLabel`, `suggestPlaceholder`, `suggestButton`, `errors`, `heart`, `interestCount`, `headerCaption`) are preserved

## Tests
9 tests added, all passing.

Closes #107

---
*Created by Claude Sonnet 4.6*