### PR TITLE
fix(picks): reject dueDate updates that set a past value

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PickNotFoundError, PickWriteClosedError } from "@/server/data/picks";
 
@@ -193,13 +193,22 @@ describe("PATCH /api/.../picks/[pickId]", () => {
   });
 
   describe("PATCH accepts YYYY-MM-DD dueDate and passes a Date to updatePickIfOpen", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("passes the parsed Date to updatePickIfOpen for a valid YYYY-MM-DD dueDate", async () => {
       const response = await PATCH(
         makeRequest({
           title: "T",
           description: "",
           topCount: 1,
-          dueDate: "2026-01-15",
+          dueDate: "2026-06-01",
         }),
         { params: Promise.resolve(baseParams) },
       );
@@ -209,7 +218,7 @@ describe("PATCH /api/.../picks/[pickId]", () => {
         "cat-1",
         "pick-1",
         expect.objectContaining({
-          dueDate: new Date("2026-01-15"),
+          dueDate: new Date("2026-06-01"),
         }),
       );
     });
@@ -247,6 +256,74 @@ describe("PATCH /api/.../picks/[pickId]", () => {
         "pick-1",
         expect.objectContaining({ dueDate: undefined }),
       );
+    });
+  });
+
+  describe("PATCH rejects a dueDate that is already in the past", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns 400 when dueDate is in the past", async () => {
+      const response = await PATCH(
+        makeRequest({
+          title: "T",
+          description: "",
+          topCount: 1,
+          dueDate: "2026-03-01",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("includes a user-readable error message for a past dueDate", async () => {
+      const response = await PATCH(
+        makeRequest({
+          title: "T",
+          description: "",
+          topCount: 1,
+          dueDate: "2026-03-01",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("dueDate cannot be in the past");
+    });
+
+    it("does not call assertPickIsOpenForWrite when dueDate is in the past", async () => {
+      await PATCH(
+        makeRequest({
+          title: "T",
+          description: "",
+          topCount: 1,
+          dueDate: "2026-03-01",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(mockUpdatePickIfOpen).not.toHaveBeenCalled();
+    });
+
+    it("returns 200 for a dueDate in the future", async () => {
+      const response = await PATCH(
+        makeRequest({
+          title: "T",
+          description: "",
+          topCount: 1,
+          dueDate: "2026-06-01",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(response.status).toBe(200);
     });
   });
 });

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.spec.ts
@@ -298,7 +298,7 @@ describe("PATCH /api/.../picks/[pickId]", () => {
       expect(body.error).toBe("dueDate cannot be in the past");
     });
 
-    it("does not call assertPickIsOpenForWrite when dueDate is in the past", async () => {
+    it("does not call updatePickIfOpen when dueDate is in the past", async () => {
       await PATCH(
         makeRequest({
           title: "T",

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/[pickId]/route.ts
@@ -76,6 +76,13 @@ export async function PATCH(
   }
   const parsedDueDate = dueDateResult.date;
 
+  if (parsedDueDate !== undefined && parsedDueDate.getTime() <= Date.now()) {
+    return NextResponse.json(
+      { error: "dueDate cannot be in the past" },
+      { status: 400 },
+    );
+  }
+
   const title = body.title.trim();
   const description =
     typeof body.description === "string" ? body.description.trim() : "";


### PR DESCRIPTION
Adds a validation guard to the PATCH pick route that rejects any `dueDate` value already in the past with a 400 response, preventing silently setting a pick into an immediately-closeable state.

The check runs after the YYYY-MM-DD format validation and before the open-write assertion, so past-date requests are rejected eagerly without touching Firebase.

## Acceptance Criteria
- [x] PATCH with a `dueDate` already in the past returns 400 with a clear error message
- [x] PATCH with a `dueDate` in the future succeeds (200)
- [x] PATCH with `dueDate: null` or absent succeeds (clearing dueDate is allowed)

## Tests
4 tests added, all passing.

Closes #174

---
*Created by Claude Sonnet 4.5*