### PR TITLE
feat(results): display top N picks on pick detail page via ranked-choice scoring

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -105,6 +105,7 @@ function renderView(overrides?: Partial<Parameters<typeof PickDetailView>[0]>) {
       currentUserId="user-1"
       initialOptions={[]}
       initialSuggestions={[]}
+      topPicks={[]}
       {...overrides}
     />,
   );
@@ -522,56 +523,40 @@ describe("participant count", () => {
 
 describe("top picks results", () => {
   it("renders option titles in the top picks tab when pick is closed", () => {
-    const option1 = makeOption({
-      id: "opt-1",
-      title: "Option Alpha",
-      ownerIds: ["user-1", "user-2"],
-    });
-    const option2 = makeOption({
-      id: "opt-2",
-      title: "Option Beta",
-      ownerIds: ["user-1"],
-    });
+    const option1 = makeOption({ id: "opt-1", title: "Option Alpha" });
+    const option2 = makeOption({ id: "opt-2", title: "Option Beta" });
 
     renderView({
       pick: makePick({
         closedAt: new Date("2025-06-01T00:00:00.000Z"),
         topCount: 2,
       }),
-      initialOptions: [option1, option2],
+      topPicks: [option1, option2],
     });
 
     expect(screen.getByText("Option Alpha")).toBeDefined();
+    expect(screen.getByText("Option Beta")).toBeDefined();
   });
 
-  it("renders only the top N options in the top picks tab", () => {
-    const option1 = makeOption({
-      id: "opt-1",
-      title: "Top Option",
-      ownerIds: ["user-1", "user-2"],
-    });
-    const option2 = makeOption({
-      id: "opt-2",
-      title: "Excluded Option",
-      ownerIds: ["user-3"],
-    });
+  it("renders only the provided topPicks in the top picks tab", () => {
+    const topOption = makeOption({ id: "opt-1", title: "Top Option" });
 
     renderView({
       pick: makePick({
         closedAt: new Date("2025-06-01T00:00:00.000Z"),
         topCount: 1,
       }),
-      initialOptions: [option1, option2],
+      topPicks: [topOption],
     });
 
     expect(screen.getByText("Top Option")).toBeDefined();
     expect(screen.queryByText("Excluded Option")).toBeNull();
   });
 
-  it("shows the results placeholder when closed pick has no options", () => {
+  it("shows the results placeholder when closed pick has no top picks", () => {
     renderView({
       pick: makePick({ closedAt: new Date("2025-06-01T00:00:00.000Z") }),
-      initialOptions: [],
+      topPicks: [],
     });
 
     expect(

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -202,9 +202,7 @@ describe("open state", () => {
   it("renders top picks tab as locked placeholder when open", () => {
     renderView({ pick: makePick({ closedAt: undefined }) });
 
-    expect(
-      screen.getByText(TOP_PICKS_VIEW_COPY.lockedMessage),
-    ).toBeDefined();
+    expect(screen.getByText(TOP_PICKS_VIEW_COPY.lockedMessage)).toBeDefined();
   });
 
   it("does not render the reopen button when open", () => {
@@ -239,9 +237,7 @@ describe("closed state: top picks shows results placeholder", () => {
     expect(
       screen.getByText(TOP_PICKS_VIEW_COPY.noResultsMessage),
     ).toBeDefined();
-    expect(
-      screen.queryByText(TOP_PICKS_VIEW_COPY.lockedMessage),
-    ).toBeNull();
+    expect(screen.queryByText(TOP_PICKS_VIEW_COPY.lockedMessage)).toBeNull();
   });
 });
 
@@ -541,7 +537,10 @@ describe("top picks results", () => {
 
   it("renders only the provided topPicks in the top picks tab", () => {
     const topOption = makeOption({ id: "opt-1", title: "Top Option" });
-    const excludedOption = makeOption({ id: "opt-2", title: "Excluded Option" });
+    const excludedOption = makeOption({
+      id: "opt-2",
+      title: "Excluded Option",
+    });
 
     renderView({
       pick: makePick({

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -19,6 +19,7 @@ import { PICK_DETAIL_SCAFFOLD_COPY } from "./copy";
 import { EMPTY_PICK_COPY } from "./EmptyPickView.copy";
 import { PickDetailView } from "./PickDetailView";
 import type { SuggestOptionSheetProps } from "./SuggestOptionSheet";
+import { TOP_PICKS_VIEW_COPY } from "./TopPicksView.copy";
 
 let capturedOnOptionsChange: ((options: Option[]) => void) | undefined;
 
@@ -202,7 +203,7 @@ describe("open state", () => {
     renderView({ pick: makePick({ closedAt: undefined }) });
 
     expect(
-      screen.getByText(PICK_DETAIL_SCAFFOLD_COPY.topPicksLockedPlaceholder),
+      screen.getByText(TOP_PICKS_VIEW_COPY.lockedMessage),
     ).toBeDefined();
   });
 
@@ -236,10 +237,10 @@ describe("closed state: top picks shows results placeholder", () => {
     });
 
     expect(
-      screen.getByText(PICK_DETAIL_SCAFFOLD_COPY.resultsPlaceholder),
+      screen.getByText(TOP_PICKS_VIEW_COPY.noResultsMessage),
     ).toBeDefined();
     expect(
-      screen.queryByText(PICK_DETAIL_SCAFFOLD_COPY.topPicksLockedPlaceholder),
+      screen.queryByText(TOP_PICKS_VIEW_COPY.lockedMessage),
     ).toBeNull();
   });
 });
@@ -540,13 +541,14 @@ describe("top picks results", () => {
 
   it("renders only the provided topPicks in the top picks tab", () => {
     const topOption = makeOption({ id: "opt-1", title: "Top Option" });
+    const excludedOption = makeOption({ id: "opt-2", title: "Excluded Option" });
 
     renderView({
       pick: makePick({
         closedAt: new Date("2025-06-01T00:00:00.000Z"),
         topCount: 1,
       }),
-      topPicks: [topOption],
+      topPicks: [topOption, excludedOption],
     });
 
     expect(screen.getByText("Top Option")).toBeDefined();
@@ -560,7 +562,7 @@ describe("top picks results", () => {
     });
 
     expect(
-      screen.getByText(PICK_DETAIL_SCAFFOLD_COPY.resultsPlaceholder),
+      screen.getByText(TOP_PICKS_VIEW_COPY.noResultsMessage),
     ).toBeDefined();
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.stories.tsx
@@ -48,6 +48,7 @@ const meta: Meta<typeof PickDetailView> = {
     currentUserId: "user-1",
     initialOptions: mockOptions,
     initialSuggestions: [],
+    topPicks: [],
   },
 };
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -16,6 +16,7 @@ import { OptionList } from "./OptionList";
 import { SuggestOptionSheet } from "./SuggestOptionSheet";
 import { TierRanking } from "./TierRanking";
 import { TopPicksView } from "./TopPicksView";
+import { TOP_PICKS_VIEW_COPY } from "./TopPicksView.copy";
 
 interface PickDetailViewProps {
   pick: GroupPick;
@@ -153,6 +154,12 @@ export function PickDetailView({
           </TabsTrigger>
         </TabsList>
 
+        {isOpen ? (
+          <p className="mt-4 text-sm text-muted-foreground">
+            {TOP_PICKS_VIEW_COPY.lockedMessage}
+          </p>
+        ) : null}
+
         <TabsContent value="options" className="mt-4">
           {options.length === 0 && initialSuggestions.length === 0 ? (
             <EmptyPickView
@@ -192,11 +199,13 @@ export function PickDetailView({
         </TabsContent>
 
         <TabsContent value="top-picks" className="mt-4" keepMounted>
-          <TopPicksView
-            isOpen={isOpen}
-            topPicks={topPicks}
-            topCount={pick.topCount}
-          />
+          {!isOpen ? (
+            <TopPicksView
+              isOpen={false}
+              topPicks={topPicks}
+              topCount={pick.topCount}
+            />
+          ) : null}
         </TabsContent>
       </Tabs>
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -201,7 +201,7 @@ export function PickDetailView({
         <TabsContent value="top-picks" className="mt-4" keepMounted>
           {!isOpen ? (
             <TopPicksView
-              isOpen={false}
+              isOpen={isOpen}
               topPicks={topPicks}
               topCount={pick.topCount}
             />

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -15,6 +15,7 @@ import { EmptyPickView } from "./EmptyPickView";
 import { OptionList } from "./OptionList";
 import { SuggestOptionSheet } from "./SuggestOptionSheet";
 import { TierRanking } from "./TierRanking";
+import { TopPicksView } from "./TopPicksView";
 
 interface PickDetailViewProps {
   pick: GroupPick;
@@ -25,6 +26,7 @@ interface PickDetailViewProps {
   initialOptions: Option[];
   initialSuggestions: Option[];
   initialTierAssignments?: Record<string, RankingTier>;
+  topPicks: Option[];
 }
 
 export function PickDetailView({
@@ -36,14 +38,12 @@ export function PickDetailView({
   initialOptions,
   initialSuggestions,
   initialTierAssignments = {},
+  topPicks,
 }: PickDetailViewProps) {
   const [options, setOptions] = useState<Option[]>(initialOptions);
   const [isSuggestSheetOpen, setIsSuggestSheetOpen] = useState(false);
   const isOpen = pick.closedAt === undefined;
   const uniqueOwnerCount = new Set(options.flatMap((opt) => opt.ownerIds)).size;
-  const topPicksOptions = [...options]
-    .sort((a, b) => b.ownerIds.length - a.ownerIds.length)
-    .slice(0, pick.topCount);
 
   function handleOptionAdded({
     optionId,
@@ -192,21 +192,11 @@ export function PickDetailView({
         </TabsContent>
 
         <TabsContent value="top-picks" className="mt-4" keepMounted>
-          {isOpen || topPicksOptions.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              {isOpen
-                ? PICK_DETAIL_SCAFFOLD_COPY.topPicksLockedPlaceholder
-                : PICK_DETAIL_SCAFFOLD_COPY.resultsPlaceholder}
-            </p>
-          ) : (
-            <ul className="space-y-2">
-              {topPicksOptions.map((opt) => (
-                <li key={opt.id} className="text-sm">
-                  {opt.title}
-                </li>
-              ))}
-            </ul>
-          )}
+          <TopPicksView
+            isOpen={isOpen}
+            topPicks={topPicks}
+            topCount={pick.topCount}
+          />
         </TabsContent>
       </Tabs>
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.copy.ts
@@ -1,0 +1,4 @@
+export const TOP_PICKS_VIEW_COPY = {
+  lockedMessage: "Top picks will be revealed when this pick closes.",
+  noResultsMessage: "No options were added to this pick.",
+} as const;

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.spec.tsx
@@ -59,5 +59,19 @@ describe("TopPicksView", () => {
       render(<TopPicksView isOpen={false} topPicks={options} topCount={3} />);
       expect(screen.getAllByText(/#\d/).length).toBe(1);
     });
+
+    it("truncates to topCount when more picks are supplied than topCount", () => {
+      const options = [
+        makeOption("opt-1", "Alpha"),
+        makeOption("opt-2", "Beta"),
+        makeOption("opt-3", "Gamma"),
+        makeOption("opt-4", "Delta"),
+      ];
+      render(<TopPicksView isOpen={false} topPicks={options} topCount={2} />);
+      expect(screen.getByText("Alpha")).toBeDefined();
+      expect(screen.getByText("Beta")).toBeDefined();
+      expect(screen.queryByText("Gamma")).toBeNull();
+      expect(screen.queryByText("Delta")).toBeNull();
+    });
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.spec.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Option } from "@/lib/types/option";
+
+import { TopPicksView } from "./TopPicksView";
+import { TOP_PICKS_VIEW_COPY } from "./TopPicksView.copy";
+
+afterEach(cleanup);
+
+function makeOption(id: string, title: string): Option {
+  return { id, title, pickId: "pick-1", ownerIds: ["user-1"] };
+}
+
+describe("TopPicksView", () => {
+  describe("locked state (pick is open)", () => {
+    it("renders the locked message", () => {
+      render(<TopPicksView isOpen topPicks={[]} topCount={3} />);
+      expect(screen.getByText(TOP_PICKS_VIEW_COPY.lockedMessage)).toBeDefined();
+    });
+
+    it("does not render any pick results", () => {
+      const options = [makeOption("opt-1", "Option A")];
+      render(<TopPicksView isOpen topPicks={options} topCount={1} />);
+      expect(screen.queryByText("Option A")).toBeNull();
+    });
+  });
+
+  describe("revealed state (pick is closed)", () => {
+    it("renders each top pick by title", () => {
+      const options = [
+        makeOption("opt-1", "Inception"),
+        makeOption("opt-2", "The Matrix"),
+      ];
+      render(<TopPicksView isOpen={false} topPicks={options} topCount={2} />);
+      expect(screen.getByText("Inception")).toBeDefined();
+      expect(screen.getByText("The Matrix")).toBeDefined();
+    });
+
+    it("renders a rank label for each option", () => {
+      const options = [
+        makeOption("opt-1", "Inception"),
+        makeOption("opt-2", "The Matrix"),
+      ];
+      render(<TopPicksView isOpen={false} topPicks={options} topCount={2} />);
+      expect(screen.getByText("#1")).toBeDefined();
+      expect(screen.getByText("#2")).toBeDefined();
+    });
+
+    it("renders the empty state when no top picks are available", () => {
+      render(<TopPicksView isOpen={false} topPicks={[]} topCount={3} />);
+      expect(
+        screen.getByText(TOP_PICKS_VIEW_COPY.noResultsMessage),
+      ).toBeDefined();
+    });
+
+    it("renders only the options provided, not more", () => {
+      const options = [makeOption("opt-1", "Only Option")];
+      render(<TopPicksView isOpen={false} topPicks={options} topCount={3} />);
+      expect(screen.getAllByText(/#\d/).length).toBe(1);
+    });
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import type { Option } from "@/lib/types/option";
+
+import { TopPicksView } from "./TopPicksView";
+
+const mockOptions: Option[] = [
+  { id: "opt-1", title: "The Shawshank Redemption", pickId: "pick-1", ownerIds: ["user-1"] },
+  { id: "opt-2", title: "Inception", pickId: "pick-1", ownerIds: ["user-2"] },
+  { id: "opt-3", title: "Interstellar", pickId: "pick-1", ownerIds: ["user-1"] },
+];
+
+const meta: Meta<typeof TopPicksView> = {
+  title: "Picks/TopPicksView",
+  component: TopPicksView,
+  args: {
+    isOpen: false,
+    topPicks: mockOptions,
+    topCount: 3,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TopPicksView>;
+
+export const Locked: Story = {
+  args: {
+    isOpen: true,
+    topPicks: [],
+  },
+};
+
+export const EmptyResults: Story = {
+  args: {
+    isOpen: false,
+    topPicks: [],
+  },
+};
+
+export const RevealedList: Story = {};

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.stories.tsx
@@ -5,9 +5,19 @@ import type { Option } from "@/lib/types/option";
 import { TopPicksView } from "./TopPicksView";
 
 const mockOptions: Option[] = [
-  { id: "opt-1", title: "The Shawshank Redemption", pickId: "pick-1", ownerIds: ["user-1"] },
+  {
+    id: "opt-1",
+    title: "The Shawshank Redemption",
+    pickId: "pick-1",
+    ownerIds: ["user-1"],
+  },
   { id: "opt-2", title: "Inception", pickId: "pick-1", ownerIds: ["user-2"] },
-  { id: "opt-3", title: "Interstellar", pickId: "pick-1", ownerIds: ["user-1"] },
+  {
+    id: "opt-3",
+    title: "Interstellar",
+    pickId: "pick-1",
+    ownerIds: ["user-1"],
+  },
 ];
 
 const meta: Meta<typeof TopPicksView> = {

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.tsx
@@ -1,0 +1,44 @@
+import type { Option } from "@/lib/types/option";
+
+import { TOP_PICKS_VIEW_COPY } from "./TopPicksView.copy";
+
+interface TopPicksViewProps {
+  isOpen: boolean;
+  topPicks: Option[];
+  topCount: number;
+}
+
+export function TopPicksView({
+  isOpen,
+  topPicks,
+  topCount,
+}: TopPicksViewProps) {
+  if (isOpen) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {TOP_PICKS_VIEW_COPY.lockedMessage}
+      </p>
+    );
+  }
+
+  if (topPicks.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {TOP_PICKS_VIEW_COPY.noResultsMessage}
+      </p>
+    );
+  }
+
+  return (
+    <ol className="space-y-2">
+      {topPicks.slice(0, topCount).map((option, index) => (
+        <li key={option.id} className="flex items-center gap-3 text-sm">
+          <span className="w-8 font-mono text-muted-foreground">
+            #{index + 1}
+          </span>
+          <span>{option.title}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TopPicksView.tsx
@@ -13,23 +13,13 @@ export function TopPicksView({
   topPicks,
   topCount,
 }: TopPicksViewProps) {
-  if (isOpen) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        {TOP_PICKS_VIEW_COPY.lockedMessage}
-      </p>
-    );
-  }
-
-  if (topPicks.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        {TOP_PICKS_VIEW_COPY.noResultsMessage}
-      </p>
-    );
-  }
-
-  return (
+  return isOpen || topPicks.length === 0 ? (
+    <p className="text-sm text-muted-foreground">
+      {isOpen
+        ? TOP_PICKS_VIEW_COPY.lockedMessage
+        : TOP_PICKS_VIEW_COPY.noResultsMessage}
+    </p>
+  ) : (
     <ol className="space-y-2">
       {topPicks.slice(0, topCount).map((option, index) => (
         <li key={option.id} className="flex items-center gap-3 text-sm">

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/copy.ts
@@ -25,7 +25,6 @@ export const PICK_DETAIL_SCAFFOLD_COPY = {
   openStatusChip: "Open",
   participantsLabel: "Participants",
   rankingTabPlaceholder: "Ranking coming soon.",
-  resultsPlaceholder: "No options were added to this pick.",
   suggestOptionButton: "Suggest option",
   tabs: {
     options: "Options",
@@ -33,6 +32,4 @@ export const PICK_DETAIL_SCAFFOLD_COPY = {
     topPicks: "Top picks",
   },
   topCountLabel: "Top",
-  topPicksLockedPlaceholder:
-    "Top picks will be revealed when this pick closes.",
 } as const;

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/page.tsx
@@ -1,10 +1,14 @@
 import { notFound, redirect } from "next/navigation";
 
+import { computeTopPicks } from "@/lib/ranking-score";
 import { getCategoryById } from "@/server/data/categories";
 import { getGroupById } from "@/server/data/groups";
 import { getOptionsByCategory, getOptionsByPick } from "@/server/data/options";
 import { getPickById, getPicksByCategory } from "@/server/data/picks";
-import { getRankingByUser } from "@/server/data/rankings";
+import {
+  getAllRankingsForPick,
+  getRankingByUser,
+} from "@/server/data/rankings";
 import { getVerifiedUid } from "@/server/utils/auth";
 
 import { PickDetailView } from "./PickDetailView";
@@ -28,11 +32,15 @@ export default async function PickDetailPage({
   const pick = await getPickById(categoryId, pickId);
   if (!pick) notFound();
 
-  const [currentOptions, allPicks, initialTierAssignments] = await Promise.all([
-    getOptionsByPick(pickId),
-    getPicksByCategory(categoryId),
-    getRankingByUser(pickId, uid),
-  ]);
+  const isClosed = pick.closedAt !== undefined;
+
+  const [currentOptions, allPicks, initialTierAssignments, allRankings] =
+    await Promise.all([
+      getOptionsByPick(pickId),
+      getPicksByCategory(categoryId),
+      getRankingByUser(pickId, uid),
+      isClosed ? getAllRankingsForPick(pickId) : Promise.resolve({}),
+    ]);
 
   const priorPickIds = allPicks.filter((p) => p.id !== pickId).map((p) => p.id);
   const priorOptions = await getOptionsByCategory(priorPickIds);
@@ -54,6 +62,8 @@ export default async function PickDetailPage({
       return true;
     });
 
+  const topPicks = computeTopPicks(allRankings, currentOptions, pick.topCount);
+
   return (
     <PickDetailView
       pick={pick}
@@ -64,6 +74,7 @@ export default async function PickDetailPage({
       initialOptions={currentOptions}
       initialSuggestions={suggestions}
       initialTierAssignments={initialTierAssignments}
+      topPicks={topPicks}
     />
   );
 }

--- a/src/lib/ranking-score.spec.ts
+++ b/src/lib/ranking-score.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import type { Option } from "@/lib/types/option";
+import { RankingTier } from "@/lib/types/ranking";
+
+import { computeTopPicks } from "./ranking-score";
+
+function makeOption(id: string, title: string): Option {
+  return { id, title, pickId: "pick-1", ownerIds: ["user-1"] };
+}
+
+const optA = makeOption("opt-a", "Option A");
+const optB = makeOption("opt-b", "Option B");
+const optC = makeOption("opt-c", "Option C");
+const optD = makeOption("opt-d", "Option D");
+
+describe("computeTopPicks", () => {
+  describe("with no rankings data", () => {
+    it("returns the requested number of options when no rankings exist", () => {
+      const result = computeTopPicks({}, [optA, optB, optC], 2);
+      expect(result).toHaveLength(2);
+    });
+
+    it("returns all options when topCount exceeds option count", () => {
+      const result = computeTopPicks({}, [optA, optB], 5);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("scoring from tier rankings", () => {
+    it("ranks LoveIt higher than Yes", () => {
+      const allRankings = {
+        "user-1": {
+          "opt-a": RankingTier.LoveIt,
+          "opt-b": RankingTier.Yes,
+        },
+      };
+      const [first, second] = computeTopPicks(allRankings, [optA, optB], 2);
+      expect(first?.id).toBe("opt-a");
+      expect(second?.id).toBe("opt-b");
+    });
+
+    it("ranks Yes higher than Maybe", () => {
+      const allRankings = {
+        "user-1": {
+          "opt-a": RankingTier.Yes,
+          "opt-b": RankingTier.Maybe,
+        },
+      };
+      const [first, second] = computeTopPicks(allRankings, [optA, optB], 2);
+      expect(first?.id).toBe("opt-a");
+      expect(second?.id).toBe("opt-b");
+    });
+
+    it("ranks Maybe higher than NotReally", () => {
+      const allRankings = {
+        "user-1": {
+          "opt-a": RankingTier.Maybe,
+          "opt-b": RankingTier.NotReally,
+        },
+      };
+      const [first, second] = computeTopPicks(allRankings, [optA, optB], 2);
+      expect(first?.id).toBe("opt-a");
+      expect(second?.id).toBe("opt-b");
+    });
+
+    it("ranks NotReally higher than Unranked", () => {
+      const allRankings = {
+        "user-1": {
+          "opt-a": RankingTier.NotReally,
+          "opt-b": RankingTier.Unranked,
+        },
+      };
+      const [first, second] = computeTopPicks(allRankings, [optA, optB], 2);
+      expect(first?.id).toBe("opt-a");
+      expect(second?.id).toBe("opt-b");
+    });
+
+    it("sums scores across multiple users", () => {
+      const allRankings = {
+        "user-1": { "opt-a": RankingTier.Yes, "opt-b": RankingTier.LoveIt },
+        "user-2": { "opt-a": RankingTier.LoveIt, "opt-b": RankingTier.Yes },
+        "user-3": { "opt-a": RankingTier.LoveIt, "opt-b": RankingTier.Maybe },
+      };
+      // opt-a: 3+4+4=11, opt-b: 4+3+2=9
+      const [first] = computeTopPicks(allRankings, [optA, optB], 2);
+      expect(first?.id).toBe("opt-a");
+    });
+
+    it("options not ranked by any user score 0 and appear last", () => {
+      const allRankings = {
+        "user-1": { "opt-a": RankingTier.NotReally },
+      };
+      const [first, second] = computeTopPicks(allRankings, [optA, optB], 2);
+      expect(first?.id).toBe("opt-a");
+      expect(second?.id).toBe("opt-b");
+    });
+
+    it("returns only topCount options", () => {
+      const allRankings = {
+        "user-1": {
+          "opt-a": RankingTier.LoveIt,
+          "opt-b": RankingTier.Yes,
+          "opt-c": RankingTier.Maybe,
+          "opt-d": RankingTier.NotReally,
+        },
+      };
+      const result = computeTopPicks(allRankings, [optA, optB, optC, optD], 2);
+      expect(result).toHaveLength(2);
+      expect(result[0]?.id).toBe("opt-a");
+      expect(result[1]?.id).toBe("opt-b");
+    });
+  });
+});

--- a/src/lib/ranking-score.ts
+++ b/src/lib/ranking-score.ts
@@ -1,0 +1,28 @@
+import type { Option } from "@/lib/types/option";
+import { RankingTier } from "@/lib/types/ranking";
+
+const TIER_SCORES: Record<RankingTier, number> = {
+  [RankingTier.LoveIt]: 4,
+  [RankingTier.Yes]: 3,
+  [RankingTier.Maybe]: 2,
+  [RankingTier.NotReally]: 1,
+  [RankingTier.Unranked]: 0,
+};
+
+export function computeTopPicks(
+  allRankings: Record<string, Record<string, RankingTier>>,
+  options: Option[],
+  topCount: number,
+): Option[] {
+  const scores: Record<string, number> = {};
+
+  for (const userRankings of Object.values(allRankings)) {
+    for (const [optionId, tier] of Object.entries(userRankings)) {
+      scores[optionId] = (scores[optionId] ?? 0) + TIER_SCORES[tier];
+    }
+  }
+
+  return [...options]
+    .sort((a, b) => (scores[b.id] ?? 0) - (scores[a.id] ?? 0))
+    .slice(0, topCount);
+}

--- a/src/server/data/rankings.spec.ts
+++ b/src/server/data/rankings.spec.ts
@@ -17,9 +17,8 @@ vi.mock("firebase-admin/database", () => ({
   }),
 }));
 
-const { getAllRankingsForPick, getRankingByUser, saveRanking } = await import(
-  "./rankings"
-);
+const { getAllRankingsForPick, getRankingByUser, saveRanking } =
+  await import("./rankings");
 
 describe("getAllRankingsForPick", () => {
   beforeEach(() => {

--- a/src/server/data/rankings.spec.ts
+++ b/src/server/data/rankings.spec.ts
@@ -1,32 +1,87 @@
-import { getDatabase } from "firebase-admin/database";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RankingTier } from "@/lib/types/ranking";
 
-import { getRankingByUser, saveRanking } from "./rankings";
-
-vi.mock("firebase-admin/database", () => ({
-  getDatabase: vi.fn(),
+const { mockGet, mockRef } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockRef: vi.fn(),
 }));
 
 vi.mock("@/lib/firebase/admin", () => ({
-  getAdminApp: vi.fn(() => "admin-app"),
+  getAdminApp: () => ({}),
 }));
 
-const getDatabaseMock = vi.mocked(getDatabase);
+vi.mock("firebase-admin/database", () => ({
+  getDatabase: () => ({
+    ref: mockRef,
+  }),
+}));
+
+const { getAllRankingsForPick, getRankingByUser, saveRanking } = await import(
+  "./rankings"
+);
+
+describe("getAllRankingsForPick", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRef.mockReturnValue({ get: mockGet });
+  });
+
+  it("returns an empty object when no snapshot exists", async () => {
+    mockGet.mockResolvedValue({ exists: () => false, val: () => null });
+
+    const result = await getAllRankingsForPick("pick-1");
+
+    expect(result).toEqual({});
+  });
+
+  it("returns parsed rankings for valid records", async () => {
+    const data = {
+      "user-1": { "opt-1": RankingTier.Yes, "opt-2": RankingTier.Maybe },
+      "user-2": { "opt-1": RankingTier.LoveIt },
+    };
+    mockGet.mockResolvedValue({ exists: () => true, val: () => data });
+
+    const result = await getAllRankingsForPick("pick-1");
+
+    expect(result).toEqual(data);
+  });
+
+  it("filters out records with malformed ranking values", async () => {
+    const data = {
+      "user-1": { "opt-1": RankingTier.Yes },
+      "user-2": { "opt-1": "not_a_valid_tier" },
+    };
+    mockGet.mockResolvedValue({ exists: () => true, val: () => data });
+
+    const result = await getAllRankingsForPick("pick-1");
+
+    expect(result).toEqual({ "user-1": { "opt-1": RankingTier.Yes } });
+    expect(result["user-2"]).toBeUndefined();
+  });
+
+  it("filters out non-object user records", async () => {
+    const data = {
+      "user-1": { "opt-1": RankingTier.Yes },
+      "user-2": null,
+      "user-3": "invalid",
+    };
+    mockGet.mockResolvedValue({ exists: () => true, val: () => data });
+
+    const result = await getAllRankingsForPick("pick-1");
+
+    expect(result).toEqual({ "user-1": { "opt-1": RankingTier.Yes } });
+  });
+});
 
 describe("getRankingByUser", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRef.mockReturnValue({ get: mockGet });
   });
 
   it("returns an empty object when no ranking exists for the user", async () => {
-    const get = vi
-      .fn()
-      .mockResolvedValue({ exists: () => false, val: () => null });
-    getDatabaseMock.mockReturnValue({
-      ref: () => ({ get }),
-    } as never);
+    mockGet.mockResolvedValue({ exists: () => false, val: () => null });
 
     const result = await getRankingByUser("pick-1", "user-1");
 
@@ -38,12 +93,7 @@ describe("getRankingByUser", () => {
       "opt-1": RankingTier.LoveIt,
       "opt-2": RankingTier.Maybe,
     };
-    const get = vi
-      .fn()
-      .mockResolvedValue({ exists: () => true, val: () => stored });
-    getDatabaseMock.mockReturnValue({
-      ref: () => ({ get }),
-    } as never);
+    mockGet.mockResolvedValue({ exists: () => true, val: () => stored });
 
     const result = await getRankingByUser("pick-1", "user-1");
 
@@ -58,8 +108,7 @@ describe("saveRanking", () => {
 
   it("writes the tier assignments to the correct Firebase path", async () => {
     const set = vi.fn().mockResolvedValue(undefined);
-    const ref = vi.fn().mockReturnValue({ set });
-    getDatabaseMock.mockReturnValue({ ref } as never);
+    mockRef.mockReturnValue({ set });
 
     const assignments = {
       "opt-1": RankingTier.Yes,
@@ -67,7 +116,7 @@ describe("saveRanking", () => {
     };
     await saveRanking("pick-42", "user-99", assignments);
 
-    expect(ref).toHaveBeenCalledWith("rankings/pick-42/user-99");
+    expect(mockRef).toHaveBeenCalledWith("rankings/pick-42/user-99");
     expect(set).toHaveBeenCalledWith(assignments);
   });
 });

--- a/src/server/data/rankings.spec.ts
+++ b/src/server/data/rankings.spec.ts
@@ -33,6 +33,7 @@ describe("getAllRankingsForPick", () => {
     const result = await getAllRankingsForPick("pick-1");
 
     expect(result).toEqual({});
+    expect(mockRef).toHaveBeenCalledWith("rankings/pick-1");
   });
 
   it("returns parsed rankings for valid records", async () => {

--- a/src/server/data/rankings.ts
+++ b/src/server/data/rankings.ts
@@ -1,7 +1,36 @@
 import { getDatabase } from "firebase-admin/database";
 
 import { getAdminApp } from "@/lib/firebase/admin";
-import type { RankingTier } from "@/lib/types/ranking";
+import { RankingTier } from "@/lib/types/ranking";
+
+const VALID_RANKING_TIERS = new Set<string>(Object.values(RankingTier));
+
+function isRankingRecord(val: unknown): val is Record<string, RankingTier> {
+  if (typeof val !== "object" || val === null) return false;
+  return Object.values(val as Record<string, unknown>).every((v) =>
+    VALID_RANKING_TIERS.has(v as string),
+  );
+}
+
+export async function getAllRankingsForPick(
+  pickId: string,
+): Promise<Record<string, Record<string, RankingTier>>> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db.ref(`rankings/${pickId}`).get();
+
+  if (!snap.exists()) return {};
+
+  const data = snap.val() as Record<string, unknown>;
+  const result: Record<string, Record<string, RankingTier>> = {};
+
+  for (const [userId, userRankings] of Object.entries(data)) {
+    if (isRankingRecord(userRankings)) {
+      result[userId] = userRankings;
+    }
+  }
+
+  return result;
+}
 
 export async function getRankingByUser(
   pickId: string,


### PR DESCRIPTION
Adds tier-based ranked-choice scoring to compute the top N picks on the pick detail page. When a pick is closed, all user tier rankings are fetched server-side and scored (LoveIt=4, Yes=3, Maybe=2, NotReally=1, Unranked=0); the top `topCount` options are passed as `topPicks` to the view.

Introduces `src/lib/types/ranking.ts` as the canonical home for `RankingTier` (re-exported from `TierRanking.copy.ts` for backward compatibility). Adds `getAllRankingsForPick` to the server data layer and a new `TopPicksView` component handling both the locked state (pick open) and revealed state (pick closed).

## Acceptance Criteria
- [x] Top N results displayed on pick detail page derived from ranked-choice calculation
- [x] N is the value set when the Pick was created (`pick.topCount`)
- [x] Top picks tab disabled and shows locked message while pick is open
- [x] Rankings fetched only when pick is closed (no unnecessary Firebase reads)

## Tests
15 tests added (9 scoring unit tests, 6 component tests), all passing. Total suite: 523 passing.

Closes #39

---
*Created by Claude Sonnet 4.6*