### PR TITLE
feat(picks): display category name, due date, participants, and top picks results

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -460,3 +460,118 @@ describe("ranking tab owner filtering", () => {
     expect(screen.queryByText("Other Option")).toBeNull();
   });
 });
+
+describe("pick metadata — category name", () => {
+  it("renders the category name when provided", () => {
+    renderView({ categoryName: "Best Movies" });
+
+    expect(screen.getByText("Best Movies")).toBeDefined();
+  });
+
+  it("does not render the category label when category name is not provided", () => {
+    renderView({ categoryName: undefined });
+
+    expect(
+      screen.queryByText(PICK_DETAIL_SCAFFOLD_COPY.categoryLabel),
+    ).toBeNull();
+  });
+});
+
+describe("pick metadata — due date", () => {
+  it("renders the formatted due date when pick.dueDate is set", () => {
+    const dueDate = new Date("2026-06-01T00:00:00.000Z");
+    renderView({ pick: makePick({ dueDate }) });
+
+    expect(screen.getByText(dueDate.toLocaleDateString())).toBeDefined();
+  });
+
+  it("does not render due date when pick.dueDate is absent", () => {
+    renderView({ pick: makePick({ dueDate: undefined }) });
+
+    expect(
+      screen.queryByText(PICK_DETAIL_SCAFFOLD_COPY.dueDateLabel),
+    ).toBeNull();
+  });
+});
+
+describe("participant count", () => {
+  it("renders the participants label", () => {
+    renderView({ initialOptions: [makeOption({ ownerIds: ["user-1"] })] });
+
+    expect(
+      screen.getByText(PICK_DETAIL_SCAFFOLD_COPY.participantsLabel),
+    ).toBeDefined();
+  });
+
+  it("counts unique owners across all options", () => {
+    renderView({
+      pick: makePick({ topCount: 99 }),
+      initialOptions: [
+        makeOption({ id: "opt-1", ownerIds: ["user-1", "user-2"] }),
+        makeOption({ id: "opt-2", ownerIds: ["user-2", "user-3"] }),
+      ],
+    });
+
+    expect(screen.getByText("3")).toBeDefined();
+  });
+});
+
+describe("top picks results", () => {
+  it("renders option titles in the top picks tab when pick is closed", () => {
+    const option1 = makeOption({
+      id: "opt-1",
+      title: "Option Alpha",
+      ownerIds: ["user-1", "user-2"],
+    });
+    const option2 = makeOption({
+      id: "opt-2",
+      title: "Option Beta",
+      ownerIds: ["user-1"],
+    });
+
+    renderView({
+      pick: makePick({
+        closedAt: new Date("2025-06-01T00:00:00.000Z"),
+        topCount: 2,
+      }),
+      initialOptions: [option1, option2],
+    });
+
+    expect(screen.getByText("Option Alpha")).toBeDefined();
+  });
+
+  it("renders only the top N options in the top picks tab", () => {
+    const option1 = makeOption({
+      id: "opt-1",
+      title: "Top Option",
+      ownerIds: ["user-1", "user-2"],
+    });
+    const option2 = makeOption({
+      id: "opt-2",
+      title: "Excluded Option",
+      ownerIds: ["user-3"],
+    });
+
+    renderView({
+      pick: makePick({
+        closedAt: new Date("2025-06-01T00:00:00.000Z"),
+        topCount: 1,
+      }),
+      initialOptions: [option1, option2],
+    });
+
+    expect(screen.getByText("Top Option")).toBeDefined();
+    expect(screen.queryByText("Excluded Option")).toBeNull();
+  });
+
+  it("shows the results placeholder when closed pick has no options", () => {
+    renderView({
+      pick: makePick({ closedAt: new Date("2025-06-01T00:00:00.000Z") }),
+      initialOptions: [],
+    });
+
+    expect(
+      screen.getByText(PICK_DETAIL_SCAFFOLD_COPY.resultsPlaceholder),
+    ).toBeDefined();
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -19,6 +19,7 @@ interface PickDetailViewProps {
   pick: GroupPick;
   groupId: string;
   categoryId: string;
+  categoryName?: string;
   currentUserId: string;
   initialOptions: Option[];
   initialSuggestions: Option[];
@@ -28,6 +29,7 @@ export function PickDetailView({
   pick,
   groupId,
   categoryId,
+  categoryName,
   currentUserId,
   initialOptions,
   initialSuggestions,
@@ -35,6 +37,10 @@ export function PickDetailView({
   const [options, setOptions] = useState<Option[]>(initialOptions);
   const [isSuggestSheetOpen, setIsSuggestSheetOpen] = useState(false);
   const isOpen = pick.closedAt === undefined;
+  const uniqueOwnerCount = new Set(options.flatMap((opt) => opt.ownerIds)).size;
+  const topPicksOptions = [...options]
+    .sort((a, b) => b.ownerIds.length - a.ownerIds.length)
+    .slice(0, pick.topCount);
 
   function handleOptionAdded({
     optionId,
@@ -73,6 +79,14 @@ export function PickDetailView({
     <main className="mx-auto max-w-lg space-y-6 p-6">
       <div className="space-y-2">
         <h1 className="text-2xl font-semibold">{pick.title}</h1>
+        {categoryName && (
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium">
+              {PICK_DETAIL_SCAFFOLD_COPY.categoryLabel}
+            </span>{" "}
+            {categoryName}
+          </p>
+        )}
         <div className="flex items-center gap-3">
           <Badge variant={isOpen ? "default" : "secondary"}>
             {isOpen
@@ -86,6 +100,20 @@ export function PickDetailView({
             {pick.topCount}
           </span>
         </div>
+        {pick.dueDate && (
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium">
+              {PICK_DETAIL_SCAFFOLD_COPY.dueDateLabel}
+            </span>{" "}
+            <span>{pick.dueDate.toLocaleDateString()}</span>
+          </p>
+        )}
+        <p className="text-sm text-muted-foreground">
+          <span className="font-medium">
+            {PICK_DETAIL_SCAFFOLD_COPY.participantsLabel}
+          </span>{" "}
+          {uniqueOwnerCount}
+        </p>
       </div>
 
       {isOpen && (
@@ -157,11 +185,21 @@ export function PickDetailView({
         </TabsContent>
 
         <TabsContent value="top-picks" className="mt-4" keepMounted>
-          <p className="text-sm text-muted-foreground">
-            {isOpen
-              ? PICK_DETAIL_SCAFFOLD_COPY.topPicksLockedPlaceholder
-              : PICK_DETAIL_SCAFFOLD_COPY.resultsPlaceholder}
-          </p>
+          {isOpen || topPicksOptions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {isOpen
+                ? PICK_DETAIL_SCAFFOLD_COPY.topPicksLockedPlaceholder
+                : PICK_DETAIL_SCAFFOLD_COPY.resultsPlaceholder}
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {topPicksOptions.map((opt) => (
+                <li key={opt.id} className="text-sm">
+                  {opt.title}
+                </li>
+              ))}
+            </ul>
+          )}
         </TabsContent>
       </Tabs>
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/copy.ts
@@ -17,10 +17,13 @@ export const PICK_DETAIL_COPY = {
 } as const;
 
 export const PICK_DETAIL_SCAFFOLD_COPY = {
+  categoryLabel: "Category",
   closedStatusChip: "Closed",
+  dueDateLabel: "Due:",
   openStatusChip: "Open",
+  participantsLabel: "Participants",
   rankingTabPlaceholder: "Ranking coming soon.",
-  resultsPlaceholder: "Results will appear here once scoring is complete.",
+  resultsPlaceholder: "No options were added to this pick.",
   suggestOptionButton: "Suggest option",
   tabs: {
     options: "Options",

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/page.tsx
@@ -57,6 +57,7 @@ export default async function PickDetailPage({
       pick={pick}
       groupId={groupId}
       categoryId={categoryId}
+      categoryName={category.name}
       currentUserId={uid}
       initialOptions={currentOptions}
       initialSuggestions={suggestions}


### PR DESCRIPTION
Completes the pick detail page metadata and results display. The page now shows category name, due date, participant count, and reveals the top N options (sorted by owner count) when the pick is closed.

Key changes: added derived `uniqueOwnerCount` and `topPicksOptions` computations to `PickDetailView`, updated the top-picks tab to render an option list instead of a static placeholder when closed picks have options, and wired `categoryName` through from `page.tsx`.

## Acceptance Criteria
- [x] Category name displayed on the pick detail page
- [x] Due date displayed when set
- [x] Participant count (unique option owners) displayed
- [x] Top picks results rendered in the top picks tab when the pick is closed

## Tests
9 tests added, all 35 passing (448 total suite).

Closes #29

---
*Created by Claude Sonnet 4.5*