### PR TITLE
fix(picks): fold updatePick into assertPickIsOpenForWrite transaction

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
@@ -6,14 +6,12 @@ const {
   mockGetVerifiedUid,
   mockGetGroupById,
   mockGetCategoryById,
-  mockAssertPickIsOpenForWrite,
-  mockUpdatePick,
+  mockUpdatePickIfOpen,
 } = vi.hoisted(() => ({
   mockGetVerifiedUid: vi.fn(),
   mockGetGroupById: vi.fn(),
   mockGetCategoryById: vi.fn(),
-  mockAssertPickIsOpenForWrite: vi.fn(),
-  mockUpdatePick: vi.fn(),
+  mockUpdatePickIfOpen: vi.fn(),
 }));
 
 vi.mock("@/server/utils/auth", () => ({
@@ -29,8 +27,7 @@ vi.mock("@/server/data/categories", () => ({
 }));
 
 vi.mock("@/server/data/picks", () => ({
-  assertPickIsOpenForWrite: mockAssertPickIsOpenForWrite,
-  updatePick: mockUpdatePick,
+  updatePickIfOpen: mockUpdatePickIfOpen,
   PICK_CLOSED_API_ERROR: "Pick is closed",
   PickNotFoundError: class PickNotFoundError extends Error {
     readonly code = "pick_not_found";
@@ -86,28 +83,18 @@ describe("PATCH /api/.../picks/[pickId]", () => {
       createdAt: new Date(),
       creatorId: "user-1",
     });
-    mockAssertPickIsOpenForWrite.mockResolvedValue({
-      id: "pick-1",
-      title: "Original Title",
-      description: "",
-      categoryId: "cat-1",
-      topCount: 1,
-      createdAt: new Date(),
-      creatorId: "user-1",
-      closedAt: undefined,
-    });
-    mockUpdatePick.mockResolvedValue(undefined);
+    mockUpdatePickIfOpen.mockResolvedValue(undefined);
   });
 
   describe("Calling PATCH on an open pick succeeds and returns 200", () => {
-    it("returns 200 and calls updatePick for an open pick", async () => {
+    it("returns 200 and calls updatePickIfOpen for an open pick", async () => {
       const response = await PATCH(
         makeRequest({ title: "New Title", description: "", topCount: 1 }),
         { params: Promise.resolve(baseParams) },
       );
 
       expect(response.status).toBe(200);
-      expect(mockUpdatePick).toHaveBeenCalledWith("cat-1", "pick-1", {
+      expect(mockUpdatePickIfOpen).toHaveBeenCalledWith("cat-1", "pick-1", {
         title: "New Title",
         description: "",
         topCount: 1,
@@ -117,8 +104,8 @@ describe("PATCH /api/.../picks/[pickId]", () => {
   });
 
   describe("Calling PATCH on a pick whose dueDate is in the past returns an error response and persists closedAt", () => {
-    it("returns 409 when assertPickIsOpenForWrite throws PickWriteClosedError", async () => {
-      mockAssertPickIsOpenForWrite.mockRejectedValue(
+    it("returns 409 when updatePickIfOpen throws PickWriteClosedError", async () => {
+      mockUpdatePickIfOpen.mockRejectedValue(
         new PickWriteClosedError(
           "Pick due date has passed. The pick has been closed and no longer accepts changes.",
         ),
@@ -130,11 +117,10 @@ describe("PATCH /api/.../picks/[pickId]", () => {
       );
 
       expect(response.status).toBe(409);
-      expect(mockUpdatePick).not.toHaveBeenCalled();
     });
 
     it("includes a user-readable error message in the 409 response", async () => {
-      mockAssertPickIsOpenForWrite.mockRejectedValue(
+      mockUpdatePickIfOpen.mockRejectedValue(
         new PickWriteClosedError(
           "Pick due date has passed. The pick has been closed and no longer accepts changes.",
         ),
@@ -149,38 +135,23 @@ describe("PATCH /api/.../picks/[pickId]", () => {
       expect(body.error).toBe("Pick is closed");
     });
 
-    it("calls assertPickIsOpenForWrite before updatePick", async () => {
-      const callOrder: string[] = [];
-      mockAssertPickIsOpenForWrite.mockImplementation(() => {
-        callOrder.push("assertPickIsOpenForWrite");
-        return Promise.resolve({
-          id: "pick-1",
-          title: "P",
-          description: "",
-          categoryId: "cat-1",
-          topCount: 1,
-          createdAt: new Date(),
-          creatorId: "user-1",
-          closedAt: undefined,
-        });
-      });
-      mockUpdatePick.mockImplementation(() => {
-        callOrder.push("updatePick");
-        return Promise.resolve();
-      });
-
+    it("calls updatePickIfOpen with categoryId and pickId", async () => {
       await PATCH(
         makeRequest({ title: "New Title", description: "", topCount: 1 }),
         { params: Promise.resolve(baseParams) },
       );
 
-      expect(callOrder).toEqual(["assertPickIsOpenForWrite", "updatePick"]);
+      expect(mockUpdatePickIfOpen).toHaveBeenCalledWith(
+        "cat-1",
+        "pick-1",
+        expect.any(Object),
+      );
     });
   });
 
   describe("Existing pick-not-found path still returns 404", () => {
-    it("returns 404 when pick not found is thrown from assertPickIsOpenForWrite", async () => {
-      mockAssertPickIsOpenForWrite.mockRejectedValue(new PickNotFoundError());
+    it("returns 404 when pick not found is thrown from updatePickIfOpen", async () => {
+      mockUpdatePickIfOpen.mockRejectedValue(new PickNotFoundError());
 
       const response = await PATCH(
         makeRequest({ title: "New Title", description: "", topCount: 1 }),
@@ -221,8 +192,8 @@ describe("PATCH /api/.../picks/[pickId]", () => {
     });
   });
 
-  describe("PATCH accepts YYYY-MM-DD dueDate and passes a Date to updatePick", () => {
-    it("passes the parsed Date to updatePick for a valid YYYY-MM-DD dueDate", async () => {
+  describe("PATCH accepts YYYY-MM-DD dueDate and passes a Date to updatePickIfOpen", () => {
+    it("passes the parsed Date to updatePickIfOpen for a valid YYYY-MM-DD dueDate", async () => {
       const response = await PATCH(
         makeRequest({
           title: "T",
@@ -234,7 +205,7 @@ describe("PATCH /api/.../picks/[pickId]", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(mockUpdatePick).toHaveBeenCalledWith(
+      expect(mockUpdatePickIfOpen).toHaveBeenCalledWith(
         "cat-1",
         "pick-1",
         expect.objectContaining({
@@ -245,7 +216,7 @@ describe("PATCH /api/.../picks/[pickId]", () => {
   });
 
   describe("PATCH clears dueDate when null or absent", () => {
-    it("passes dueDate: undefined to updatePick when dueDate is null", async () => {
+    it("passes dueDate: undefined to updatePickIfOpen when dueDate is null", async () => {
       const response = await PATCH(
         makeRequest({
           title: "T",
@@ -257,21 +228,21 @@ describe("PATCH /api/.../picks/[pickId]", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(mockUpdatePick).toHaveBeenCalledWith(
+      expect(mockUpdatePickIfOpen).toHaveBeenCalledWith(
         "cat-1",
         "pick-1",
         expect.objectContaining({ dueDate: undefined }),
       );
     });
 
-    it("passes dueDate: undefined to updatePick when dueDate is absent", async () => {
+    it("passes dueDate: undefined to updatePickIfOpen when dueDate is absent", async () => {
       const response = await PATCH(
         makeRequest({ title: "T", description: "", topCount: 1 }),
         { params: Promise.resolve(baseParams) },
       );
 
       expect(response.status).toBe(200);
-      expect(mockUpdatePick).toHaveBeenCalledWith(
+      expect(mockUpdatePickIfOpen).toHaveBeenCalledWith(
         "cat-1",
         "pick-1",
         expect.objectContaining({ dueDate: undefined }),

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.ts
@@ -3,11 +3,10 @@ import { NextResponse } from "next/server";
 import { getCategoryById } from "@/server/data/categories";
 import { getGroupById } from "@/server/data/groups";
 import {
-  assertPickIsOpenForWrite,
   PICK_CLOSED_API_ERROR,
   PickNotFoundError,
   PickWriteClosedError,
-  updatePick,
+  updatePickIfOpen,
 } from "@/server/data/picks";
 import { getVerifiedUid } from "@/server/utils/auth";
 
@@ -85,8 +84,18 @@ export async function PATCH(
     parsedDueDate = parsed;
   }
 
+  const title = body.title.trim();
+  const description =
+    typeof body.description === "string" ? body.description.trim() : "";
+  const topCount = body.topCount;
+
   try {
-    await assertPickIsOpenForWrite(categoryId, pickId);
+    await updatePickIfOpen(categoryId, pickId, {
+      title,
+      description,
+      topCount,
+      dueDate: parsedDueDate,
+    });
   } catch (err) {
     if (err instanceof PickWriteClosedError) {
       return NextResponse.json(
@@ -99,18 +108,6 @@ export async function PATCH(
     }
     throw err;
   }
-
-  const title = body.title.trim();
-  const description =
-    typeof body.description === "string" ? body.description.trim() : "";
-  const topCount = body.topCount;
-
-  await updatePick(categoryId, pickId, {
-    title,
-    description,
-    topCount,
-    dueDate: parsedDueDate,
-  });
 
   return NextResponse.json({ pickId });
 }

--- a/src/server/data/picks.spec.ts
+++ b/src/server/data/picks.spec.ts
@@ -10,6 +10,7 @@ import {
   hasPicks,
   PickNotFoundError,
   PickWriteClosedError,
+  updatePickIfOpen,
 } from "./picks";
 
 vi.mock("firebase-admin/database", () => ({
@@ -386,5 +387,204 @@ describe("closePick", () => {
     await expect(closePick("cat-123", "pick-123")).resolves.toBeUndefined();
     expect(storedPick.closedAt).toBeDefined();
     expect(storedPick.closedManually).toBeUndefined();
+  });
+});
+
+describe("updatePickIfOpen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies field updates atomically when the pick is open", async () => {
+    let storedPick = makeFirebasePickPublic({
+      title: "Old Title",
+      description: "Old desc",
+      topCount: 1,
+      dueDate: new Date("2025-01-20T12:00:00.000Z").getTime(),
+    });
+    const transaction = vi.fn(
+      (
+        update: (
+          currentData: FirebasePickPublic | null,
+        ) => FirebasePickPublic | undefined,
+      ) => {
+        const nextPick = update(storedPick);
+        if (nextPick !== undefined) storedPick = nextPick;
+        return {
+          snapshot: {
+            exists: () => true,
+            val: () => storedPick,
+          },
+        };
+      },
+    );
+
+    getDatabaseMock.mockReturnValue({
+      ref: () => ({ transaction }),
+    } as never);
+
+    await updatePickIfOpen(
+      "cat-123",
+      "pick-123",
+      {
+        title: "New Title",
+        description: "New desc",
+        topCount: 3,
+        dueDate: undefined,
+      },
+      new Date("2025-01-19T12:00:00.000Z"),
+    );
+
+    expect(storedPick.title).toBe("New Title");
+    expect(storedPick.description).toBe("New desc");
+    expect(storedPick.topCount).toBe(3);
+    expect(storedPick.dueDate).toBeUndefined();
+    expect(transaction).toHaveBeenCalledOnce();
+  });
+
+  it("clears description when an empty string is provided", async () => {
+    let storedPick = makeFirebasePickPublic({ description: "Old desc" });
+    const transaction = vi.fn(
+      (
+        update: (
+          currentData: FirebasePickPublic | null,
+        ) => FirebasePickPublic | undefined,
+      ) => {
+        const nextPick = update(storedPick);
+        if (nextPick !== undefined) storedPick = nextPick;
+        return {
+          snapshot: {
+            exists: () => true,
+            val: () => storedPick,
+          },
+        };
+      },
+    );
+
+    getDatabaseMock.mockReturnValue({
+      ref: () => ({ transaction }),
+    } as never);
+
+    await updatePickIfOpen("cat-123", "pick-123", {
+      title: "T",
+      description: "",
+      topCount: 1,
+      dueDate: undefined,
+    });
+
+    expect(storedPick.description).toBeUndefined();
+  });
+
+  it("throws PickWriteClosedError without modifying when the pick is already closed", async () => {
+    const closedAt = new Date("2025-01-18T12:00:00.000Z").getTime();
+    let storedPick = makeFirebasePickPublic({ closedAt });
+    const transaction = vi.fn(
+      (
+        update: (
+          currentData: FirebasePickPublic | null,
+        ) => FirebasePickPublic | undefined,
+      ) => {
+        const nextPick = update(storedPick);
+        storedPick = nextPick ?? storedPick;
+        return {
+          snapshot: {
+            exists: () => true,
+            val: () => storedPick,
+          },
+        };
+      },
+    );
+
+    getDatabaseMock.mockReturnValue({
+      ref: () => ({ transaction }),
+    } as never);
+
+    await expect(
+      updatePickIfOpen("cat-123", "pick-123", {
+        title: "T",
+        description: "",
+        topCount: 1,
+        dueDate: undefined,
+      }),
+    ).rejects.toMatchObject(
+      new PickWriteClosedError("Pick is closed and no longer accepts changes."),
+    );
+
+    expect(storedPick.closedAt).toBe(closedAt);
+    expect(storedPick.title).toBe("Best Picture");
+  });
+
+  it("atomically closes an overdue pick and throws PickWriteClosedError", async () => {
+    const now = new Date("2025-01-21T12:00:00.000Z");
+    let storedPick = makeFirebasePickPublic({
+      dueDate: new Date("2025-01-20T12:00:00.000Z").getTime(),
+    });
+    const transaction = vi.fn(
+      (
+        update: (
+          currentData: FirebasePickPublic | null,
+        ) => FirebasePickPublic | undefined,
+      ) => {
+        const nextPick = update(storedPick);
+        storedPick = nextPick ?? storedPick;
+        return {
+          snapshot: {
+            exists: () => true,
+            val: () => storedPick,
+          },
+        };
+      },
+    );
+
+    getDatabaseMock.mockReturnValue({
+      ref: () => ({ transaction }),
+    } as never);
+
+    await expect(
+      updatePickIfOpen(
+        "cat-123",
+        "pick-123",
+        { title: "T", description: "", topCount: 1, dueDate: undefined },
+        now,
+      ),
+    ).rejects.toMatchObject({
+      code: "pick_closed",
+      message:
+        "Pick due date has passed. The pick has been closed and no longer accepts changes.",
+    });
+
+    expect(storedPick.closedAt).toBe(now.getTime());
+    expect(storedPick.title).toBe("Best Picture");
+  });
+
+  it("throws PickNotFoundError when the pick does not exist", async () => {
+    const transaction = vi.fn(
+      (
+        update: (
+          currentData: FirebasePickPublic | null,
+        ) => FirebasePickPublic | undefined,
+      ) => {
+        update(null);
+        return {
+          snapshot: {
+            exists: () => false,
+            val: () => null,
+          },
+        };
+      },
+    );
+
+    getDatabaseMock.mockReturnValue({
+      ref: () => ({ transaction }),
+    } as never);
+
+    await expect(
+      updatePickIfOpen("cat-123", "pick-missing", {
+        title: "T",
+        description: "",
+        topCount: 1,
+        dueDate: undefined,
+      }),
+    ).rejects.toBeInstanceOf(PickNotFoundError);
   });
 });

--- a/src/server/data/picks.ts
+++ b/src/server/data/picks.ts
@@ -134,18 +134,65 @@ export async function createPick(
   return { id, createdAt };
 }
 
-export async function updatePick(
+export async function updatePickIfOpen(
   categoryId: string,
   pickId: string,
   updates: Pick<GroupPick, "title" | "description" | "topCount" | "dueDate">,
+  now: Date = new Date(),
 ): Promise<void> {
   const db = getDatabase(getAdminApp());
-  await db.ref(`categories/${categoryId}/picks/${pickId}`).update({
-    title: updates.title,
-    description: updates.description !== "" ? updates.description : null,
-    topCount: updates.topCount,
-    dueDate: updates.dueDate?.getTime() ?? null,
-  });
+  const pickRef = db.ref(`categories/${categoryId}/picks/${pickId}`);
+  const nowTimestamp = now.getTime();
+
+  const result = await pickRef.transaction(
+    (currentData: FirebasePickPublic | null) => {
+      if (currentData === null) return undefined;
+      if (currentData.closedAt !== undefined) return currentData;
+      if (
+        currentData.dueDate !== undefined &&
+        currentData.dueDate <= nowTimestamp
+      ) {
+        return { ...currentData, closedAt: nowTimestamp };
+      }
+
+      const next: FirebasePickPublic = {
+        ...currentData,
+        title: updates.title,
+        topCount: updates.topCount,
+      };
+
+      if (updates.description !== "") {
+        next.description = updates.description;
+      } else {
+        delete next.description;
+      }
+
+      if (updates.dueDate !== undefined) {
+        next.dueDate = updates.dueDate.getTime();
+      } else {
+        delete next.dueDate;
+      }
+
+      return next;
+    },
+  );
+
+  if (!result.snapshot.exists()) {
+    throw new PickNotFoundError();
+  }
+
+  const pick = firebaseToPick(
+    pickId,
+    result.snapshot.val() as FirebasePickPublic,
+  );
+
+  if (pick.closedAt !== undefined) {
+    throw new PickWriteClosedError(
+      pick.closedAt.getTime() === nowTimestamp
+        ? PICK_DUE_DATE_PASSED_ERROR
+        : PICK_CLOSED_ERROR,
+    );
+  }
 }
 
 export async function closePick(


### PR DESCRIPTION
Replace the two-step `assertPickIsOpenForWrite` + `updatePick` pattern in the PATCH pick route with a new `updatePickIfOpen` function that performs the open/closed/overdue check and the field update atomically in one Firebase RTDB transaction.

The previous pattern had a narrow TOCTOU race window: another request could close the pick between the preflight check and the subsequent write. The new function eliminates this window by checking state and applying updates inside the same transaction — the update only commits if the pick is open at the exact moment of the write.

## Acceptance Criteria
- [x] `updatePick` fields are applied inside the same Firebase transaction that checks open/closed state
- [x] If the pick is closed/not-found at transaction time, the write is rejected with no partial write
- [x] PATCH route returns 200 on success, 404 on not-found, 409 on closed pick — same external contract

## Tests
11 tests added (5 for `updatePickIfOpen` in `picks.spec.ts`, 6 updated in `route.spec.ts`), all 627 passing.

Closes #173

---
*Created by Claude Sonnet 4.5*