### PR TITLE
fix(groups): correct null-return and missing-ownership-check bugs in removeMember transaction

### DIFF
--- a/src/server/data/groups.spec.ts
+++ b/src/server/data/groups.spec.ts
@@ -69,7 +69,7 @@ describe("removeMember last-member transaction", () => {
     });
   });
 
-  it("preserves the original members value when the snapshot is null (group already gone)", async () => {
+  it("aborts the transaction (returns undefined) when the snapshot is null", async () => {
     let capturedUpdate:
       | ((m: Record<string, unknown> | null) => unknown)
       | undefined;
@@ -82,7 +82,23 @@ describe("removeMember last-member transaction", () => {
 
     await removeMember("group-1", "user-1");
 
-    expect(capturedUpdate?.(null)).toBeNull();
+    expect(capturedUpdate?.(null)).toBeUndefined();
+  });
+
+  it("returns members map unchanged when uid is not in a single-member map", async () => {
+    let capturedUpdate:
+      | ((m: Record<string, unknown> | null) => unknown)
+      | undefined;
+    mockTransaction.mockImplementation(
+      (update: (m: Record<string, unknown> | null) => unknown) => {
+        capturedUpdate = update;
+        return Promise.resolve({ committed: true });
+      },
+    );
+
+    await removeMember("group-1", "user-1");
+
+    expect(capturedUpdate?.({ "user-2": true })).toEqual({ "user-2": true });
   });
 
   it("reports lastMember=true when the transaction did not commit", async () => {

--- a/src/server/data/groups.ts
+++ b/src/server/data/groups.ts
@@ -63,7 +63,8 @@ export async function removeMember(
   const result = await db
     .ref(`groups/${groupId}/members`)
     .transaction((members: Record<string, unknown> | null) => {
-      if (!members) return members;
+      if (!members) return undefined;
+      if (!(uid in members)) return members;
       if (Object.keys(members).length <= 1) return undefined;
       return Object.fromEntries(
         Object.entries(members).filter(([key]) => key !== uid),


### PR DESCRIPTION
Fixes two bugs in `removeMember`'s Firebase RTDB transaction update function that mirror the issues fixed for `unjoinOption` in #153.

**Bug 1 — `return null` commits instead of aborting**: `if (!members) return members` returned `null`, which Firebase treats as a commit (writing `null` to the database). Changed to `return undefined` so a missing snapshot correctly aborts.

**Bug 2 — Missing ownership check**: The `length <= 1` guard fired for any single-entry map regardless of whether `uid` was in it. A caller not in the members map would receive `{ lastMember: true }` and trigger group-cleanup logic even though they were never a member. Added `if (!(uid in members)) return members` before the sole-entry check.

## Acceptance Criteria
- [x] Null snapshot returns `undefined` (aborts the transaction)
- [x] Single-entry map where `uid` is NOT the key → update fn returns map unchanged; `lastMember: false`
- [x] Single-entry map where `uid` IS the key → update fn returns `undefined`; `lastMember: true`

## Tests
2 tests updated/added, 463 total passing.

Closes #175

---
*Created by Claude Sonnet 4.6*