### PR TITLE
feat(groups): empty state for first-run groups list

### DIFF
--- a/src/app/groups/GroupListView.spec.tsx
+++ b/src/app/groups/GroupListView.spec.tsx
@@ -23,7 +23,7 @@ describe("GroupListView", () => {
 
   it("renders empty state when no groups", () => {
     render(<GroupListView groups={[]} />);
-    expect(screen.getByText(GROUP_LIST_COPY.emptyState)).toBeDefined();
+    expect(screen.getByText(GROUP_LIST_COPY.emptyHeadline)).toBeDefined();
   });
 
   it("renders a list of groups", () => {
@@ -38,7 +38,7 @@ describe("GroupListView", () => {
 
   it("does not render the empty state when there are groups", () => {
     render(<GroupListView groups={[makeGroup()]} />);
-    expect(screen.queryByText(GROUP_LIST_COPY.emptyState)).toBeNull();
+    expect(screen.queryByText(GROUP_LIST_COPY.emptyHeadline)).toBeNull();
   });
 
   it("renders group names as links", () => {

--- a/src/app/groups/GroupListView.tsx
+++ b/src/app/groups/GroupListView.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { Group } from "@/lib/types/group";
 import { Button } from "@/components/ui/button";
 import { GROUP_LIST_COPY } from "./copy";
+import { NoGroupsView } from "./NoGroupsView";
 
 interface GroupListViewProps {
   groups: Group[];
@@ -17,7 +18,7 @@ export function GroupListView({ groups }: GroupListViewProps) {
         </Button>
       </div>
       {groups.length === 0 ? (
-        <p className="text-sm text-zinc-500">{GROUP_LIST_COPY.emptyState}</p>
+        <NoGroupsView />
       ) : (
         <ul className="space-y-2">
           {groups.map((group) => (

--- a/src/app/groups/NoGroupsView.spec.tsx
+++ b/src/app/groups/NoGroupsView.spec.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { NoGroupsView } from "./NoGroupsView";
+import { GROUP_LIST_COPY } from "./copy";
+
+afterEach(cleanup);
+
+describe("NoGroupsView", () => {
+  describe("headline and body", () => {
+    it("renders the empty-state headline", () => {
+      render(<NoGroupsView />);
+      expect(screen.getByRole("heading").textContent).toBe(
+        GROUP_LIST_COPY.emptyHeadline,
+      );
+    });
+
+    it("renders the body copy", () => {
+      render(<NoGroupsView />);
+      expect(screen.getByText(GROUP_LIST_COPY.emptyBody)).toBeDefined();
+    });
+  });
+
+  describe("create group CTA", () => {
+    it("renders a link to /groups/new", () => {
+      render(<NoGroupsView />);
+      const link = screen.getByRole("link", {
+        name: GROUP_LIST_COPY.emptyCreateButton,
+      });
+      expect(link.getAttribute("href")).toContain("/groups/new");
+    });
+  });
+
+  describe("join group CTA", () => {
+    it("renders the join button", () => {
+      render(<NoGroupsView />);
+      expect(
+        screen.getByRole("button", { name: GROUP_LIST_COPY.emptyJoinButton }),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/app/groups/NoGroupsView.stories.tsx
+++ b/src/app/groups/NoGroupsView.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NoGroupsView } from "./NoGroupsView";
+
+const meta: Meta<typeof NoGroupsView> = {
+  title: "Groups/NoGroupsView",
+  component: NoGroupsView,
+};
+
+export default meta;
+type Story = StoryObj<typeof NoGroupsView>;
+
+export const Default: Story = {};

--- a/src/app/groups/NoGroupsView.tsx
+++ b/src/app/groups/NoGroupsView.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { GROUP_LIST_COPY } from "./copy";
+
+export function NoGroupsView() {
+  return (
+    <div className="flex flex-col items-center gap-4 py-12 text-center">
+      <h2 className="text-xl font-semibold">{GROUP_LIST_COPY.emptyHeadline}</h2>
+      <p className="max-w-sm text-sm text-muted-foreground">
+        {GROUP_LIST_COPY.emptyBody}
+      </p>
+      <div className="flex w-full max-w-xs flex-col gap-2">
+        <Button render={<Link href="/groups/new" />}>
+          {GROUP_LIST_COPY.emptyCreateButton}
+        </Button>
+        <Button variant="outline" disabled>
+          {GROUP_LIST_COPY.emptyJoinButton}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/groups/copy.ts
+++ b/src/app/groups/copy.ts
@@ -1,5 +1,9 @@
 export const GROUP_LIST_COPY = {
-  title: "My Groups",
+  emptyBody:
+    "Create a group to start making picks with friends, or join one with an invite link.",
+  emptyCreateButton: "Create a group",
+  emptyHeadline: "Groups are where picks happen",
+  emptyJoinButton: "Join with an invite link",
   newGroupButton: "New Group",
-  emptyState: "You have not joined any groups yet.",
+  title: "My Groups",
 } as const;


### PR DESCRIPTION
Replaces the placeholder empty-state text on `/groups` with a richer `NoGroupsView` component: headline, body copy, "Create a group" CTA linking to `/groups/new`, and a placeholder "Join with an invite link" button (disabled until invite flow is wired up).

4 tests added for `NoGroupsView`; existing `GroupListView` tests updated to assert against the new copy keys.

## Acceptance Criteria
- [x] Empty-state component shown on `/groups` when user has no groups
- [x] Friendly headline and body copy explaining what groups are
- [x] "Create a group" CTA links to `/groups/new`
- [x] "Join with an invite link" placeholder CTA rendered

## Tests
4 tests added, all passing (10 total across `NoGroupsView` and `GroupListView`).

Closes #141

---
*Created by Claude Sonnet 4.6*