### PR TITLE
feat(auth): sign in screen visual scaffold

### DIFF
--- a/src/app/(auth)/sign-in/SignInForm.tsx
+++ b/src/app/(auth)/sign-in/SignInForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { FirebaseError } from "firebase/app";
 import {
@@ -10,10 +9,8 @@ import {
   signInWithApple,
   signInWithGoogle,
 } from "@/services/auth";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { SIGN_IN_COPY } from "./copy";
+import { SignInFormView } from "./SignInFormView";
 
 const INVITE_TOKEN_FORMAT = /^[A-Za-z0-9_-]+$/;
 
@@ -79,125 +76,20 @@ export default function SignInForm() {
   }
 
   return (
-    <div className="w-full max-w-sm space-y-6">
-      <h1 className="text-2xl font-semibold">{SIGN_IN_COPY.title}</h1>
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => {
-          void handleOAuthSignIn(signInWithGoogle);
-        }}
-        disabled={loading}
-        className="w-full"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 48 48"
-          className="h-4 w-4"
-          aria-hidden="true"
-        >
-          <path
-            fill="#EA4335"
-            d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
-          />
-          <path
-            fill="#4285F4"
-            d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
-          />
-          <path
-            fill="#FBBC05"
-            d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
-          />
-          <path
-            fill="#34A853"
-            d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
-          />
-          <path fill="none" d="M0 0h48v48H0z" />
-        </svg>
-        {SIGN_IN_COPY.googleButton}
-      </Button>
-      {appleEnabled && (
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => {
-            void handleOAuthSignIn(signInWithApple);
-          }}
-          disabled={loading}
-          className="w-full"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 814 1000"
-            className="h-4 w-4"
-            aria-hidden="true"
-          >
-            <path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-37.3-150.3-93.2c-52.3-65.3-95.9-166.3-95.9-262.6 0-175.1 114.4-267.3 227.2-267.3 59.7 0 109.4 39.5 147.2 39.5 35.8 0 92.1-42.2 160.9-42.2 25.9 0 108.2 2.6 168.1 80.1zm-128.5-111.3c26.5-31.7 45.4-75.8 45.4-119.9 0-6.1-.5-12.2-1.6-17.3-42.8 1.6-93.5 28.5-124.1 64.8-22.4 25.2-44.7 68.7-44.7 113.4 0 6.7 1.1 13.4 1.6 15.5 2.7.5 7 1.1 11.3 1.1 38.4 0 86.2-25.8 112.1-57.6z" />
-          </svg>
-          {SIGN_IN_COPY.appleButton}
-        </Button>
-      )}
-      <div className="flex items-center gap-3 text-sm text-gray-400">
-        <hr className="flex-1" />
-        {SIGN_IN_COPY.orDivider}
-        <hr className="flex-1" />
-      </div>
-      <form
-        onSubmit={(e) => {
-          void handleSubmit(e);
-        }}
-        className="space-y-4"
-      >
-        <div className="space-y-1">
-          <Label htmlFor="email">{SIGN_IN_COPY.emailLabel}</Label>
-          <Input
-            id="email"
-            type="email"
-            autoComplete="email"
-            required
-            value={email}
-            onChange={(e) => {
-              setEmail(e.target.value);
-            }}
-            placeholder={SIGN_IN_COPY.emailPlaceholder}
-            className="w-full"
-          />
-        </div>
-        <div className="space-y-1">
-          <Label htmlFor="password">{SIGN_IN_COPY.passwordLabel}</Label>
-          <Input
-            id="password"
-            type="password"
-            autoComplete="current-password"
-            required
-            value={password}
-            onChange={(e) => {
-              setPassword(e.target.value);
-            }}
-            className="w-full"
-          />
-        </div>
-        {error && <p className="text-sm text-red-600">{error}</p>}
-        <Button type="submit" disabled={loading} className="w-full">
-          {SIGN_IN_COPY.submitButton}
-        </Button>
-      </form>
-      <div className="flex items-center justify-between text-sm">
-        <Link href="/forgot-password" className="underline">
-          {SIGN_IN_COPY.forgotPasswordLink}
-        </Link>
-        <span>
-          {SIGN_IN_COPY.signUpPrompt}{" "}
-          <Link
-            href={
-              inviteToken ? `/sign-up?invite_token=${inviteToken}` : "/sign-up"
-            }
-            className="underline"
-          >
-            {SIGN_IN_COPY.signUpLink}
-          </Link>
-        </span>
-      </div>
-    </div>
+    <SignInFormView
+      email={email}
+      onEmailChange={setEmail}
+      password={password}
+      onPasswordChange={setPassword}
+      onSubmit={(e) => void handleSubmit(e)}
+      onGoogleSignIn={() => void handleOAuthSignIn(signInWithGoogle)}
+      onAppleSignIn={() => void handleOAuthSignIn(signInWithApple)}
+      appleEnabled={appleEnabled}
+      loading={loading}
+      error={error}
+      signUpHref={
+        inviteToken ? `/sign-up?invite_token=${inviteToken}` : "/sign-up"
+      }
+    />
   );
 }

