### PR TITLE
feat(groups): create group form visual scaffold

### DIFF
--- a/src/app/groups/new/CreateGroupForm.tsx
+++ b/src/app/groups/new/CreateGroupForm.tsx
@@ -31,7 +31,7 @@ export function CreateGroupForm() {
       name={name}
       onNameChange={setName}
       onSubmit={(e) => void handleSubmit(e)}
-      onCancel={() => { router.back(); }}
+      onCancel={() => router.back()}
       loading={loading}
       error={error}
     />

--- a/src/app/groups/new/CreateGroupForm.tsx
+++ b/src/app/groups/new/CreateGroupForm.tsx
@@ -31,6 +31,7 @@ export function CreateGroupForm() {
       name={name}
       onNameChange={setName}
       onSubmit={(e) => void handleSubmit(e)}
+      onCancel={() => { router.back(); }}
       loading={loading}
       error={error}
     />

--- a/src/app/groups/new/CreateGroupForm.tsx
+++ b/src/app/groups/new/CreateGroupForm.tsx
@@ -31,7 +31,9 @@ export function CreateGroupForm() {
       name={name}
       onNameChange={setName}
       onSubmit={(e) => void handleSubmit(e)}
-      onCancel={() => router.back()}
+      onCancel={() => {
+        router.back();
+      }}
       loading={loading}
       error={error}
     />

--- a/src/app/groups/new/CreateGroupFormView.spec.tsx
+++ b/src/app/groups/new/CreateGroupFormView.spec.tsx
@@ -5,87 +5,110 @@ import { CREATE_GROUP_COPY } from "./copy";
 
 afterEach(cleanup);
 
-describe("CreateGroupFormView", () => {
-  it("renders the title and form fields", () => {
-    render(
-      <CreateGroupFormView
-        name=""
-        onNameChange={vi.fn()}
-        onSubmit={vi.fn()}
-        loading={false}
-        error={undefined}
-      />,
-    );
+function renderView(
+  overrides?: Partial<Parameters<typeof CreateGroupFormView>[0]>,
+) {
+  const defaults = {
+    name: "",
+    onNameChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    loading: false,
+    error: undefined,
+  };
+  return render(<CreateGroupFormView {...defaults} {...overrides} />);
+}
 
-    expect(screen.getByText(CREATE_GROUP_COPY.title)).toBeDefined();
+describe("page structure", () => {
+  it("renders the title", () => {
+    renderView();
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+      CREATE_GROUP_COPY.title,
+    );
+  });
+
+  it("renders the emoji picker placeholder", () => {
+    renderView();
+    expect(
+      screen.getByRole("button", { name: CREATE_GROUP_COPY.emojiPickerLabel }),
+    ).toBeDefined();
+  });
+});
+
+describe("name field", () => {
+  it("renders the group name input", () => {
+    renderView();
     expect(screen.getByLabelText(CREATE_GROUP_COPY.nameLabel)).toBeDefined();
+  });
+
+  it("reflects the name prop in the input", () => {
+    renderView({ name: "Friday Night" });
+    const input = screen.getByLabelText<HTMLInputElement>(
+      CREATE_GROUP_COPY.nameLabel,
+    );
+    expect(input.value).toBe("Friday Night");
+  });
+
+  it("calls onNameChange when the input value changes", () => {
+    const onNameChange = vi.fn();
+    renderView({ onNameChange });
+    fireEvent.change(screen.getByLabelText(CREATE_GROUP_COPY.nameLabel), {
+      target: { value: "My Group" },
+    });
+    expect(onNameChange).toHaveBeenCalledWith("My Group");
+  });
+});
+
+describe("submit button", () => {
+  it("renders the submit button", () => {
+    renderView();
     expect(
       screen.getByRole("button", { name: CREATE_GROUP_COPY.submitButton }),
     ).toBeDefined();
   });
 
-  it("displays an error message when error is provided", () => {
-    const errorMessage = "Something went wrong.";
-    render(
-      <CreateGroupFormView
-        name=""
-        onNameChange={vi.fn()}
-        onSubmit={vi.fn()}
-        loading={false}
-        error={errorMessage}
-      />,
-    );
-
-    expect(screen.getByText(errorMessage)).toBeDefined();
-  });
-
   it("disables the submit button when loading", () => {
-    render(
-      <CreateGroupFormView
-        name=""
-        onNameChange={vi.fn()}
-        onSubmit={vi.fn()}
-        loading={true}
-        error={undefined}
-      />,
-    );
-
-    const button = screen.getByRole("button", {
+    renderView({ loading: true });
+    const button = screen.getByRole<HTMLButtonElement>("button", {
       name: CREATE_GROUP_COPY.submitButton,
     });
-    expect((button as HTMLButtonElement).disabled).toBe(true);
-  });
-
-  it("calls onNameChange when the input value changes", () => {
-    const onNameChange = vi.fn();
-    render(
-      <CreateGroupFormView
-        name=""
-        onNameChange={onNameChange}
-        onSubmit={vi.fn()}
-        loading={false}
-        error={undefined}
-      />,
-    );
-
-    const input = screen.getByLabelText(CREATE_GROUP_COPY.nameLabel);
-    fireEvent.change(input, { target: { value: "My Group" } });
-    expect(onNameChange).toHaveBeenCalledWith("My Group");
+    expect(button.disabled).toBe(true);
   });
 
   it("calls onSubmit when the form is submitted", () => {
     const onSubmit = vi.fn();
-    render(
-      <CreateGroupFormView
-        name="My Group"
-        onNameChange={vi.fn()}
-        onSubmit={onSubmit}
-        loading={false}
-        error={undefined}
-      />,
-    );
-
+    renderView({ onSubmit, name: "My Group" });
     fireEvent.submit(screen.getByRole("form"));
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("cancel button", () => {
+  it("renders the cancel button", () => {
+    renderView();
+    expect(
+      screen.getByRole("button", { name: CREATE_GROUP_COPY.cancelButton }),
+    ).toBeDefined();
+  });
+
+  it("calls onCancel when the cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    renderView({ onCancel });
+    fireEvent.click(
+      screen.getByRole("button", { name: CREATE_GROUP_COPY.cancelButton }),
+    );
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});
+
+describe("error display", () => {
+  it("displays an error message when error is provided", () => {
+    renderView({ error: CREATE_GROUP_COPY.errors.default });
+    expect(screen.getByText(CREATE_GROUP_COPY.errors.default)).toBeDefined();
+  });
+
+  it("does not display an error message when error is undefined", () => {
+    renderView({ error: undefined });
+    expect(screen.queryByText(CREATE_GROUP_COPY.errors.default)).toBeNull();
   });
 });

--- a/src/app/groups/new/CreateGroupFormView.stories.tsx
+++ b/src/app/groups/new/CreateGroupFormView.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { CreateGroupFormView } from "./CreateGroupFormView";
+import { CREATE_GROUP_COPY } from "./copy";
+
+const meta: Meta<typeof CreateGroupFormView> = {
+  title: "Groups/CreateGroupFormView",
+  component: CreateGroupFormView,
+  args: {
+    name: "",
+    onNameChange: () => undefined,
+    onSubmit: () => undefined,
+    onCancel: () => undefined,
+    loading: false,
+    error: undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CreateGroupFormView>;
+
+export const Default: Story = {};
+
+export const WithName: Story = {
+  args: {
+    name: "Friday Night Picks",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    name: "Friday Night Picks",
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    error: CREATE_GROUP_COPY.errors.default,
+  },
+};

--- a/src/app/groups/new/CreateGroupFormView.stories.tsx
+++ b/src/app/groups/new/CreateGroupFormView.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof CreateGroupFormView> = {
   args: {
     name: "",
     onNameChange: () => undefined,
-    onSubmit: () => undefined,
+    onSubmit: (e) => e.preventDefault(),
     onCancel: () => undefined,
     loading: false,
     error: undefined,

--- a/src/app/groups/new/CreateGroupFormView.stories.tsx
+++ b/src/app/groups/new/CreateGroupFormView.stories.tsx
@@ -8,7 +8,9 @@ const meta: Meta<typeof CreateGroupFormView> = {
   args: {
     name: "",
     onNameChange: () => undefined,
-    onSubmit: (e) => e.preventDefault(),
+    onSubmit: (e) => {
+      e.preventDefault();
+    },
     onCancel: () => undefined,
     loading: false,
     error: undefined,

--- a/src/app/groups/new/CreateGroupFormView.tsx
+++ b/src/app/groups/new/CreateGroupFormView.tsx
@@ -7,6 +7,7 @@ interface CreateGroupFormViewProps {
   name: string;
   onNameChange: (name: string) => void;
   onSubmit: (e: React.SyntheticEvent) => void;
+  onCancel: () => void;
   loading: boolean;
   error: string | undefined;
 }
@@ -15,21 +16,34 @@ export function CreateGroupFormView({
   name,
   onNameChange,
   onSubmit,
+  onCancel,
   loading,
   error,
 }: CreateGroupFormViewProps) {
   return (
     <div className="w-full max-w-sm space-y-6">
       <h1 className="text-2xl font-semibold">{CREATE_GROUP_COPY.title}</h1>
+      <div className="flex justify-center">
+        <button
+          type="button"
+          aria-label={CREATE_GROUP_COPY.emojiPickerLabel}
+          disabled={loading}
+          className="flex h-24 w-24 items-center justify-center rounded-2xl bg-muted text-4xl"
+        >
+          🏷️
+        </button>
+      </div>
       <form
         aria-label={CREATE_GROUP_COPY.title}
         onSubmit={onSubmit}
         className="space-y-4"
       >
-        <div className="space-y-1">
-          <Label htmlFor="name">{CREATE_GROUP_COPY.nameLabel}</Label>
+        <div className="space-y-1.5">
+          <Label htmlFor="create-group-name">
+            {CREATE_GROUP_COPY.nameLabel}
+          </Label>
           <Input
-            id="name"
+            id="create-group-name"
             type="text"
             required
             value={name}
@@ -37,13 +51,25 @@ export function CreateGroupFormView({
               onNameChange(e.target.value);
             }}
             placeholder={CREATE_GROUP_COPY.namePlaceholder}
+            disabled={loading}
             className="w-full"
           />
         </div>
-        {error && <p className="text-sm text-red-600">{error}</p>}
-        <Button type="submit" disabled={loading} className="w-full">
-          {CREATE_GROUP_COPY.submitButton}
-        </Button>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <div className="space-y-2">
+          <Button type="submit" disabled={loading} className="w-full">
+            {CREATE_GROUP_COPY.submitButton}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            disabled={loading}
+            className="w-full"
+          >
+            {CREATE_GROUP_COPY.cancelButton}
+          </Button>
+        </div>
       </form>
     </div>
   );

--- a/src/app/groups/new/CreateGroupFormView.tsx
+++ b/src/app/groups/new/CreateGroupFormView.tsx
@@ -28,7 +28,7 @@ export function CreateGroupFormView({
           type="button"
           aria-label={CREATE_GROUP_COPY.emojiPickerLabel}
           disabled={loading}
-          className="flex h-24 w-24 items-center justify-center rounded-2xl bg-muted text-4xl"
+          className="flex h-24 w-24 items-center justify-center rounded-2xl bg-muted text-4xl disabled:pointer-events-none disabled:opacity-50"
         >
           🏷️
         </button>

--- a/src/app/groups/new/copy.ts
+++ b/src/app/groups/new/copy.ts
@@ -1,8 +1,10 @@
 export const CREATE_GROUP_COPY = {
-  title: "Create a Group",
+  cancelButton: "Cancel",
+  emojiPickerLabel: "Choose emoji",
   nameLabel: "Group Name",
   namePlaceholder: "e.g. Friday Night Picks",
-  submitButton: "Create Group",
+  submitButton: "Create",
+  title: "Create a Group",
   errors: {
     default: "Something went wrong. Please try again.",
   },


### PR DESCRIPTION
Aligns the `/groups/new` create-group form with the wireframe layout.

- Adds an emoji picker placeholder (large clickable square — non-functional per scope; real emoji feature tracked in #116)
- Adds a Cancel button that calls `router.back()`
- Updates copy: `submitButton` → "Create", adds `cancelButton` and `emojiPickerLabel`
- 12 tests updated; Storybook stories added (Default, WithName, Loading, WithError)

Closes #139

---
*Created by Claude Sonnet 4.6*