### PR TITLE
chore(picks): optimise OptionList initialOptions sync effect dependency array

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/OptionList.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/OptionList.spec.tsx
@@ -165,3 +165,45 @@ describe("OptionList heart toggle", () => {
     ).toBeNull();
   });
 });
+
+describe("OptionList initialOptions sync", () => {
+  it("replaces local options when initialOptions changes from the parent", () => {
+    const optA = makeOption({ id: "opt-a", title: "Option A" });
+    const optB = makeOption({ id: "opt-b", title: "Option B" });
+
+    const { rerender } = render(
+      <OptionList {...baseProps} initialOptions={[optA]} />,
+    );
+
+    expect(screen.getByText("Option A")).toBeDefined();
+
+    rerender(<OptionList {...baseProps} initialOptions={[optB]} />);
+
+    expect(screen.queryByText("Option A")).toBeNull();
+    expect(screen.getByText("Option B")).toBeDefined();
+  });
+
+  it("preserves local options when initialOptions is unchanged after a mutation", async () => {
+    mockJoinOptionOwner.mockResolvedValue(undefined);
+    const option = makeOption({ ownerIds: ["user-2"] });
+
+    render(<OptionList {...baseProps} initialOptions={[option]} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.addOwnership,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockJoinOptionOwner).toHaveBeenCalled();
+    });
+
+    // Local state should reflect the heart — NOT reset to initial by the effect
+    expect(
+      screen.getByRole("button", {
+        name: PICK_DETAIL_COPY.heart.removeOwnership,
+      }),
+    ).toBeDefined();
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/OptionList.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/OptionList.tsx
@@ -64,15 +64,14 @@ export function OptionList({
 
   useEffect(() => {
     const nextInitialOptionsKey = getOptionsSyncKey(initialOptions);
-    const currentOptionsKey = getOptionsSyncKey(options);
-    if (previousInitialOptionsKeyRef.current !== nextInitialOptionsKey) {
-      previousInitialOptionsKeyRef.current = nextInitialOptionsKey;
-      if (currentOptionsKey !== nextInitialOptionsKey) {
-        skipNextOptionsChangeEffect.current = true;
-        setOptions(initialOptions);
-      }
-    }
-  }, [initialOptions, options]);
+    if (previousInitialOptionsKeyRef.current === nextInitialOptionsKey) return;
+    previousInitialOptionsKeyRef.current = nextInitialOptionsKey;
+    setOptions((prev) => {
+      if (getOptionsSyncKey(prev) === nextInitialOptionsKey) return prev;
+      skipNextOptionsChangeEffect.current = true;
+      return initialOptions;
+    });
+  }, [initialOptions]);
 
   function updateOptions(updater: (prev: Option[]) => Option[]) {
     setOptions(updater);


### PR DESCRIPTION
Removes `options` from the `initialOptions` sync effect's dependency array and captures current state inside a functional `setOptions` callback instead. The effect now fires only when `initialOptions` changes (a parent-driven prop update), not on every local mutation (heart toggle, adopt, add option). Eliminates the O(n) `getOptionsSyncKey` call on every local state change.

No behavior change — the functional callback reads the same `prev` snapshot that the old direct `options` read did, and the `skipNextOptionsChangeEffect` flag is still set before React commits the new state.

## Acceptance Criteria
- [x] Effect no longer runs when local options state changes
- [x] Sync still fires when `initialOptions` changes from the parent

## Tests
2 tests added covering the sync boundary (parent-driven change replaces local options; local mutation does not reset them). 450 tests total, all passing.

Closes #187

---
*Created by Claude Sonnet 4.5*