### PR TITLE
feat(picks): add description field to create pick form

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickForm.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickForm.tsx
@@ -21,6 +21,7 @@ export function CreatePickForm({
 }: CreatePickFormProps) {
   const router = useRouter();
   const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
   const [topCount, setTopCount] = useState(3);
   const [dueDate, setDueDate] = useState("");
   const [error, setError] = useState<string | undefined>();
@@ -39,6 +40,7 @@ export function CreatePickForm({
         groupId,
         categoryId,
         title.trim(),
+        description.trim() || undefined,
         topCount,
         dueDate || undefined,
       );
@@ -56,6 +58,8 @@ export function CreatePickForm({
     <CreatePickFormView
       title={title}
       onTitleChange={setTitle}
+      description={description}
+      onDescriptionChange={setDescription}
       topCount={topCount}
       onTopCountChange={setTopCount}
       dueDate={dueDate}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.spec.tsx
@@ -10,6 +10,8 @@ describe("CreatePickFormView", () => {
   const defaultProps = {
     title: "",
     onTitleChange: vi.fn(),
+    description: "",
+    onDescriptionChange: vi.fn(),
     topCount: 3,
     onTopCountChange: vi.fn(),
     dueDate: "",
@@ -30,6 +32,13 @@ describe("CreatePickFormView", () => {
     it("renders the pick title input", () => {
       render(<CreatePickFormView {...defaultProps} />);
       expect(screen.getByLabelText(CREATE_PICK_COPY.titleLabel)).toBeDefined();
+    });
+
+    it("renders the description textarea", () => {
+      render(<CreatePickFormView {...defaultProps} />);
+      expect(
+        screen.getByLabelText(CREATE_PICK_COPY.descriptionLabel),
+      ).toBeDefined();
     });
 
     it("renders the top-N count input", () => {
@@ -87,6 +96,21 @@ describe("CreatePickFormView", () => {
         target: { value: "Best Movies" },
       });
       expect(onTitleChange).toHaveBeenCalledWith("Best Movies");
+    });
+
+    it("calls onDescriptionChange when description textarea changes", () => {
+      const onDescriptionChange = vi.fn();
+      render(
+        <CreatePickFormView
+          {...defaultProps}
+          onDescriptionChange={onDescriptionChange}
+        />,
+      );
+      fireEvent.change(
+        screen.getByLabelText(CREATE_PICK_COPY.descriptionLabel),
+        { target: { value: "A great pick" } },
+      );
+      expect(onDescriptionChange).toHaveBeenCalledWith("A great pick");
     });
 
     it("calls onTopCountChange with a number when topCount input changes", () => {

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.stories.tsx
@@ -8,6 +8,8 @@ const meta: Meta<typeof CreatePickFormView> = {
   args: {
     title: "",
     onTitleChange: () => undefined,
+    description: "",
+    onDescriptionChange: () => undefined,
     topCount: 3,
     onTopCountChange: () => undefined,
     dueDate: "",

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.tsx
@@ -3,12 +3,15 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 
 import { CREATE_PICK_COPY } from "./copy";
 
 interface CreatePickFormViewProps {
   title: string;
   onTitleChange: (title: string) => void;
+  description: string;
+  onDescriptionChange: (description: string) => void;
   topCount: number;
   onTopCountChange: (topCount: number) => void;
   dueDate: string;
@@ -23,6 +26,8 @@ interface CreatePickFormViewProps {
 export function CreatePickFormView({
   title,
   onTitleChange,
+  description,
+  onDescriptionChange,
   topCount,
   onTopCountChange,
   dueDate,
@@ -65,6 +70,21 @@ export function CreatePickFormView({
             placeholder={CREATE_PICK_COPY.titlePlaceholder}
             disabled={loading}
             required
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="pick-description">
+            {CREATE_PICK_COPY.descriptionLabel}
+          </Label>
+          <Textarea
+            id="pick-description"
+            value={description}
+            onChange={(e) => {
+              onDescriptionChange(e.target.value);
+            }}
+            placeholder={CREATE_PICK_COPY.descriptionPlaceholder}
+            disabled={loading}
           />
         </div>
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/copy.ts
@@ -1,5 +1,7 @@
 export const CREATE_PICK_COPY = {
   cancelButton: "Cancel",
+  descriptionLabel: "Description",
+  descriptionPlaceholder: "Optional description",
   dueDateLabel: "Due date (optional)",
   errors: {
     default: "Something went wrong. Please try again.",

--- a/src/services/picks.ts
+++ b/src/services/picks.ts
@@ -2,6 +2,7 @@ export async function createPick(
   groupId: string,
   categoryId: string,
   title: string,
+  description: string | undefined,
   topCount: number,
   dueDate?: string,
 ): Promise<{ pickId: string; createdAt: Date }> {
@@ -10,7 +11,7 @@ export async function createPick(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title, topCount, dueDate }),
+      body: JSON.stringify({ title, description, topCount, dueDate }),
     },
   );
   if (!response.ok) throw new Error("Failed to create pick");


### PR DESCRIPTION
Adds the optional description field to the create pick form. The API route and data layer already supported description, but the form view and form state didn't expose it.

The `description` prop is threaded through `CreatePickFormView`, `CreatePickForm`, and `services/picks.ts` so it flows correctly to the API on submit.

## Acceptance Criteria
- [x] Users can select a Category for the pick (pre-filled from the URL context)
- [x] Users can provide a name for the pick
- [x] Users can provide an optional description for the pick
- [x] Users can set the Top N count
- [x] Users can optionally set a due date
- [x] Submitting the form creates the pick and redirects to its detail page

## Tests
2 tests added (description renders + onDescriptionChange fires), all 439 passing.

Closes #27

---
*Created by Claude Sonnet 4.5*