### PR TITLE
refactor(picks): add PickNotFoundError to replace string-matched throw

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PickWriteClosedError } from "@/server/data/picks";
+import { PickNotFoundError, PickWriteClosedError } from "@/server/data/picks";
 
 const {
   mockGetVerifiedUid,
@@ -32,6 +32,13 @@ vi.mock("@/server/data/picks", () => ({
   assertPickIsOpenForWrite: mockAssertPickIsOpenForWrite,
   updatePick: mockUpdatePick,
   PICK_CLOSED_API_ERROR: "Pick is closed",
+  PickNotFoundError: class PickNotFoundError extends Error {
+    readonly code = "pick_not_found";
+    constructor() {
+      super("Pick not found");
+      this.name = "PickNotFoundError";
+    }
+  },
   PickWriteClosedError: class PickWriteClosedError extends Error {
     readonly code = "pick_closed";
     constructor(message = "Pick is closed and no longer accepts changes.") {
@@ -173,9 +180,7 @@ describe("PATCH /api/.../picks/[pickId]", () => {
 
   describe("Existing pick-not-found path still returns 404", () => {
     it("returns 404 when pick not found is thrown from assertPickIsOpenForWrite", async () => {
-      mockAssertPickIsOpenForWrite.mockRejectedValue(
-        new Error("Pick not found"),
-      );
+      mockAssertPickIsOpenForWrite.mockRejectedValue(new PickNotFoundError());
 
       const response = await PATCH(
         makeRequest({ title: "New Title", description: "", topCount: 1 }),

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.ts
@@ -5,6 +5,7 @@ import { getGroupById } from "@/server/data/groups";
 import {
   assertPickIsOpenForWrite,
   PICK_CLOSED_API_ERROR,
+  PickNotFoundError,
   PickWriteClosedError,
   updatePick,
 } from "@/server/data/picks";
@@ -108,7 +109,7 @@ export async function PATCH(
         { status: 409 },
       );
     }
-    if (err instanceof Error && err.message === "Pick not found") {
+    if (err instanceof PickNotFoundError) {
       return NextResponse.json({ error: "Pick not found" }, { status: 404 });
     }
     throw err;

--- a/src/server/data/picks.spec.ts
+++ b/src/server/data/picks.spec.ts
@@ -6,6 +6,7 @@ import type { FirebasePickPublic } from "@/lib/firebase/schema/pick";
 import {
   assertPickIsOpenForWrite,
   getPickById,
+  PickNotFoundError,
   PickWriteClosedError,
 } from "./picks";
 
@@ -155,7 +156,7 @@ describe("assertPickIsOpenForWrite", () => {
     expect(storedPick.closedAt).toBe(closedAt);
   });
 
-  it("throws Pick not found when the transaction finds no data", async () => {
+  it("throws PickNotFoundError when the transaction finds no data", async () => {
     const transaction = vi.fn(
       (
         update: (
@@ -180,7 +181,7 @@ describe("assertPickIsOpenForWrite", () => {
 
     await expect(
       assertPickIsOpenForWrite("cat-123", "pick-missing"),
-    ).rejects.toThrow("Pick not found");
+    ).rejects.toBeInstanceOf(PickNotFoundError);
   });
 });
 

--- a/src/server/data/picks.ts
+++ b/src/server/data/picks.ts
@@ -13,6 +13,15 @@ const PICK_CLOSED_ERROR = "Pick is closed and no longer accepts changes.";
 const PICK_DUE_DATE_PASSED_ERROR =
   "Pick due date has passed. The pick has been closed and no longer accepts changes.";
 
+export class PickNotFoundError extends Error {
+  readonly code = "pick_not_found";
+
+  constructor() {
+    super("Pick not found");
+    this.name = "PickNotFoundError";
+  }
+}
+
 export class PickWriteClosedError extends Error {
   readonly code = "pick_closed";
 
@@ -73,7 +82,7 @@ export async function assertPickIsOpenForWrite(
   );
 
   if (!result.snapshot.exists()) {
-    throw new Error("Pick not found");
+    throw new PickNotFoundError();
   }
 
   const pick = firebaseToPick(


### PR DESCRIPTION
Replaces `new Error("Pick not found")` in `assertPickIsOpenForWrite` with a typed `PickNotFoundError` class, and updates the PATCH route's catch block to use `instanceof PickNotFoundError` instead of `err.message === "Pick not found"`. This makes the not-found path resilient to message-string changes.

`PickNotFoundError` follows the same pattern as the existing `PickWriteClosedError` — readonly `code` field, named class for stack traces.

## Acceptance Criteria
- [x] `PickNotFoundError` class exported from `src/server/data/picks.ts`
- [x] `assertPickIsOpenForWrite` throws `PickNotFoundError` instead of plain `Error("Pick not found")`
- [x] PATCH route catch block updated to `instanceof PickNotFoundError`
- [x] Existing tests updated to test `PickNotFoundError` directly (no string matching)

## Tests
2 tests updated, 456 total passing.

Closes #162

---
*Created by Claude Sonnet 4.5*