### PR TITLE
feat(picks): wire assertPickIsOpenForWrite into close pick route

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.spec.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PickWriteClosedError } from "@/server/data/picks";
+
+const {
+  mockGetVerifiedUid,
+  mockGetGroupById,
+  mockGetCategoryById,
+  mockAssertPickIsOpenForWrite,
+  mockClosePick,
+} = vi.hoisted(() => ({
+  mockGetVerifiedUid: vi.fn(),
+  mockGetGroupById: vi.fn(),
+  mockGetCategoryById: vi.fn(),
+  mockAssertPickIsOpenForWrite: vi.fn(),
+  mockClosePick: vi.fn(),
+}));
+
+vi.mock("@/server/utils/auth", () => ({
+  getVerifiedUid: mockGetVerifiedUid,
+}));
+
+vi.mock("@/server/data/groups", () => ({
+  getGroupById: mockGetGroupById,
+}));
+
+vi.mock("@/server/data/categories", () => ({
+  getCategoryById: mockGetCategoryById,
+}));
+
+vi.mock("@/server/data/picks", () => ({
+  assertPickIsOpenForWrite: mockAssertPickIsOpenForWrite,
+  closePick: mockClosePick,
+  PICK_CLOSED_API_ERROR: "Pick is closed",
+  PickWriteClosedError: class PickWriteClosedError extends Error {
+    readonly code = "pick_closed";
+    constructor(message = "Pick is closed and no longer accepts changes.") {
+      super(message);
+      this.name = "PickWriteClosedError";
+    }
+  },
+}));
+
+const { POST } = await import("./route");
+
+const baseParams = {
+  id: "group-1",
+  categoryId: "cat-1",
+  pickId: "pick-1",
+};
+
+function makeRequest() {
+  return new Request(
+    "http://localhost/api/groups/group-1/categories/cat-1/picks/pick-1/close",
+    { method: "POST" },
+  );
+}
+
+describe("POST /api/.../picks/[pickId]/close", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVerifiedUid.mockResolvedValue("user-1");
+    mockGetGroupById.mockResolvedValue({
+      id: "group-1",
+      name: "G",
+      createdAt: new Date(),
+      creatorId: "user-1",
+      memberIds: ["user-1"],
+    });
+    mockGetCategoryById.mockResolvedValue({
+      id: "cat-1",
+      groupId: "group-1",
+      name: "C",
+      description: "",
+      createdAt: new Date(),
+      creatorId: "user-1",
+    });
+    mockAssertPickIsOpenForWrite.mockResolvedValue({
+      id: "pick-1",
+      title: "Open Pick",
+      description: "",
+      categoryId: "cat-1",
+      topCount: 1,
+      createdAt: new Date(),
+      creatorId: "user-1",
+      closedAt: undefined,
+    });
+    mockClosePick.mockResolvedValue(undefined);
+  });
+
+  describe("Close succeeds for an open pick", () => {
+    it("returns 200 and calls closePick when pick is open", async () => {
+      const response = await POST(makeRequest(), {
+        params: Promise.resolve(baseParams),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockClosePick).toHaveBeenCalledWith("cat-1", "pick-1");
+    });
+
+    it("calls assertPickIsOpenForWrite before closePick", async () => {
+      const callOrder: string[] = [];
+      mockAssertPickIsOpenForWrite.mockImplementation(() => {
+        callOrder.push("assertPickIsOpenForWrite");
+        return Promise.resolve({
+          id: "pick-1",
+          title: "P",
+          description: "",
+          categoryId: "cat-1",
+          topCount: 1,
+          createdAt: new Date(),
+          creatorId: "user-1",
+          closedAt: undefined,
+        });
+      });
+      mockClosePick.mockImplementation(() => {
+        callOrder.push("closePick");
+        return Promise.resolve();
+      });
+
+      await POST(makeRequest(), { params: Promise.resolve(baseParams) });
+
+      expect(callOrder).toEqual(["assertPickIsOpenForWrite", "closePick"]);
+    });
+  });
+
+  describe("Close returns 409 when pick is already closed", () => {
+    it("returns 409 when assertPickIsOpenForWrite throws PickWriteClosedError", async () => {
+      mockAssertPickIsOpenForWrite.mockRejectedValue(
+        new PickWriteClosedError(
+          "Pick is closed and no longer accepts changes.",
+        ),
+      );
+
+      const response = await POST(makeRequest(), {
+        params: Promise.resolve(baseParams),
+      });
+
+      expect(response.status).toBe(409);
+      expect(mockClosePick).not.toHaveBeenCalled();
+    });
+
+    it("includes PICK_CLOSED_API_ERROR in the 409 response body", async () => {
+      mockAssertPickIsOpenForWrite.mockRejectedValue(
+        new PickWriteClosedError(
+          "Pick is closed and no longer accepts changes.",
+        ),
+      );
+
+      const response = await POST(makeRequest(), {
+        params: Promise.resolve(baseParams),
+      });
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Pick is closed");
+    });
+  });
+
+  describe("Close returns 404 when pick is not found", () => {
+    it("returns 404 when assertPickIsOpenForWrite throws Pick not found", async () => {
+      mockAssertPickIsOpenForWrite.mockRejectedValue(
+        new Error("Pick not found"),
+      );
+
+      const response = await POST(makeRequest(), {
+        params: Promise.resolve(baseParams),
+      });
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { PickWriteClosedError } from "@/server/data/picks";
+import { PickNotFoundError, PickWriteClosedError } from "@/server/data/picks";
 
 const {
   mockGetVerifiedUid,
@@ -32,6 +32,13 @@ vi.mock("@/server/data/picks", () => ({
   assertPickIsOpenForWrite: mockAssertPickIsOpenForWrite,
   closePick: mockClosePick,
   PICK_CLOSED_API_ERROR: "Pick is closed",
+  PickNotFoundError: class PickNotFoundError extends Error {
+    readonly code = "pick_not_found";
+    constructor() {
+      super("Pick not found");
+      this.name = "PickNotFoundError";
+    }
+  },
   PickWriteClosedError: class PickWriteClosedError extends Error {
     readonly code = "pick_closed";
     constructor(message = "Pick is closed and no longer accepts changes.") {
@@ -157,10 +164,8 @@ describe("POST /api/.../picks/[pickId]/close", () => {
   });
 
   describe("Close returns 404 when pick is not found", () => {
-    it("returns 404 when assertPickIsOpenForWrite throws Pick not found", async () => {
-      mockAssertPickIsOpenForWrite.mockRejectedValue(
-        new Error("Pick not found"),
-      );
+    it("returns 404 when assertPickIsOpenForWrite throws PickNotFoundError", async () => {
+      mockAssertPickIsOpenForWrite.mockRejectedValue(new PickNotFoundError());
 
       const response = await POST(makeRequest(), {
         params: Promise.resolve(baseParams),

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.ts
@@ -6,6 +6,7 @@ import {
   assertPickIsOpenForWrite,
   closePick,
   PICK_CLOSED_API_ERROR,
+  PickNotFoundError,
   PickWriteClosedError,
 } from "@/server/data/picks";
 import { getVerifiedUid } from "@/server/utils/auth";
@@ -47,7 +48,7 @@ export async function POST(
         { status: 409 },
       );
     }
-    if (err instanceof Error && err.message === "Pick not found") {
+    if (err instanceof PickNotFoundError) {
       return NextResponse.json({ error: "Pick not found" }, { status: 404 });
     }
     throw err;

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/close/route.ts
@@ -3,9 +3,10 @@ import { NextResponse } from "next/server";
 import { getCategoryById } from "@/server/data/categories";
 import { getGroupById } from "@/server/data/groups";
 import {
+  assertPickIsOpenForWrite,
   closePick,
-  getPickById,
   PICK_CLOSED_API_ERROR,
+  PickWriteClosedError,
 } from "@/server/data/picks";
 import { getVerifiedUid } from "@/server/utils/auth";
 
@@ -37,14 +38,19 @@ export async function POST(
     return NextResponse.json({ error: "Category not found" }, { status: 404 });
   }
 
-  const pick = await getPickById(categoryId, pickId);
-
-  if (!pick) {
-    return NextResponse.json({ error: "Pick not found" }, { status: 404 });
-  }
-
-  if (pick.closedAt !== undefined) {
-    return NextResponse.json({ error: PICK_CLOSED_API_ERROR }, { status: 409 });
+  try {
+    await assertPickIsOpenForWrite(categoryId, pickId);
+  } catch (err) {
+    if (err instanceof PickWriteClosedError) {
+      return NextResponse.json(
+        { error: PICK_CLOSED_API_ERROR },
+        { status: 409 },
+      );
+    }
+    if (err instanceof Error && err.message === "Pick not found") {
+      return NextResponse.json({ error: "Pick not found" }, { status: 404 });
+    }
+    throw err;
   }
 
   await closePick(categoryId, pickId);


### PR DESCRIPTION
Replaces the manual `getPickById` + `closedAt` check in the close pick route with `assertPickIsOpenForWrite`, giving consistent transactional semantics and typed error handling across all pick-write paths.

Returns 409 with `PICK_CLOSED_API_ERROR` for already-closed picks and 404 for missing picks. The reopen route is excluded pending UX confirmation per the issue body.

## Acceptance Criteria
- [x] `close/route.ts` calls `assertPickIsOpenForWrite` instead of `getPickById` + manual `closedAt` check
- [x] Returns 409 with `PICK_CLOSED_API_ERROR` when the pick is already closed
- [x] Returns 404 when the pick is not found

## Tests
5 tests added, all passing.

Closes #164

---
*Created by Claude Sonnet 4.6*