### PR TITLE
feat(ui-scaffold): Tier-bucket ranking UI

### DIFF
--- a/src/app/categories/[id]/picks/[pickId]/OptionList.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/OptionList.tsx
@@ -20,6 +20,7 @@ interface OptionListProps {
   initialOptions: Option[];
   initialSuggestions: Option[];
   pickClosed: boolean;
+  onOptionsChange?: (options: Option[]) => void;
 }
 
 export function OptionList({
@@ -30,9 +31,18 @@ export function OptionList({
   initialOptions,
   initialSuggestions,
   pickClosed,
+  onOptionsChange,
 }: OptionListProps) {
   const [options, setOptions] = useState<Option[]>(initialOptions);
   const [suggestions, setSuggestions] = useState<Option[]>(initialSuggestions);
+
+  function updateOptions(updater: (prev: Option[]) => Option[]) {
+    setOptions((prev) => {
+      const next = updater(prev);
+      onOptionsChange?.(next);
+      return next;
+    });
+  }
   const [newTitle, setNewTitle] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
@@ -52,7 +62,7 @@ export function OptionList({
       );
       const existing = options.find((o) => o.id === optionId);
       if (existing) {
-        setOptions((prev) =>
+        updateOptions((prev) =>
           prev.map((o) =>
             o.id === optionId && !o.ownerIds.includes(currentUserId)
               ? { ...o, ownerIds: [...o.ownerIds, currentUserId] }
@@ -60,7 +70,7 @@ export function OptionList({
           ),
         );
       } else {
-        setOptions((prev) => [
+        updateOptions((prev) => [
           ...prev,
           { id: optionId, title, pickId, ownerIds: [currentUserId] },
         ]);
@@ -88,7 +98,7 @@ export function OptionList({
       );
       const existing = options.find((o) => o.id === optionId);
       if (existing) {
-        setOptions((prev) =>
+        updateOptions((prev) =>
           prev.map((o) =>
             o.id === optionId && !o.ownerIds.includes(currentUserId)
               ? { ...o, ownerIds: [...o.ownerIds, currentUserId] }
@@ -96,7 +106,7 @@ export function OptionList({
           ),
         );
       } else {
-        setOptions((prev) => [
+        updateOptions((prev) => [
           ...prev,
           {
             id: optionId,
@@ -121,7 +131,7 @@ export function OptionList({
     // Optimistic update
     if (wasHearted) {
       const willBeEmpty = option.ownerIds.length === 1;
-      setOptions((prev) =>
+      updateOptions((prev) =>
         willBeEmpty
           ? prev.filter((o) => o.id !== option.id)
           : prev.map((o) =>
@@ -134,7 +144,7 @@ export function OptionList({
             ),
       );
     } else {
-      setOptions((prev) =>
+      updateOptions((prev) =>
         prev.map((o) =>
           o.id === option.id
             ? { ...o, ownerIds: [...o.ownerIds, currentUserId] }
@@ -151,7 +161,7 @@ export function OptionList({
       }
     } catch {
       // Revert on failure
-      setOptions((prev) => {
+      updateOptions((prev) => {
         const exists = prev.some((o) => o.id === option.id);
         if (!exists) {
           return [...prev, option];

--- a/src/app/categories/[id]/picks/[pickId]/OptionList.tsx
+++ b/src/app/categories/[id]/picks/[pickId]/OptionList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { Option } from "@/lib/types/option";
 import {
@@ -35,17 +35,22 @@ export function OptionList({
 }: OptionListProps) {
   const [options, setOptions] = useState<Option[]>(initialOptions);
   const [suggestions, setSuggestions] = useState<Option[]>(initialSuggestions);
-
-  function updateOptions(updater: (prev: Option[]) => Option[]) {
-    setOptions((prev) => {
-      const next = updater(prev);
-      onOptionsChange?.(next);
-      return next;
-    });
-  }
   const [newTitle, setNewTitle] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+      return;
+    }
+    onOptionsChange?.(options);
+  }, [options, onOptionsChange]);
+
+  function updateOptions(updater: (prev: Option[]) => Option[]) {
+    setOptions(updater);
+  }
 
   async function handleAddSubmit(e: React.SyntheticEvent) {
     e.preventDefault();

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Option } from "@/lib/types/option";
@@ -26,10 +26,10 @@ function makePick(overrides?: Partial<GroupPick>): GroupPick {
   };
 }
 
-function makeOption(overrides?: Partial<Option>): Option {
+function makeOption(overrides: Partial<Option> = {}): Option {
   return {
     id: "opt-1",
-    title: "Option title",
+    title: "Option A",
     pickId: "pick-1",
     ownerIds: ["user-1"],
     ...overrides,
@@ -250,5 +250,32 @@ describe("empty state when no options", () => {
     renderView({ initialOptions: [makeOption()] });
 
     expect(screen.queryByText(EMPTY_PICK_COPY.headline)).toBeNull();
+  });
+});
+
+describe("ranking tab owner filtering", () => {
+  it("shows only the current user's options in the ranking tab", () => {
+    const ownedOption = makeOption({
+      id: "opt-owned",
+      title: "My Option",
+      ownerIds: ["user-1"],
+    });
+    const otherOption = makeOption({
+      id: "opt-other",
+      title: "Other Option",
+      ownerIds: ["user-2"],
+    });
+
+    renderView({
+      currentUserId: "user-1",
+      initialOptions: [ownedOption, otherOption],
+    });
+
+    fireEvent.click(
+      screen.getByRole("tab", { name: PICK_DETAIL_SCAFFOLD_COPY.tabs.ranking }),
+    );
+
+    expect(screen.getByText("My Option")).toBeDefined();
+    expect(screen.queryByText("Other Option")).toBeNull();
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Option } from "@/lib/types/option";
@@ -10,8 +10,13 @@ import { PickDetailView } from "./PickDetailView";
 
 afterEach(cleanup);
 
+let capturedOnOptionsChange: ((options: Option[]) => void) | undefined;
+
 vi.mock("@/app/categories/[id]/picks/[pickId]/OptionList", () => ({
-  OptionList: () => <div data-testid="option-list" />,
+  OptionList: ({ onOptionsChange }: { onOptionsChange?: (options: Option[]) => void }) => {
+    capturedOnOptionsChange = onOptionsChange;
+    return <div data-testid="option-list" />;
+  },
 }));
 
 function makePick(overrides?: Partial<GroupPick>): GroupPick {
@@ -216,6 +221,61 @@ describe("closed state: reopen button for creator only", () => {
         name: PICK_DETAIL_SCAFFOLD_COPY.reopenButton,
       }),
     ).toBeNull();
+  });
+});
+
+describe("ranking tab live options sync", () => {
+  it("reflects in-session options changes in the ranking tab", () => {
+    const initialOption = makeOption({
+      id: "opt-initial",
+      title: "Initial Option",
+      ownerIds: ["user-1"],
+    });
+
+    renderView({
+      currentUserId: "user-1",
+      initialOptions: [initialOption],
+    });
+
+    const newOption: Option = {
+      id: "opt-new",
+      title: "Newly Adopted Option",
+      pickId: "pick-1",
+      ownerIds: ["user-1"],
+    };
+
+    act(() => {
+      capturedOnOptionsChange?.([initialOption, newOption]);
+    });
+
+    fireEvent.click(
+      screen.getByRole("tab", { name: PICK_DETAIL_SCAFFOLD_COPY.tabs.ranking }),
+    );
+
+    expect(screen.getByText("Newly Adopted Option")).toBeDefined();
+  });
+
+  it("removes a dehearted option from the ranking tab", () => {
+    const option = makeOption({
+      id: "opt-1",
+      title: "Option To Remove",
+      ownerIds: ["user-1"],
+    });
+
+    renderView({
+      currentUserId: "user-1",
+      initialOptions: [option],
+    });
+
+    act(() => {
+      capturedOnOptionsChange?.([]);
+    });
+
+    fireEvent.click(
+      screen.getByRole("tab", { name: PICK_DETAIL_SCAFFOLD_COPY.tabs.ranking }),
+    );
+
+    expect(screen.queryByText("Option To Remove")).toBeNull();
   });
 });
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -1,4 +1,10 @@
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Option } from "@/lib/types/option";
@@ -8,12 +14,19 @@ import { PICK_DETAIL_SCAFFOLD_COPY } from "./copy";
 import { EMPTY_PICK_COPY } from "./EmptyPickView.copy";
 import { PickDetailView } from "./PickDetailView";
 
-afterEach(cleanup);
-
 let capturedOnOptionsChange: ((options: Option[]) => void) | undefined;
 
+afterEach(() => {
+  cleanup();
+  capturedOnOptionsChange = undefined;
+});
+
 vi.mock("@/app/categories/[id]/picks/[pickId]/OptionList", () => ({
-  OptionList: ({ onOptionsChange }: { onOptionsChange?: (options: Option[]) => void }) => {
+  OptionList: ({
+    onOptionsChange,
+  }: {
+    onOptionsChange?: (options: Option[]) => void;
+  }) => {
     capturedOnOptionsChange = onOptionsChange;
     return <div data-testid="option-list" />;
   },

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 import { OptionList } from "@/app/categories/[id]/picks/[pickId]/OptionList";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -28,6 +30,7 @@ export function PickDetailView({
   initialOptions,
   initialSuggestions,
 }: PickDetailViewProps) {
+  const [options, setOptions] = useState<Option[]>(initialOptions);
   const isOpen = pick.closedAt === undefined;
   const isCreator = pick.creatorId === currentUserId;
 
@@ -86,7 +89,7 @@ export function PickDetailView({
         </TabsList>
 
         <TabsContent value="options" className="mt-4">
-          {initialOptions.length === 0 ? (
+          {options.length === 0 ? (
             <EmptyPickView onSuggestOption={() => undefined} />
           ) : (
             <OptionList
@@ -94,16 +97,17 @@ export function PickDetailView({
               categoryId={categoryId}
               pickId={pick.id}
               currentUserId={currentUserId}
-              initialOptions={initialOptions}
+              initialOptions={options}
               initialSuggestions={initialSuggestions}
               pickClosed={!isOpen}
+              onOptionsChange={setOptions}
             />
           )}
         </TabsContent>
 
         <TabsContent value="ranking" className="mt-4">
           <TierRanking
-            options={initialOptions.filter((opt) =>
+            options={options.filter((opt) =>
               opt.ownerIds.includes(currentUserId),
             )}
           />

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -9,6 +9,7 @@ import type { GroupPick } from "@/lib/types/pick";
 
 import { PICK_DETAIL_SCAFFOLD_COPY } from "./copy";
 import { EmptyPickView } from "./EmptyPickView";
+import { TierRanking } from "./TierRanking";
 
 interface PickDetailViewProps {
   pick: GroupPick;
@@ -101,9 +102,11 @@ export function PickDetailView({
         </TabsContent>
 
         <TabsContent value="ranking" className="mt-4">
-          <p className="text-sm text-muted-foreground">
-            {PICK_DETAIL_SCAFFOLD_COPY.rankingTabPlaceholder}
-          </p>
+          <TierRanking
+            options={initialOptions.filter((opt) =>
+              opt.ownerIds.includes(currentUserId),
+            )}
+          />
         </TabsContent>
 
         <TabsContent value="top-picks" className="mt-4" keepMounted>

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.copy.ts
@@ -6,6 +6,14 @@ export enum RankingTier {
   Yes = "yes",
 }
 
+export const TIER_ORDER = [
+  RankingTier.LoveIt,
+  RankingTier.Yes,
+  RankingTier.Maybe,
+  RankingTier.NotReally,
+  RankingTier.Unranked,
+] as const;
+
 export const TIER_RANKING_COPY = {
   tiers: {
     [RankingTier.LoveIt]: "Love it",

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.copy.ts
@@ -1,0 +1,17 @@
+export enum RankingTier {
+  LoveIt = "love_it",
+  Maybe = "maybe",
+  NotReally = "not_really",
+  Unranked = "unranked",
+  Yes = "yes",
+}
+
+export const TIER_RANKING_COPY = {
+  tiers: {
+    [RankingTier.LoveIt]: "Love it",
+    [RankingTier.Maybe]: "Maybe",
+    [RankingTier.NotReally]: "Not really",
+    [RankingTier.Unranked]: "Unranked",
+    [RankingTier.Yes]: "Yes",
+  },
+} as const;

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.spec.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { TierRanking } from "./TierRanking";
+import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
+import type { Option } from "@/lib/types/option";
+
+afterEach(cleanup);
+
+const makeOption = (overrides: Partial<Option> = {}): Option => ({
+  id: "opt-1",
+  title: "Option A",
+  pickId: "pick-1",
+  ownerIds: ["user-1"],
+  ...overrides,
+});
+
+describe("TierRanking", () => {
+  describe("cycling tier on click", () => {
+    it("starts with options in Unranked", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(<TierRanking options={[option]} />);
+      expect(screen.getByText("Inception")).toBeDefined();
+    });
+
+    it("advances an option to LoveIt on first click", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(<TierRanking options={[option]} />);
+      fireEvent.click(screen.getByText("Inception"));
+      const loveItHeader = screen.getByText(
+        TIER_RANKING_COPY.tiers[RankingTier.LoveIt],
+      );
+      expect(loveItHeader).toBeDefined();
+      expect(screen.getAllByText("Inception")).toBeDefined();
+    });
+
+    it("cycles through all tiers and back to Unranked", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(<TierRanking options={[option]} />);
+
+      const getChip = () => screen.getByText("Inception");
+      const getTierSectionFor = (chip: HTMLElement) => {
+        // Walk up to the tier bucket div (the one with the h3 sibling)
+        let el: HTMLElement | null = chip;
+        while (el && el.previousElementSibling?.tagName !== "H3") {
+          el = el.parentElement;
+        }
+        return el?.previousElementSibling?.textContent ?? null;
+      };
+
+      // Unranked → LoveIt
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.LoveIt],
+      );
+
+      // LoveIt → Yes
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.Yes],
+      );
+
+      // Yes → Maybe
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.Maybe],
+      );
+
+      // Maybe → NotReally
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.NotReally],
+      );
+
+      // NotReally → Unranked
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.Unranked],
+      );
+    });
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.spec.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Option } from "@/lib/types/option";
+
 import { TierRanking } from "./TierRanking";
 import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
-import type { Option } from "@/lib/types/option";
 
 afterEach(cleanup);
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.tsx
@@ -2,20 +2,12 @@
 
 import { useState } from "react";
 import type { Option } from "@/lib/types/option";
-import { RankingTier } from "./TierRanking.copy";
+import { RankingTier, TIER_ORDER } from "./TierRanking.copy";
 import { TierRankingView } from "./TierRankingView";
 
 interface TierRankingProps {
   options: Option[];
 }
-
-const TIER_CYCLE = [
-  RankingTier.LoveIt,
-  RankingTier.Yes,
-  RankingTier.Maybe,
-  RankingTier.NotReally,
-  RankingTier.Unranked,
-] as const;
 
 export function TierRanking({ options }: TierRankingProps) {
   const [tierAssignments, setTierAssignments] = useState<
@@ -23,13 +15,14 @@ export function TierRanking({ options }: TierRankingProps) {
   >({});
 
   function handleOptionClick(optionId: string) {
-    const current = tierAssignments[optionId] ?? RankingTier.Unranked;
-    const currentIndex = TIER_CYCLE.indexOf(current);
-    const nextTier =
-      TIER_CYCLE[(currentIndex + 1) % TIER_CYCLE.length] ?? RankingTier.LoveIt;
-    const next = { ...tierAssignments };
-    next[optionId] = nextTier;
-    setTierAssignments(next);
+    setTierAssignments((prev) => {
+      const current = prev[optionId] ?? RankingTier.Unranked;
+      const currentIndex = TIER_ORDER.indexOf(current);
+      const nextTier =
+        TIER_ORDER[(currentIndex + 1) % TIER_ORDER.length] ??
+        RankingTier.LoveIt;
+      return { ...prev, [optionId]: nextTier };
+    });
   }
 
   return (

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState } from "react";
+
 import type { Option } from "@/lib/types/option";
+
 import { RankingTier, TIER_ORDER } from "./TierRanking.copy";
 import { TierRankingView } from "./TierRankingView";
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import type { Option } from "@/lib/types/option";
+import { RankingTier } from "./TierRanking.copy";
+import { TierRankingView } from "./TierRankingView";
+
+interface TierRankingProps {
+  options: Option[];
+}
+
+const TIER_CYCLE = [
+  RankingTier.LoveIt,
+  RankingTier.Yes,
+  RankingTier.Maybe,
+  RankingTier.NotReally,
+  RankingTier.Unranked,
+] as const;
+
+export function TierRanking({ options }: TierRankingProps) {
+  const [tierAssignments, setTierAssignments] = useState<
+    Record<string, RankingTier>
+  >({});
+
+  function handleOptionClick(optionId: string) {
+    const current = tierAssignments[optionId] ?? RankingTier.Unranked;
+    const currentIndex = TIER_CYCLE.indexOf(current);
+    const nextTier =
+      TIER_CYCLE[(currentIndex + 1) % TIER_CYCLE.length] ?? RankingTier.LoveIt;
+    const next = { ...tierAssignments };
+    next[optionId] = nextTier;
+    setTierAssignments(next);
+  }
+
+  return (
+    <TierRankingView
+      options={options}
+      tierAssignments={tierAssignments}
+      onOptionClick={handleOptionClick}
+    />
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
@@ -1,8 +1,6 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
-import { fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { TierRankingView } from "./TierRankingView";
-import { TierRanking } from "./TierRanking";
 import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
 import type { Option } from "@/lib/types/option";
 
@@ -123,72 +121,6 @@ describe("TierRankingView", () => {
       );
       fireEvent.click(screen.getByText("Matrix"));
       expect(onOptionClick).toHaveBeenCalledWith("opt-99");
-    });
-  });
-});
-
-describe("TierRanking", () => {
-  describe("cycling tier on click", () => {
-    it("starts with options in Unranked", () => {
-      const option = makeOption({ id: "opt-1", title: "Inception" });
-      render(<TierRanking options={[option]} />);
-      expect(screen.getByText("Inception")).toBeDefined();
-    });
-
-    it("advances an option to LoveIt on first click", () => {
-      const option = makeOption({ id: "opt-1", title: "Inception" });
-      render(<TierRanking options={[option]} />);
-      fireEvent.click(screen.getByText("Inception"));
-      const loveItHeader = screen.getByText(
-        TIER_RANKING_COPY.tiers[RankingTier.LoveIt],
-      );
-      expect(loveItHeader).toBeDefined();
-      expect(screen.getAllByText("Inception")).toBeDefined();
-    });
-
-    it("cycles through all tiers and back to Unranked", () => {
-      const option = makeOption({ id: "opt-1", title: "Inception" });
-      render(<TierRanking options={[option]} />);
-
-      const getChip = () => screen.getByText("Inception");
-      const getTierSectionFor = (chip: HTMLElement) => {
-        // Walk up to the tier bucket div (the one with the h3 sibling)
-        let el: HTMLElement | null = chip;
-        while (el && el.previousElementSibling?.tagName !== "H3") {
-          el = el.parentElement;
-        }
-        return el?.previousElementSibling?.textContent ?? null;
-      };
-
-      // Unranked → LoveIt
-      fireEvent.click(getChip());
-      expect(getTierSectionFor(getChip())).toBe(
-        TIER_RANKING_COPY.tiers[RankingTier.LoveIt],
-      );
-
-      // LoveIt → Yes
-      fireEvent.click(getChip());
-      expect(getTierSectionFor(getChip())).toBe(
-        TIER_RANKING_COPY.tiers[RankingTier.Yes],
-      );
-
-      // Yes → Maybe
-      fireEvent.click(getChip());
-      expect(getTierSectionFor(getChip())).toBe(
-        TIER_RANKING_COPY.tiers[RankingTier.Maybe],
-      );
-
-      // Maybe → NotReally
-      fireEvent.click(getChip());
-      expect(getTierSectionFor(getChip())).toBe(
-        TIER_RANKING_COPY.tiers[RankingTier.NotReally],
-      );
-
-      // NotReally → Unranked
-      fireEvent.click(getChip());
-      expect(getTierSectionFor(getChip())).toBe(
-        TIER_RANKING_COPY.tiers[RankingTier.Unranked],
-      );
     });
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { TierRankingView } from "./TierRankingView";
-import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import type { Option } from "@/lib/types/option";
+
+import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
+import { TierRankingView } from "./TierRankingView";
 
 afterEach(cleanup);
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { TierRankingView } from "./TierRankingView";
+import { TierRanking } from "./TierRanking";
+import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
+import type { Option } from "@/lib/types/option";
+
+afterEach(cleanup);
+
+const makeOption = (overrides: Partial<Option> = {}): Option => ({
+  id: "opt-1",
+  title: "Option A",
+  pickId: "pick-1",
+  ownerIds: ["user-1"],
+  ...overrides,
+});
+
+describe("TierRankingView", () => {
+  describe("renders tier bucket headers", () => {
+    it("renders the Love it tier header", () => {
+      render(
+        <TierRankingView
+          options={[]}
+          tierAssignments={{}}
+          onOptionClick={() => undefined}
+        />,
+      );
+      expect(
+        screen.getByText(TIER_RANKING_COPY.tiers[RankingTier.LoveIt]),
+      ).toBeDefined();
+    });
+
+    it("renders the Yes tier header", () => {
+      render(
+        <TierRankingView
+          options={[]}
+          tierAssignments={{}}
+          onOptionClick={() => undefined}
+        />,
+      );
+      expect(
+        screen.getByText(TIER_RANKING_COPY.tiers[RankingTier.Yes]),
+      ).toBeDefined();
+    });
+
+    it("renders the Maybe tier header", () => {
+      render(
+        <TierRankingView
+          options={[]}
+          tierAssignments={{}}
+          onOptionClick={() => undefined}
+        />,
+      );
+      expect(
+        screen.getByText(TIER_RANKING_COPY.tiers[RankingTier.Maybe]),
+      ).toBeDefined();
+    });
+
+    it("renders the Not really tier header", () => {
+      render(
+        <TierRankingView
+          options={[]}
+          tierAssignments={{}}
+          onOptionClick={() => undefined}
+        />,
+      );
+      expect(
+        screen.getByText(TIER_RANKING_COPY.tiers[RankingTier.NotReally]),
+      ).toBeDefined();
+    });
+
+    it("renders the Unranked tier header", () => {
+      render(
+        <TierRankingView
+          options={[]}
+          tierAssignments={{}}
+          onOptionClick={() => undefined}
+        />,
+      );
+      expect(
+        screen.getByText(TIER_RANKING_COPY.tiers[RankingTier.Unranked]),
+      ).toBeDefined();
+    });
+  });
+
+  describe("places options in their assigned tier", () => {
+    it("shows an option in the assigned tier section", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(
+        <TierRankingView
+          options={[option]}
+          tierAssignments={{ "opt-1": RankingTier.LoveIt }}
+          onOptionClick={() => undefined}
+        />,
+      );
+      expect(screen.getByText("Inception")).toBeDefined();
+    });
+
+    it("shows unassigned options in the Unranked section", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(
+        <TierRankingView
+          options={[option]}
+          tierAssignments={{}}
+          onOptionClick={() => undefined}
+        />,
+      );
+      expect(screen.getByText("Inception")).toBeDefined();
+    });
+  });
+
+  describe("calls onOptionClick", () => {
+    it("calls onOptionClick with the option id when an option chip is clicked", () => {
+      const onOptionClick = vi.fn();
+      const option = makeOption({ id: "opt-99", title: "Matrix" });
+      render(
+        <TierRankingView
+          options={[option]}
+          tierAssignments={{}}
+          onOptionClick={onOptionClick}
+        />,
+      );
+      fireEvent.click(screen.getByText("Matrix"));
+      expect(onOptionClick).toHaveBeenCalledWith("opt-99");
+    });
+  });
+});
+
+describe("TierRanking", () => {
+  describe("cycling tier on click", () => {
+    it("starts with options in Unranked", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(<TierRanking options={[option]} />);
+      expect(screen.getByText("Inception")).toBeDefined();
+    });
+
+    it("advances an option to LoveIt on first click", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(<TierRanking options={[option]} />);
+      fireEvent.click(screen.getByText("Inception"));
+      const loveItHeader = screen.getByText(
+        TIER_RANKING_COPY.tiers[RankingTier.LoveIt],
+      );
+      expect(loveItHeader).toBeDefined();
+      expect(screen.getAllByText("Inception")).toBeDefined();
+    });
+
+    it("cycles through all tiers and back to Unranked", () => {
+      const option = makeOption({ id: "opt-1", title: "Inception" });
+      render(<TierRanking options={[option]} />);
+      const chip = screen.getByText("Inception");
+      // Unranked → LoveIt → Yes → Maybe → NotReally → Unranked
+      fireEvent.click(chip);
+      fireEvent.click(chip);
+      fireEvent.click(chip);
+      fireEvent.click(chip);
+      fireEvent.click(chip);
+      expect(screen.getByText("Inception")).toBeDefined();
+    });
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
@@ -149,14 +149,46 @@ describe("TierRanking", () => {
     it("cycles through all tiers and back to Unranked", () => {
       const option = makeOption({ id: "opt-1", title: "Inception" });
       render(<TierRanking options={[option]} />);
-      const chip = screen.getByText("Inception");
-      // Unranked → LoveIt → Yes → Maybe → NotReally → Unranked
-      fireEvent.click(chip);
-      fireEvent.click(chip);
-      fireEvent.click(chip);
-      fireEvent.click(chip);
-      fireEvent.click(chip);
-      expect(screen.getByText("Inception")).toBeDefined();
+
+      const getChip = () => screen.getByText("Inception");
+      const getTierSectionFor = (chip: HTMLElement) => {
+        // Walk up to the tier bucket div (the one with the h3 sibling)
+        let el: HTMLElement | null = chip;
+        while (el && el.previousElementSibling?.tagName !== "H3") {
+          el = el.parentElement;
+        }
+        return el?.previousElementSibling?.textContent ?? null;
+      };
+
+      // Unranked → LoveIt
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.LoveIt],
+      );
+
+      // LoveIt → Yes
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.Yes],
+      );
+
+      // Yes → Maybe
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.Maybe],
+      );
+
+      // Maybe → NotReally
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.NotReally],
+      );
+
+      // NotReally → Unranked
+      fireEvent.click(getChip());
+      expect(getTierSectionFor(getChip())).toBe(
+        TIER_RANKING_COPY.tiers[RankingTier.Unranked],
+      );
     });
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { Option } from "@/lib/types/option";
+import { RankingTier } from "./TierRanking.copy";
+import { TierRankingView } from "./TierRankingView";
+
+const mockOptions: Option[] = [
+  {
+    id: "opt-1",
+    title: "The Shawshank Redemption",
+    pickId: "pick-1",
+    ownerIds: ["user-1"],
+  },
+  { id: "opt-2", title: "Inception", pickId: "pick-1", ownerIds: ["user-1"] },
+  {
+    id: "opt-3",
+    title: "Interstellar",
+    pickId: "pick-1",
+    ownerIds: ["user-1"],
+  },
+  { id: "opt-4", title: "The Matrix", pickId: "pick-1", ownerIds: ["user-1"] },
+  { id: "opt-5", title: "Parasite", pickId: "pick-1", ownerIds: ["user-1"] },
+];
+
+const meta: Meta<typeof TierRankingView> = {
+  title: "Picks/TierRankingView",
+  component: TierRankingView,
+  args: {
+    options: mockOptions,
+    tierAssignments: {},
+    onOptionClick: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TierRankingView>;
+
+export const AllUnranked: Story = {};
+
+export const MixedTiers: Story = {
+  args: {
+    tierAssignments: {
+      "opt-1": RankingTier.LoveIt,
+      "opt-2": RankingTier.Yes,
+      "opt-3": RankingTier.Maybe,
+      "opt-4": RankingTier.NotReally,
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    options: [],
+  },
+};

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
 import type { Option } from "@/lib/types/option";
+
 import { RankingTier } from "./TierRanking.copy";
 import { TierRankingView } from "./TierRankingView";
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import type { Option } from "@/lib/types/option";
+import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
+
+interface TierRankingViewProps {
+  options: Option[];
+  tierAssignments: Record<string, RankingTier>;
+  onOptionClick: (optionId: string) => void;
+}
+
+const TIER_ORDER = [
+  RankingTier.LoveIt,
+  RankingTier.Yes,
+  RankingTier.Maybe,
+  RankingTier.NotReally,
+  RankingTier.Unranked,
+] as const;
+
+export function TierRankingView({
+  options,
+  tierAssignments,
+  onOptionClick,
+}: TierRankingViewProps) {
+  return (
+    <div className="space-y-4">
+      {TIER_ORDER.map((tier) => (
+        <div key={tier}>
+          <h3 className="mb-2 text-sm font-semibold text-muted-foreground">
+            {TIER_RANKING_COPY.tiers[tier]}
+          </h3>
+          <div className="flex min-h-10 flex-wrap gap-2 rounded-md border p-2">
+            {options
+              .filter(
+                (opt) =>
+                  (tierAssignments[opt.id] ?? RankingTier.Unranked) === tier,
+              )
+              .map((opt) => (
+                <button
+                  key={opt.id}
+                  type="button"
+                  onClick={() => {
+                    onOptionClick(opt.id);
+                  }}
+                  className="rounded-full border bg-background px-3 py-1 text-sm hover:bg-muted"
+                >
+                  {opt.title}
+                </button>
+              ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.tsx
@@ -1,21 +1,13 @@
 "use client";
 
 import type { Option } from "@/lib/types/option";
-import { RankingTier, TIER_RANKING_COPY } from "./TierRanking.copy";
+import { RankingTier, TIER_ORDER, TIER_RANKING_COPY } from "./TierRanking.copy";
 
 interface TierRankingViewProps {
   options: Option[];
   tierAssignments: Record<string, RankingTier>;
   onOptionClick: (optionId: string) => void;
 }
-
-const TIER_ORDER = [
-  RankingTier.LoveIt,
-  RankingTier.Yes,
-  RankingTier.Maybe,
-  RankingTier.NotReally,
-  RankingTier.Unranked,
-] as const;
 
 export function TierRankingView({
   options,

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Option } from "@/lib/types/option";
+
 import { RankingTier, TIER_ORDER, TIER_RANKING_COPY } from "./TierRanking.copy";
 
 interface TierRankingViewProps {


### PR DESCRIPTION
Adds a tier-bucket ranking UI to the "Your ranking" tab of the pick detail scaffold. Users can click options to cycle them through Love it → Yes → Maybe → Not really → Unranked. State is local only (no persistence).

The implementation uses the presentational view pattern: `TierRankingView` accepts `options`, `tierAssignments`, and `onOptionClick`; `TierRanking` wraps it with `useState` to manage the assignments. Options are filtered to `ownerIds.includes(currentUserId)` before being passed in.

## Acceptance Criteria
- [x] "Your ranking" tab shows the user's hearted options bucketed into tier sections (Love it, Yes, Maybe, Not really, Unranked)
- [x] Clicking an option chip cycles it to the next tier
- [x] No persistence — local state only

## Tests
11 tests added, all passing.

Closes #136

---
*Created by Claude Sonnet 4.6*