### PR TITLE
perf(catalog): parallelize Firebase reads in category detail page

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/page.tsx
@@ -22,12 +22,13 @@ export default async function CategoryDetailPage({
   if (!uid) redirect("/sign-in");
 
   const { id, categoryId } = await params;
-  const group = await getGroupById(id);
+
+  const [group, category] = await Promise.all([
+    getGroupById(id),
+    getCategoryById(categoryId),
+  ]);
 
   if (!group?.memberIds.includes(uid)) notFound();
-
-  const category = await getCategoryById(categoryId);
-
   if (!category) notFound();
   if (category.groupId !== id) notFound();
 


### PR DESCRIPTION
Replaces two sequential `await` calls with `Promise.all` in the category detail page so `getGroupById` and `getCategoryById` run concurrently. Neither call depends on the other — both only need their respective IDs from `params`. Removes one serial Firebase round-trip from the page's critical path.

All validation guards (`memberIds.includes(uid)`, `!category`, `category.groupId !== id`) are preserved in the same order.

## Acceptance Criteria
- [x] `getGroupById` and `getCategoryById` run in parallel

## Tests
No new tests (server page orchestration — view components already have specs). 448 tests passing.

Closes #186

---
*Created by Claude Sonnet 4.5*