### PR TITLE
perf(picks): replace full collection read with limitToFirst(1) for hasPicks check

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { getCategoryById } from "@/server/data/categories";
 import { getGroupById } from "@/server/data/groups";
-import { getPicksByCategory } from "@/server/data/picks";
+import { hasPicks } from "@/server/data/picks";
 import { getVerifiedUid } from "@/server/utils/auth";
 
 import { CreatePickForm } from "./CreatePickForm";
@@ -25,14 +25,14 @@ export default async function CreatePickPage({
   if (!group.memberIds.includes(uid)) notFound();
   if (category?.groupId !== groupId) notFound();
 
-  const picks = await getPicksByCategory(categoryId);
+  const hasPriorPicks = await hasPicks(categoryId);
 
   return (
     <main className="mx-auto max-w-lg p-6">
       <CreatePickForm
         groupId={groupId}
         categoryId={categoryId}
-        hasPriorPicks={picks.length > 0}
+        hasPriorPicks={hasPriorPicks}
       />
     </main>
   );

--- a/src/server/data/picks.spec.ts
+++ b/src/server/data/picks.spec.ts
@@ -6,6 +6,7 @@ import type { FirebasePickPublic } from "@/lib/firebase/schema/pick";
 import {
   assertPickIsOpenForWrite,
   getPickById,
+  hasPicks,
   PickNotFoundError,
   PickWriteClosedError,
 } from "./picks";
@@ -182,6 +183,40 @@ describe("assertPickIsOpenForWrite", () => {
     await expect(
       assertPickIsOpenForWrite("cat-123", "pick-missing"),
     ).rejects.toBeInstanceOf(PickNotFoundError);
+  });
+});
+
+describe("hasPicks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when at least one pick exists", async () => {
+    const get = vi.fn().mockResolvedValue({ exists: () => true });
+    const limitToFirst = vi.fn().mockReturnValue({ get });
+
+    getDatabaseMock.mockReturnValue({
+      ref: () => ({ limitToFirst }),
+    } as never);
+
+    const result = await hasPicks("cat-123");
+
+    expect(result).toBe(true);
+    expect(limitToFirst).toHaveBeenCalledWith(1);
+  });
+
+  it("returns false when no picks exist", async () => {
+    const get = vi.fn().mockResolvedValue({ exists: () => false });
+    const limitToFirst = vi.fn().mockReturnValue({ get });
+
+    getDatabaseMock.mockReturnValue({
+      ref: () => ({ limitToFirst }),
+    } as never);
+
+    const result = await hasPicks("cat-123");
+
+    expect(result).toBe(false);
+    expect(limitToFirst).toHaveBeenCalledWith(1);
   });
 });
 

--- a/src/server/data/picks.ts
+++ b/src/server/data/picks.ts
@@ -31,6 +31,15 @@ export class PickWriteClosedError extends Error {
   }
 }
 
+export async function hasPicks(categoryId: string): Promise<boolean> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db
+    .ref(`categories/${categoryId}/picks`)
+    .limitToFirst(1)
+    .get();
+  return snap.exists();
+}
+
 export async function getPicksByCategory(
   categoryId: string,
 ): Promise<GroupPick[]> {


### PR DESCRIPTION
Adds a `hasPicks(categoryId)` helper to `src/server/data/picks.ts` that uses Firebase RTDB's `limitToFirst(1)` to fetch only the first document, avoiding a full collection scan just to compute a boolean.

Updates `CreatePickPage` to call `hasPicks()` instead of `getPicksByCategory()` — the full picks array is no longer needed at page load, so only a single-document query is made.

## Acceptance Criteria
- [x] `hasPicks(categoryId)` returns `true` when at least one pick exists
- [x] `hasPicks(categoryId)` returns `false` when no picks exist
- [x] Uses `limitToFirst(1)` (not a full collection read)
- [x] `CreatePickPage` uses `hasPicks` instead of `getPicksByCategory`

## Tests
2 tests added, all 468 passing.

Closes #181

---
*Created by Claude Sonnet 4.6*