--- a/src/app/(auth)/sign-in/SignInFormView.spec.tsx
+++ b/src/app/(auth)/sign-in/SignInFormView.spec.tsx
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { SignInFormView } from "./SignInFormView";
+import { SIGN_IN_COPY } from "./copy";
+
+afterEach(cleanup);
+
+function renderView(overrides?: Partial<Parameters<typeof SignInFormView>[0]>) {
+  const defaults = {
+    email: "",
+    onEmailChange: vi.fn(),
+    password: "",
+    onPasswordChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onGoogleSignIn: vi.fn(),
+    onAppleSignIn: vi.fn(),
+    appleEnabled: false,
+    loading: false,
+    error: undefined,
+    signUpHref: "/sign-up",
+  };
+  return render(<SignInFormView {...defaults} {...overrides} />);
+}
+
+describe("page structure", () => {
+  it("renders the page title", () => {
+    renderView();
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+      SIGN_IN_COPY.title,
+    );
+  });
+
+  it("renders the OR divider", () => {
+    renderView();
+    expect(screen.getByText(SIGN_IN_COPY.orDivider)).toBeDefined();
+  });
+});
+
+describe("SSO buttons", () => {
+  it("renders the Google sign-in button", () => {
+    renderView();
+    expect(screen.getByText(SIGN_IN_COPY.googleButton)).toBeDefined();
+  });
+
+  it("renders the Apple sign-in button when appleEnabled is true", () => {
+    renderView({ appleEnabled: true });
+    expect(screen.getByText(SIGN_IN_COPY.appleButton)).toBeDefined();
+  });
+
+  it("hides the Apple sign-in button when appleEnabled is false", () => {
+    renderView({ appleEnabled: false });
+    expect(screen.queryByText(SIGN_IN_COPY.appleButton)).toBeNull();
+  });
+
+  it("calls onGoogleSignIn when the Google button is clicked", () => {
+    const onGoogleSignIn = vi.fn();
+    renderView({ onGoogleSignIn });
+    fireEvent.click(screen.getByText(SIGN_IN_COPY.googleButton));
+    expect(onGoogleSignIn).toHaveBeenCalledOnce();
+  });
+
+  it("calls onAppleSignIn when the Apple button is clicked", () => {
+    const onAppleSignIn = vi.fn();
+    renderView({ appleEnabled: true, onAppleSignIn });
+    fireEvent.click(screen.getByText(SIGN_IN_COPY.appleButton));
+    expect(onAppleSignIn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("email/password fields", () => {
+  it("renders the email input", () => {
+    renderView();
+    expect(screen.getByLabelText(SIGN_IN_COPY.emailLabel)).toBeDefined();
+  });
+
+  it("renders the password input", () => {
+    renderView();
+    expect(screen.getByLabelText(SIGN_IN_COPY.passwordLabel)).toBeDefined();
+  });
+
+  it("reflects the email prop in the email input", () => {
+    renderView({ email: "test@example.com" });
+    const input = screen.getByLabelText<HTMLInputElement>(
+      SIGN_IN_COPY.emailLabel,
+    );
+    expect(input.value).toBe("test@example.com");
+  });
+
+  it("reflects the password prop in the password input", () => {
+    renderView({ password: "secret123" });
+    const input = screen.getByLabelText<HTMLInputElement>(
+      SIGN_IN_COPY.passwordLabel,
+    );
+    expect(input.value).toBe("secret123");
+  });
+
+  it("calls onEmailChange when the email input changes", () => {
+    const onEmailChange = vi.fn();
+    renderView({ onEmailChange });
+    fireEvent.change(screen.getByLabelText(SIGN_IN_COPY.emailLabel), {
+      target: { value: "new@example.com" },
+    });
+    expect(onEmailChange).toHaveBeenCalled();
+  });
+
+  it("calls onPasswordChange when the password input changes", () => {
+    const onPasswordChange = vi.fn();
+    renderView({ onPasswordChange });
+    fireEvent.change(screen.getByLabelText(SIGN_IN_COPY.passwordLabel), {
+      target: { value: "newpassword" },
+    });
+    expect(onPasswordChange).toHaveBeenCalled();
+  });
+});
+
+describe("form submission", () => {
+  it("renders the submit button", () => {
+    renderView();
+    expect(
+      screen.getByRole("button", { name: SIGN_IN_COPY.submitButton }),
+    ).toBeDefined();
+  });
+
+  it("calls onSubmit when the form is submitted", () => {
+    const onSubmit = vi.fn();
+    renderView({ onSubmit });
+    const form = screen
+      .getByRole("button", { name: SIGN_IN_COPY.submitButton })
+      .closest("form");
+    fireEvent.submit(form!);
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});
+
+describe("footer links", () => {
+  it("renders the forgot password link", () => {
+    renderView();
+    expect(screen.getByText(SIGN_IN_COPY.forgotPasswordLink)).toBeDefined();
+  });
+
+  it("renders the sign-up link", () => {
+    renderView();
+    expect(screen.getByText(SIGN_IN_COPY.signUpLink)).toBeDefined();
+  });
+
+  it("uses signUpHref for the sign-up link href", () => {
+    renderView({ signUpHref: "/sign-up?invite_token=abc" });
+    const link = screen.getByText(SIGN_IN_COPY.signUpLink).closest("a");
+    expect(link?.getAttribute("href")).toBe("/sign-up?invite_token=abc");
+  });
+});
+
+describe("error display", () => {
+  it("shows the error message when error is provided", () => {
+    renderView({ error: SIGN_IN_COPY.errors.default });
+    expect(screen.getByText(SIGN_IN_COPY.errors.default)).toBeDefined();
+  });
+
+  it("does not show an error message when error is undefined", () => {
+    renderView({ error: undefined });
+    expect(screen.queryByText(SIGN_IN_COPY.errors.default)).toBeNull();
+  });
+});
+
+describe("loading state", () => {
+  it("disables the Google button when loading", () => {
+    renderView({ loading: true });
+    const button = screen.getByRole<HTMLButtonElement>("button", {
+      name: SIGN_IN_COPY.googleButton,
+    });
+    expect(button.disabled).toBe(true);
+  });
+
+  it("disables the submit button when loading", () => {
+    renderView({ loading: true });
+    const button = screen.getByRole<HTMLButtonElement>("button", {
+      name: SIGN_IN_COPY.submitButton,
+    });
+    expect(button.disabled).toBe(true);
+  });
+
+  it("disables the email input when loading", () => {
+    renderView({ loading: true });
+    const input = screen.getByLabelText<HTMLInputElement>(
+      SIGN_IN_COPY.emailLabel,
+    );
+    expect(input.disabled).toBe(true);
+  });
+
+  it("disables the password input when loading", () => {
+    renderView({ loading: true });
+    const input = screen.getByLabelText<HTMLInputElement>(
+      SIGN_IN_COPY.passwordLabel,
+    );
+    expect(input.disabled).toBe(true);
+  });
+});

--- a/src/app/(auth)/sign-in/SignInFormView.stories.tsx
+++ b/src/app/(auth)/sign-in/SignInFormView.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SignInFormView } from "./SignInFormView";
+import { SIGN_IN_COPY } from "./copy";
+
+const meta: Meta<typeof SignInFormView> = {
+  title: "Auth/SignInFormView",
+  component: SignInFormView,
+  args: {
+    email: "",
+    onEmailChange: () => undefined,
+    password: "",
+    onPasswordChange: () => undefined,
+    onSubmit: () => undefined,
+    onGoogleSignIn: () => undefined,
+    onAppleSignIn: () => undefined,
+    appleEnabled: false,
+    loading: false,
+    error: undefined,
+    signUpHref: "/sign-up",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SignInFormView>;
+
+export const Default: Story = {};
+
+export const WithApple: Story = {
+  args: {
+    appleEnabled: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    error: SIGN_IN_COPY.errors.default,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    email: "user@example.com",
+  },
+};
+
+export const WithInviteToken: Story = {
+  args: {
+    signUpHref: "/sign-up?invite_token=abc123",
+  },
+};

--- a/src/app/(auth)/sign-in/SignInFormView.tsx
+++ b/src/app/(auth)/sign-in/SignInFormView.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SIGN_IN_COPY } from "./copy";
+
+export interface SignInFormViewProps {
+  email: string;
+  onEmailChange: (value: string) => void;
+  password: string;
+  onPasswordChange: (value: string) => void;
+  onSubmit: (e: React.SyntheticEvent) => void;
+  onGoogleSignIn: () => void;
+  onAppleSignIn: () => void;
+  appleEnabled: boolean;
+  loading: boolean;
+  error: string | undefined;
+  signUpHref: string;
+}
+
+export function SignInFormView({
+  email,
+  onEmailChange,
+  password,
+  onPasswordChange,
+  onSubmit,
+  onGoogleSignIn,
+  onAppleSignIn,
+  appleEnabled,
+  loading,
+  error,
+  signUpHref,
+}: SignInFormViewProps) {
+  return (
+    <div className="w-full max-w-sm space-y-6">
+      <h1 className="text-2xl font-semibold">{SIGN_IN_COPY.title}</h1>
+
+      <div className="space-y-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onGoogleSignIn}
+          disabled={loading}
+          className="w-full"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 48 48"
+            className="h-4 w-4"
+            aria-hidden="true"
+          >
+            <path
+              fill="#EA4335"
+              d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+            />
+            <path
+              fill="#4285F4"
+              d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+            />
+            <path
+              fill="#34A853"
+              d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+            />
+            <path fill="none" d="M0 0h48v48H0z" />
+          </svg>
+          {SIGN_IN_COPY.googleButton}
+        </Button>
+
+        {appleEnabled && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onAppleSignIn}
+            disabled={loading}
+            className="w-full"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 814 1000"
+              className="h-4 w-4"
+              aria-hidden="true"
+            >
+              <path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-37.3-150.3-93.2c-52.3-65.3-95.9-166.3-95.9-262.6 0-175.1 114.4-267.3 227.2-267.3 59.7 0 109.4 39.5 147.2 39.5 35.8 0 92.1-42.2 160.9-42.2 25.9 0 108.2 2.6 168.1 80.1zm-128.5-111.3c26.5-31.7 45.4-75.8 45.4-119.9 0-6.1-.5-12.2-1.6-17.3-42.8 1.6-93.5 28.5-124.1 64.8-22.4 25.2-44.7 68.7-44.7 113.4 0 6.7 1.1 13.4 1.6 15.5 2.7.5 7 1.1 11.3 1.1 38.4 0 86.2-25.8 112.1-57.6z" />
+            </svg>
+            {SIGN_IN_COPY.appleButton}
+          </Button>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 text-sm text-muted-foreground">
+        <hr className="flex-1" />
+        {SIGN_IN_COPY.orDivider}
+        <hr className="flex-1" />
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="sign-in-email">{SIGN_IN_COPY.emailLabel}</Label>
+          <Input
+            id="sign-in-email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => {
+              onEmailChange(e.target.value);
+            }}
+            placeholder={SIGN_IN_COPY.emailPlaceholder}
+            disabled={loading}
+            className="w-full"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="sign-in-password">{SIGN_IN_COPY.passwordLabel}</Label>
+          <Input
+            id="sign-in-password"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(e) => {
+              onPasswordChange(e.target.value);
+            }}
+            disabled={loading}
+            className="w-full"
+          />
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <Button type="submit" disabled={loading} className="w-full">
+          {SIGN_IN_COPY.submitButton}
+        </Button>
+      </form>
+
+      <div className="flex items-center justify-between text-sm">
+        <Link
+          href="/forgot-password"
+          className="text-muted-foreground underline underline-offset-4 hover:text-foreground"
+        >
+          {SIGN_IN_COPY.forgotPasswordLink}
+        </Link>
+        <p className="text-muted-foreground">
+          {SIGN_IN_COPY.signUpPrompt}{" "}
+          <Link
+            href={signUpHref}
+            className="text-foreground underline underline-offset-4"
+          >
+            {SIGN_IN_COPY.signUpLink}
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Aligns the existing `/sign-in` route with the wireframe layout. Extracts `SignInFormView` for testability and Storybook coverage while keeping `SignInForm` as the thin hook wrapper.

Visual updates: consistent `space-y-1.5` field spacing, muted-foreground OR divider, refined footer link styles with `underline-offset-4`. The `invite_token` query param redirect is preserved through the refactor.

## Acceptance Criteria
- [x] Sign-in page shows title, Google SSO button, optional Apple SSO button, OR divider, email/password fields, submit CTA, forgot-password link, and sign-up footer
- [x] `invite_token` query param redirect still works after sign-in
- [x] `SignInFormView` is testable in isolation without mocking navigation hooks
- [x] Storybook stories cover all key visual states

## Tests
24 tests added for `SignInFormView`, all passing. 14 existing `SignInForm` tests continue to pass. Full suite: 300 passing.

Closes #137

---
*Created by Claude Sonnet 4.6*