### PR TITLE
feat(ui-scaffold): Empty state for pick with no options

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.copy.ts
@@ -1,0 +1,5 @@
+export const EMPTY_PICK_COPY = {
+  body: "Heart options you like, and suggest your own for others to consider.",
+  ctaButton: "Suggest the first option",
+  headline: "No options yet",
+} as const;

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.spec.tsx
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { EmptyPickView } from "./EmptyPickView";
+import { EMPTY_PICK_COPY } from "./EmptyPickView.copy";
+
+afterEach(cleanup);
+
+describe("headline and body copy", () => {
+  it("renders the headline", () => {
+    render(<EmptyPickView onSuggestOption={() => undefined} />);
+    expect(screen.getByRole("heading").textContent).toBe(
+      EMPTY_PICK_COPY.headline,
+    );
+  });
+
+  it("renders the body copy", () => {
+    render(<EmptyPickView onSuggestOption={() => undefined} />);
+    expect(screen.getByText(EMPTY_PICK_COPY.body)).toBeDefined();
+  });
+});
+
+describe("suggest CTA", () => {
+  it("renders the suggest-first-option button", () => {
+    render(<EmptyPickView onSuggestOption={() => undefined} />);
+    expect(
+      screen.getByRole("button", { name: EMPTY_PICK_COPY.ctaButton }),
+    ).toBeDefined();
+  });
+
+  it("calls onSuggestOption when the CTA is clicked", () => {
+    const onSuggestOption = vi.fn();
+    render(<EmptyPickView onSuggestOption={onSuggestOption} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: EMPTY_PICK_COPY.ctaButton }),
+    );
+    expect(onSuggestOption).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { EmptyPickView } from "./EmptyPickView";
+
+const meta: Meta<typeof EmptyPickView> = {
+  title: "Picks/EmptyPickView",
+  component: EmptyPickView,
+  args: {
+    onSuggestOption: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyPickView>;
+
+export const Default: Story = {};

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/EmptyPickView.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { EMPTY_PICK_COPY } from "./EmptyPickView.copy";
+
+interface EmptyPickViewProps {
+  onSuggestOption: () => void;
+}
+
+export function EmptyPickView({ onSuggestOption }: EmptyPickViewProps) {
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-6 text-center">
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">{EMPTY_PICK_COPY.headline}</h2>
+          <p className="text-sm text-muted-foreground">
+            {EMPTY_PICK_COPY.body}
+          </p>
+        </div>
+        <Button
+          type="button"
+          onClick={() => {
+            onSuggestOption();
+          }}
+        >
+          {EMPTY_PICK_COPY.ctaButton}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { GroupPick } from "@/lib/types/pick";
+import type { Option } from "@/lib/types/option";
 import { PickDetailView } from "./PickDetailView";
 import { PICK_DETAIL_SCAFFOLD_COPY } from "./copy";
+import { EMPTY_PICK_COPY } from "./EmptyPickView.copy";
 
 afterEach(cleanup);
 
@@ -18,6 +20,16 @@ function makePick(overrides?: Partial<GroupPick>): GroupPick {
     categoryId: "cat-1",
     createdAt: new Date("2025-01-01T00:00:00.000Z"),
     creatorId: "user-1",
+    ...overrides,
+  };
+}
+
+function makeOption(overrides?: Partial<Option>): Option {
+  return {
+    id: "opt-1",
+    title: "Option title",
+    pickId: "pick-1",
+    ownerIds: ["user-1"],
     ...overrides,
   };
 }
@@ -73,8 +85,8 @@ describe("tabs structure", () => {
     ).toBeDefined();
   });
 
-  it("renders OptionList in the Options tab panel", () => {
-    renderView();
+  it("renders OptionList in the Options tab panel when options exist", () => {
+    renderView({ initialOptions: [makeOption()] });
 
     expect(screen.getByTestId("option-list")).toBeDefined();
   });
@@ -109,5 +121,39 @@ describe('"+ Suggest option" button', () => {
         name: PICK_DETAIL_SCAFFOLD_COPY.suggestOptionButton,
       }),
     ).toBeDefined();
+  });
+});
+
+describe("empty state when no options", () => {
+  it("shows the empty-state headline when initialOptions is empty", () => {
+    renderView({ initialOptions: [] });
+
+    expect(screen.getByText(EMPTY_PICK_COPY.headline)).toBeDefined();
+  });
+
+  it("shows the empty-state body copy when initialOptions is empty", () => {
+    renderView({ initialOptions: [] });
+
+    expect(screen.getByText(EMPTY_PICK_COPY.body)).toBeDefined();
+  });
+
+  it("shows the suggest-first-option CTA when initialOptions is empty", () => {
+    renderView({ initialOptions: [] });
+
+    expect(
+      screen.getByRole("button", { name: EMPTY_PICK_COPY.ctaButton }),
+    ).toBeDefined();
+  });
+
+  it("does not show OptionList when initialOptions is empty", () => {
+    renderView({ initialOptions: [] });
+
+    expect(screen.queryByTestId("option-list")).toBeNull();
+  });
+
+  it("does not show the empty state when initialOptions is non-empty", () => {
+    renderView({ initialOptions: [makeOption()] });
+
+    expect(screen.queryByText(EMPTY_PICK_COPY.headline)).toBeNull();
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { OptionList } from "@/app/categories/[id]/picks/[pickId]/OptionList";
+import { EmptyPickView } from "./EmptyPickView";
 import { PICK_DETAIL_SCAFFOLD_COPY } from "./copy";
 
 interface PickDetailViewProps {
@@ -63,15 +64,19 @@ export function PickDetailView({
         </TabsList>
 
         <TabsContent value="options" className="mt-4">
-          <OptionList
-            groupId={groupId}
-            categoryId={categoryId}
-            pickId={pick.id}
-            currentUserId={currentUserId}
-            initialOptions={initialOptions}
-            initialSuggestions={initialSuggestions}
-            pickClosed={!isOpen}
-          />
+          {initialOptions.length === 0 ? (
+            <EmptyPickView onSuggestOption={() => undefined} />
+          ) : (
+            <OptionList
+              groupId={groupId}
+              categoryId={categoryId}
+              pickId={pick.id}
+              currentUserId={currentUserId}
+              initialOptions={initialOptions}
+              initialSuggestions={initialSuggestions}
+              pickClosed={!isOpen}
+            />
+          )}
         </TabsContent>
 
         <TabsContent value="ranking" className="mt-4">


### PR DESCRIPTION
Adds an `EmptyPickView` component shown in the options tab when a pick has no options yet. The component displays a headline, explanatory body copy, and a "Suggest the first option" CTA (no-op until the suggest-option sheet from #135 lands).

`PickDetailView` now conditionally renders `EmptyPickView` (empty) or `OptionList` (non-empty) in the options tab.

## Acceptance Criteria
- [x] Empty-state component shown on pick detail scaffold when the pick has no options yet
- [x] Friendly headline + body copy explaining the heart-toggle / suggest-option model
- [x] "Suggest the first option" CTA button rendered
- [x] Replaces the placeholder empty option list from the scaffold

## Tests
9 tests added (4 for `EmptyPickView`, 5 new assertions in `PickDetailView.spec.tsx`), all passing. Full suite: 322 passing.

Closes #142

---
*Created by Claude Sonnet 4.6*