### PR TITLE
chore(infra): add pnpm install step to CLAUDE.md worktree setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ pnpm run env:validate # Validate deployment config files against schema
 pnpm run secrets-check # Config validation + gitleaks scan (also runs pre-commit)
 ```
 
+## Worktree Setup
+
+After creating a git worktree (`git worktree add .git-worktrees/<name> -b <branch> origin/main`), run `pnpm install --frozen-lockfile` inside the worktree before invoking any build, test, or lint command. pnpm's `node-modules` linker creates per-directory `node_modules` trees; a fresh worktree has none. The global store is already populated so this step only creates hardlinks — it takes a few seconds and requires no network access.
+
 ## Deployment Config
 
 Public (non-secret) environment config lives in `deployment/{env}.yml` and is validated against `deployment/schema.yml`. Only `NEXT_PUBLIC_*` and explicitly allowlisted keys are permitted; patterns matching `*SECRET*`, `*_TOKEN*`, or `*PRIVATE_KEY*` are hard-denied.


### PR DESCRIPTION
Adds a "Worktree Setup" section to `CLAUDE.md` (which is a symlink to `AGENTS.md`) immediately after the "Common Commands" block.

Sub-agents that create git worktrees were failing silently on `pnpm lint`, `pnpm test`, and `pnpm tsc` because pnpm's `node-modules` linker requires `pnpm install --frozen-lockfile` to be run inside each new worktree before any toolchain command works. The new section documents this requirement and notes that the install is fast (hardlinks from the populated global store, no network access).

## Acceptance Criteria
- [x] `CLAUDE.md` has a "Worktree Setup" section immediately after "Common Commands" that instructs agents to run `pnpm install --frozen-lockfile` in a new worktree before running any build/test/lint command
- [x] The note clarifies that `pnpm install` in a fresh worktree is fast (hardlinks from the global store, no downloading)

## Tests
No tests — documentation-only change.

Closes #216

---
*Created by Claude Sonnet 4.6*