### PR TITLE
feat(picks): tier-bucket ranking UI (MVP ranking interaction)

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/route.spec.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { RankingMode } from "@/lib/types/pick";
+
 const {
   mockGetVerifiedUid,
   mockGetGroupById,
@@ -246,6 +248,84 @@ describe("POST /api/.../categories/[categoryId]/picks", () => {
       );
 
       expect(response.status).toBe(201);
+    });
+  });
+
+  describe("rankingMode handling", () => {
+    it("defaults rankingMode to TierBuckets when omitted", async () => {
+      const response = await POST(
+        makeRequest({ title: "Best Pizza", topCount: 3 }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockCreatePick).toHaveBeenCalledWith(
+        expect.objectContaining({ rankingMode: RankingMode.TierBuckets }),
+      );
+    });
+
+    it("passes through rankingMode tier-buckets", async () => {
+      const response = await POST(
+        makeRequest({
+          title: "Best Pizza",
+          topCount: 3,
+          rankingMode: "tier-buckets",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockCreatePick).toHaveBeenCalledWith(
+        expect.objectContaining({ rankingMode: RankingMode.TierBuckets }),
+      );
+    });
+
+    it("passes through rankingMode stack-rank", async () => {
+      const response = await POST(
+        makeRequest({
+          title: "Best Pizza",
+          topCount: 3,
+          rankingMode: "stack-rank",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockCreatePick).toHaveBeenCalledWith(
+        expect.objectContaining({ rankingMode: RankingMode.StackRank }),
+      );
+    });
+
+    it("passes through rankingMode head-to-head", async () => {
+      const response = await POST(
+        makeRequest({
+          title: "Best Pizza",
+          topCount: 3,
+          rankingMode: "head-to-head",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockCreatePick).toHaveBeenCalledWith(
+        expect.objectContaining({ rankingMode: RankingMode.HeadToHead }),
+      );
+    });
+
+    it("returns 400 for an invalid rankingMode value", async () => {
+      const response = await POST(
+        makeRequest({
+          title: "Best Pizza",
+          topCount: 3,
+          rankingMode: "invalid-value",
+        }),
+        { params: Promise.resolve(baseParams) },
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.error).toBe("Invalid rankingMode");
+      expect(mockCreatePick).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { RankingMode } from "@/lib/types/pick";
 import { getCategoryById } from "@/server/data/categories";
 import { getGroupById } from "@/server/data/groups";
 import { createPick, getPicksByCategory } from "@/server/data/picks";
@@ -80,6 +81,7 @@ export async function POST(
     description: unknown;
     topCount: unknown;
     dueDate: unknown;
+    rankingMode: unknown;
   };
   try {
     body = (await request.json()) as {
@@ -87,6 +89,7 @@ export async function POST(
       description: unknown;
       topCount: unknown;
       dueDate: unknown;
+      rankingMode: unknown;
     };
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
@@ -117,6 +120,13 @@ export async function POST(
   }
   const dueDate = dueDateResult.date;
 
+  const rankingMode =
+    body.rankingMode === RankingMode.StackRank
+      ? RankingMode.StackRank
+      : body.rankingMode === RankingMode.HeadToHead
+        ? RankingMode.HeadToHead
+        : RankingMode.TierBuckets;
+
   const { id: pickId, createdAt } = await createPick({
     title,
     description,
@@ -124,6 +134,7 @@ export async function POST(
     creatorId: uid,
     topCount,
     dueDate,
+    rankingMode,
   });
 
   return NextResponse.json(

--- a/src/app/api/groups/[id]/categories/[categoryId]/picks/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/picks/route.ts
@@ -120,12 +120,16 @@ export async function POST(
   }
   const dueDate = dueDateResult.date;
 
-  const rankingMode =
-    body.rankingMode === RankingMode.StackRank
-      ? RankingMode.StackRank
-      : body.rankingMode === RankingMode.HeadToHead
-        ? RankingMode.HeadToHead
-        : RankingMode.TierBuckets;
+  let rankingMode: RankingMode;
+  if (body.rankingMode === undefined) {
+    rankingMode = RankingMode.TierBuckets;
+  } else if (
+    Object.values(RankingMode).includes(body.rankingMode as RankingMode)
+  ) {
+    rankingMode = body.rankingMode as RankingMode;
+  } else {
+    return NextResponse.json({ error: "Invalid rankingMode" }, { status: 400 });
+  }
 
   const { id: pickId, createdAt } = await createPick({
     title,

--- a/src/app/groups/[id]/GroupDetailView.spec.tsx
+++ b/src/app/groups/[id]/GroupDetailView.spec.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { InviteMode } from "@/lib/types/invite";
+import { RankingMode } from "@/lib/types/pick";
 
 import { GROUP_DETAIL_COPY } from "./copy";
 import { GroupDetailView } from "./GroupDetailView";
@@ -153,6 +154,7 @@ describe("GroupDetailView", () => {
       topCount: 1,
       createdAt: new Date("2025-01-01"),
       creatorId: "user-123",
+      rankingMode: RankingMode.TierBuckets,
     };
     renderView({
       categories: [category],
@@ -180,6 +182,7 @@ describe("GroupDetailView", () => {
       createdAt: new Date("2025-01-01"),
       creatorId: "user-123",
       closedAt: new Date("2025-06-01"),
+      rankingMode: RankingMode.TierBuckets,
     };
     renderView({
       categories: [category],
@@ -206,6 +209,7 @@ describe("GroupDetailView", () => {
       topCount: 1,
       createdAt: new Date("2025-01-01"),
       creatorId: "user-123",
+      rankingMode: RankingMode.TierBuckets,
     };
     renderView({
       categories: [category],
@@ -233,6 +237,7 @@ describe("GroupDetailView", () => {
       topCount: 1,
       createdAt: new Date("2025-01-01"),
       creatorId: "user-123",
+      rankingMode: RankingMode.TierBuckets,
     };
     renderView({
       categories: [category],

--- a/src/app/groups/[id]/GroupDetailView.stories.tsx
+++ b/src/app/groups/[id]/GroupDetailView.stories.tsx
@@ -4,6 +4,7 @@ import type { Category } from "@/lib/types/category";
 import type { Group } from "@/lib/types/group";
 import { InviteMode } from "@/lib/types/invite";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 import { GroupDetailView } from "./GroupDetailView";
 
@@ -53,6 +54,7 @@ const mockFridayFlick: GroupPick = {
   dueDate: new Date("2025-06-07"),
   createdAt: new Date("2025-01-15T12:00:00.000Z"),
   creatorId: "user-123",
+  rankingMode: RankingMode.TierBuckets,
 };
 
 const mockBeachWeekRead: GroupPick = {
@@ -62,6 +64,7 @@ const mockBeachWeekRead: GroupPick = {
   topCount: 1,
   createdAt: new Date("2025-01-16T12:00:00.000Z"),
   creatorId: "user-123",
+  rankingMode: RankingMode.TierBuckets,
 };
 
 const mockDateNightFilm: GroupPick = {
@@ -72,6 +75,7 @@ const mockDateNightFilm: GroupPick = {
   closedAt: new Date("2025-03-24"),
   createdAt: new Date("2025-01-10T12:00:00.000Z"),
   creatorId: "user-456",
+  rankingMode: RankingMode.TierBuckets,
 };
 
 const meta: Meta<typeof GroupDetailView> = {

--- a/src/app/groups/[id]/categories/CategoryListView.spec.tsx
+++ b/src/app/groups/[id]/categories/CategoryListView.spec.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { Category } from "@/lib/types/category";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 import { CategoryListView } from "./CategoryListView";
 import { CATEGORY_COPY } from "./copy";
@@ -32,6 +33,7 @@ function makePick(overrides?: Partial<GroupPick>): GroupPick {
     categoryId: "cat-1",
     createdAt: new Date("2025-01-15T12:00:00.000Z"),
     creatorId: "user-1",
+    rankingMode: RankingMode.TierBuckets,
     ...overrides,
   };
 }

--- a/src/app/groups/[id]/categories/CategoryListView.stories.tsx
+++ b/src/app/groups/[id]/categories/CategoryListView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import type { Category } from "@/lib/types/category";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 import { CategoryListView } from "./CategoryListView";
 import { CATEGORY_COPY } from "./copy";
@@ -33,6 +34,7 @@ const mockPicks: GroupPick[] = [
     categoryId: "cat-1",
     createdAt: new Date("2024-01-10"),
     creatorId: "user-1",
+    rankingMode: RankingMode.TierBuckets,
   },
   {
     id: "pick-2",
@@ -41,6 +43,7 @@ const mockPicks: GroupPick[] = [
     categoryId: "cat-1",
     createdAt: new Date("2024-01-11"),
     creatorId: "user-2",
+    rankingMode: RankingMode.TierBuckets,
   },
 ];
 

--- a/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.spec.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Category } from "@/lib/types/category";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 import { CategoryDetailView } from "./CategoryDetailView";
 import { CATEGORY_DETAIL_COPY } from "./copy";
@@ -39,6 +40,7 @@ function makePick(overrides?: Partial<GroupPick>): GroupPick {
     closedAt: undefined,
     createdAt: new Date("2025-01-20T12:00:00.000Z"),
     creatorId: "user-1",
+    rankingMode: RankingMode.TierBuckets,
     ...overrides,
   };
 }

--- a/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import type { Category } from "@/lib/types/category";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 import { CategoryDetailView } from "./CategoryDetailView";
 
@@ -24,6 +25,7 @@ const picks: GroupPick[] = [
     closedAt: undefined,
     createdAt: new Date("2025-01-20T12:00:00.000Z"),
     creatorId: "user-1",
+    rankingMode: RankingMode.TierBuckets,
   },
   {
     id: "pick-closed",
@@ -35,6 +37,7 @@ const picks: GroupPick[] = [
     closedManually: true,
     createdAt: new Date("2025-01-20T12:00:00.000Z"),
     creatorId: "user-1",
+    rankingMode: RankingMode.TierBuckets,
   },
 ];
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.spec.tsx
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Option } from "@/lib/types/option";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 vi.mock("@/services/rankings", () => ({
   saveRankings: vi.fn().mockResolvedValue(undefined),
@@ -84,6 +85,7 @@ function makePick(overrides?: Partial<GroupPick>): GroupPick {
     categoryId: "cat-1",
     createdAt: new Date("2025-01-01T00:00:00.000Z"),
     creatorId: "user-1",
+    rankingMode: RankingMode.TierBuckets,
     ...overrides,
   };
 }

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import type { Option } from "@/lib/types/option";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 import { PickDetailView } from "./PickDetailView";
 
@@ -12,6 +13,7 @@ const mockPick: GroupPick = {
   categoryId: "cat-1",
   createdAt: new Date("2025-01-01T00:00:00.000Z"),
   creatorId: "user-1",
+  rankingMode: RankingMode.TierBuckets,
 };
 
 const mockClosedPick: GroupPick = {

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.copy.ts
@@ -6,7 +6,7 @@ export const TIER_ORDER = [
   RankingTier.LoveIt,
   RankingTier.Yes,
   RankingTier.Maybe,
-  RankingTier.NotReally,
+  RankingTier.NotForMe,
   RankingTier.Unranked,
 ] as const;
 
@@ -14,7 +14,7 @@ export const TIER_RANKING_COPY = {
   tiers: {
     [RankingTier.LoveIt]: "Love it",
     [RankingTier.Maybe]: "Maybe",
-    [RankingTier.NotReally]: "Not really",
+    [RankingTier.NotForMe]: "Not for me",
     [RankingTier.Unranked]: "Unranked",
     [RankingTier.Yes]: "Yes",
   },

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRanking.spec.tsx
@@ -182,13 +182,13 @@ describe("TierRanking", () => {
         TIER_RANKING_COPY.tiers[RankingTier.Maybe],
       );
 
-      // Maybe → NotReally
+      // Maybe → NotForMe
       fireEvent.click(getChip());
       expect(getTierSectionFor(getChip())).toBe(
-        TIER_RANKING_COPY.tiers[RankingTier.NotReally],
+        TIER_RANKING_COPY.tiers[RankingTier.NotForMe],
       );
 
-      // NotReally → Unranked
+      // NotForMe → Unranked
       fireEvent.click(getChip());
       expect(getTierSectionFor(getChip())).toBe(
         TIER_RANKING_COPY.tiers[RankingTier.Unranked],

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.spec.tsx
@@ -57,7 +57,7 @@ describe("TierRankingView", () => {
       ).toBeDefined();
     });
 
-    it("renders the Not really tier header", () => {
+    it("renders the Not for me tier header", () => {
       render(
         <TierRankingView
           options={[]}
@@ -66,7 +66,7 @@ describe("TierRankingView", () => {
         />,
       );
       expect(
-        screen.getByText(TIER_RANKING_COPY.tiers[RankingTier.NotReally]),
+        screen.getByText(TIER_RANKING_COPY.tiers[RankingTier.NotForMe]),
       ).toBeDefined();
     });
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/TierRankingView.stories.tsx
@@ -44,7 +44,7 @@ export const MixedTiers: Story = {
       "opt-1": RankingTier.LoveIt,
       "opt-2": RankingTier.Yes,
       "opt-3": RankingTier.Maybe,
-      "opt-4": RankingTier.NotReally,
+      "opt-4": RankingTier.NotForMe,
     },
   },
 };

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickForm.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickForm.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { RankingMode } from "@/lib/types/pick";
 import { createPick } from "@/services/picks";
 
 import { CREATE_PICK_COPY } from "./copy";
@@ -24,6 +25,9 @@ export function CreatePickForm({
   const [description, setDescription] = useState("");
   const [topCount, setTopCount] = useState(3);
   const [dueDate, setDueDate] = useState("");
+  const [rankingMode, setRankingMode] = useState<RankingMode>(
+    RankingMode.TierBuckets,
+  );
   const [error, setError] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
 
@@ -43,6 +47,7 @@ export function CreatePickForm({
         description.trim() || undefined,
         topCount,
         dueDate || undefined,
+        rankingMode,
       );
       router.push(
         `/groups/${groupId}/categories/${categoryId}/picks/${pickId}`,
@@ -64,6 +69,8 @@ export function CreatePickForm({
       onTopCountChange={setTopCount}
       dueDate={dueDate}
       onDueDateChange={setDueDate}
+      rankingMode={rankingMode}
+      onRankingModeChange={setRankingMode}
       hasPriorPicks={hasPriorPicks}
       onSubmit={(e) => void handleSubmit(e)}
       onCancel={() => {

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.spec.tsx
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { RankingMode } from "@/lib/types/pick";
+
 import { CREATE_PICK_COPY } from "./copy";
 import { CreatePickFormView } from "./CreatePickFormView";
 
@@ -16,6 +18,8 @@ describe("CreatePickFormView", () => {
     onTopCountChange: vi.fn(),
     dueDate: "",
     onDueDateChange: vi.fn(),
+    rankingMode: RankingMode.TierBuckets,
+    onRankingModeChange: vi.fn(),
     hasPriorPicks: false,
     onSubmit: vi.fn(),
     onCancel: vi.fn(),
@@ -187,6 +191,56 @@ describe("CreatePickFormView", () => {
       const error = "Something went wrong.";
       render(<CreatePickFormView {...defaultProps} error={error} />);
       expect(screen.getByText(error)).toBeDefined();
+    });
+  });
+
+  describe("ranking mode selector", () => {
+    it("renders the ranking mode section label", () => {
+      render(<CreatePickFormView {...defaultProps} />);
+      expect(screen.getByText(CREATE_PICK_COPY.rankingModeLabel)).toBeDefined();
+    });
+
+    it("renders the Tier Buckets option as enabled", () => {
+      render(<CreatePickFormView {...defaultProps} />);
+      const tierBucketsButton = screen.getByRole("radio", {
+        name: CREATE_PICK_COPY.rankingModes.tierBuckets,
+      });
+      expect(tierBucketsButton.disabled).toBe(false);
+    });
+
+    it("renders the Stack Rank option as disabled", () => {
+      render(<CreatePickFormView {...defaultProps} />);
+      const stackRankButton = screen.getByRole("radio", {
+        name: new RegExp(CREATE_PICK_COPY.rankingModes.stackRank),
+      });
+      expect(stackRankButton.disabled).toBe(true);
+    });
+
+    it("renders the Head-to-Head option as disabled", () => {
+      render(<CreatePickFormView {...defaultProps} />);
+      const headToHeadButton = screen.getByRole("radio", {
+        name: new RegExp(CREATE_PICK_COPY.rankingModes.headToHead),
+      });
+      expect(headToHeadButton.disabled).toBe(true);
+    });
+
+    it("calls onRankingModeChange when Tier Buckets is selected", () => {
+      const onRankingModeChange = vi.fn();
+      // Render with a non-TierBuckets mode so the TierBuckets radio is unchecked
+      // and clicking it fires onChange
+      render(
+        <CreatePickFormView
+          {...defaultProps}
+          rankingMode={RankingMode.StackRank}
+          onRankingModeChange={onRankingModeChange}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("radio", {
+          name: CREATE_PICK_COPY.rankingModes.tierBuckets,
+        }),
+      );
+      expect(onRankingModeChange).toHaveBeenCalledWith(RankingMode.TierBuckets);
     });
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { RankingMode } from "@/lib/types/pick";
 
 import { CREATE_PICK_COPY } from "./copy";
 
@@ -16,6 +17,8 @@ interface CreatePickFormViewProps {
   onTopCountChange: (topCount: number) => void;
   dueDate: string;
   onDueDateChange: (dueDate: string) => void;
+  rankingMode: RankingMode;
+  onRankingModeChange: (mode: RankingMode) => void;
   hasPriorPicks: boolean;
   onSubmit: (e: React.SyntheticEvent) => void;
   onCancel: () => void;
@@ -32,6 +35,8 @@ export function CreatePickFormView({
   onTopCountChange,
   dueDate,
   onDueDateChange,
+  rankingMode,
+  onRankingModeChange,
   hasPriorPicks,
   onSubmit,
   onCancel,
@@ -121,6 +126,55 @@ export function CreatePickFormView({
             disabled={loading}
           />
         </div>
+
+        <fieldset className="space-y-1">
+          <legend className="text-sm font-medium">
+            {CREATE_PICK_COPY.rankingModeLabel}
+          </legend>
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="ranking-mode"
+                value={RankingMode.TierBuckets}
+                checked={rankingMode === RankingMode.TierBuckets}
+                onChange={() => {
+                  onRankingModeChange(RankingMode.TierBuckets);
+                }}
+                disabled={loading}
+              />
+              {CREATE_PICK_COPY.rankingModes.tierBuckets}
+            </label>
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="radio"
+                name="ranking-mode"
+                value={RankingMode.StackRank}
+                checked={rankingMode === RankingMode.StackRank}
+                onChange={() => {
+                  onRankingModeChange(RankingMode.StackRank);
+                }}
+                disabled
+              />
+              {CREATE_PICK_COPY.rankingModes.stackRank}{" "}
+              {CREATE_PICK_COPY.rankingModesPostMvp}
+            </label>
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="radio"
+                name="ranking-mode"
+                value={RankingMode.HeadToHead}
+                checked={rankingMode === RankingMode.HeadToHead}
+                onChange={() => {
+                  onRankingModeChange(RankingMode.HeadToHead);
+                }}
+                disabled
+              />
+              {CREATE_PICK_COPY.rankingModes.headToHead}{" "}
+              {CREATE_PICK_COPY.rankingModesPostMvp}
+            </label>
+          </div>
+        </fieldset>
 
         {error && <p className="text-sm text-red-600">{error}</p>}
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/copy.ts
@@ -10,6 +10,13 @@ export const CREATE_PICK_COPY = {
   priorPicksBannerBody:
     "This category already has picks. The new pick will be listed alongside them.",
   priorPicksBannerTitle: "Prior picks exist",
+  rankingModeLabel: "Ranking mode",
+  rankingModes: {
+    headToHead: "Head-to-head",
+    stackRank: "Stack rank",
+    tierBuckets: "Tier buckets",
+  },
+  rankingModesPostMvp: "(post-MVP)",
   submitButton: "Create pick",
   title: "Create a pick",
   titleLabel: "Pick name",

--- a/src/lib/firebase/schema/pick.spec.ts
+++ b/src/lib/firebase/schema/pick.spec.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { RankingMode } from "@/lib/types/pick";
+
 import {
   type FirebasePickPublic,
   firebaseToPick,
@@ -274,6 +276,54 @@ describe("firebaseToPick", () => {
     const result = firebaseToPick("pick-xyz", data);
 
     expect(result.closedManually).toBeUndefined();
+  });
+});
+
+describe("pickToFirebase rankingMode", () => {
+  it("serializes rankingMode when provided", () => {
+    const result = pickToFirebase({
+      title: "Movie",
+      topCount: 1,
+      categoryId: "cat-abc",
+      createdAt: FIXED_DATE,
+      creatorId: "user-abc",
+      rankingMode: RankingMode.TierBuckets,
+    });
+
+    expect(result.rankingMode).toBe(RankingMode.TierBuckets);
+  });
+
+  it("omits rankingMode when undefined", () => {
+    const result = pickToFirebase({
+      title: "Movie",
+      topCount: 1,
+      categoryId: "cat-abc",
+      createdAt: FIXED_DATE,
+      creatorId: "user-abc",
+      rankingMode: undefined,
+    });
+
+    expect(result.rankingMode).toBeUndefined();
+  });
+});
+
+describe("firebaseToPick rankingMode", () => {
+  it("deserializes rankingMode when present", () => {
+    const data = makeFirebasePickPublic({
+      rankingMode: RankingMode.TierBuckets,
+    });
+
+    const result = firebaseToPick("pick-xyz", data);
+
+    expect(result.rankingMode).toBe(RankingMode.TierBuckets);
+  });
+
+  it("defaults rankingMode to TierBuckets when absent", () => {
+    const data = makeFirebasePickPublic({ rankingMode: undefined });
+
+    const result = firebaseToPick("pick-xyz", data);
+
+    expect(result.rankingMode).toBe(RankingMode.TierBuckets);
   });
 });
 

--- a/src/lib/firebase/schema/pick.ts
+++ b/src/lib/firebase/schema/pick.ts
@@ -1,4 +1,5 @@
 import type { GroupPick, PickOption } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 export interface FirebasePickOption {
   ownerIds: string[];
@@ -16,6 +17,7 @@ export interface FirebasePickPublic {
   closedManually?: boolean;
   createdAt: number;
   creatorId: string;
+  rankingMode?: string;
 }
 
 function pickOptionToFirebase(option: PickOption): FirebasePickOption {
@@ -49,7 +51,7 @@ export function pickToFirebase(
     | "options"
     | "closedAt"
     | "closedManually"
-  >,
+  > & { rankingMode?: RankingMode },
 ): FirebasePickPublic {
   const options =
     pick.options === undefined
@@ -72,6 +74,7 @@ export function pickToFirebase(
     creatorId: pick.creatorId,
     closedAt: pick.closedAt?.getTime(),
     closedManually: pick.closedManually,
+    rankingMode: pick.rankingMode,
   };
 }
 
@@ -92,6 +95,13 @@ export function firebaseToPick(
           firebaseToPickOption(optionId, optionData),
         );
 
+  const rankingMode =
+    data.rankingMode === RankingMode.StackRank
+      ? RankingMode.StackRank
+      : data.rankingMode === RankingMode.HeadToHead
+        ? RankingMode.HeadToHead
+        : RankingMode.TierBuckets;
+
   return {
     id,
     options,
@@ -108,6 +118,7 @@ export function firebaseToPick(
         ? new Date(data.closedAt)
         : undefined,
     closedManually: data.closedManually,
+    rankingMode,
   };
 }
 

--- a/src/lib/ranking-score.spec.ts
+++ b/src/lib/ranking-score.spec.ts
@@ -52,11 +52,11 @@ describe("computeTopPicks", () => {
       expect(second?.id).toBe("opt-b");
     });
 
-    it("ranks Maybe higher than NotReally", () => {
+    it("ranks Maybe higher than NotForMe", () => {
       const allRankings = {
         "user-1": {
           "opt-a": RankingTier.Maybe,
-          "opt-b": RankingTier.NotReally,
+          "opt-b": RankingTier.NotForMe,
         },
       };
       const [first, second] = computeTopPicks(allRankings, [optA, optB], 2);
@@ -64,10 +64,10 @@ describe("computeTopPicks", () => {
       expect(second?.id).toBe("opt-b");
     });
 
-    it("ranks NotReally higher than Unranked", () => {
+    it("ranks NotForMe higher than Unranked", () => {
       const allRankings = {
         "user-1": {
-          "opt-a": RankingTier.NotReally,
+          "opt-a": RankingTier.NotForMe,
           "opt-b": RankingTier.Unranked,
         },
       };
@@ -89,7 +89,7 @@ describe("computeTopPicks", () => {
 
     it("options not ranked by any user score 0 and appear last", () => {
       const allRankings = {
-        "user-1": { "opt-a": RankingTier.NotReally },
+        "user-1": { "opt-a": RankingTier.NotForMe },
       };
       const [first, second] = computeTopPicks(allRankings, [optA, optB], 2);
       expect(first?.id).toBe("opt-a");
@@ -102,7 +102,7 @@ describe("computeTopPicks", () => {
           "opt-a": RankingTier.LoveIt,
           "opt-b": RankingTier.Yes,
           "opt-c": RankingTier.Maybe,
-          "opt-d": RankingTier.NotReally,
+          "opt-d": RankingTier.NotForMe,
         },
       };
       const result = computeTopPicks(allRankings, [optA, optB, optC, optD], 2);

--- a/src/lib/ranking-score.ts
+++ b/src/lib/ranking-score.ts
@@ -5,7 +5,7 @@ const TIER_SCORES: Record<RankingTier, number> = {
   [RankingTier.LoveIt]: 4,
   [RankingTier.Yes]: 3,
   [RankingTier.Maybe]: 2,
-  [RankingTier.NotReally]: 1,
+  [RankingTier.NotForMe]: 1,
   [RankingTier.Unranked]: 0,
 };
 

--- a/src/lib/types/pick.ts
+++ b/src/lib/types/pick.ts
@@ -1,3 +1,9 @@
+export enum RankingMode {
+  HeadToHead = "head-to-head",
+  StackRank = "stack-rank",
+  TierBuckets = "tier-buckets",
+}
+
 export interface PickOption {
   id: string;
   ownerIds: string[];
@@ -15,5 +21,6 @@ export interface GroupPick {
   closedManually?: boolean;
   createdAt: Date;
   creatorId: string;
+  rankingMode: RankingMode;
   options?: PickOption[];
 }

--- a/src/lib/types/ranking.ts
+++ b/src/lib/types/ranking.ts
@@ -1,7 +1,7 @@
 export enum RankingTier {
   LoveIt = "love_it",
   Maybe = "maybe",
-  NotReally = "not_really",
+  NotForMe = "not_for_me",
   Unranked = "unranked",
   Yes = "yes",
 }

--- a/src/server/data/picks.ts
+++ b/src/server/data/picks.ts
@@ -6,8 +6,7 @@ import {
   firebaseToPick,
   pickToFirebase,
 } from "@/lib/firebase/schema/pick";
-import type { GroupPick } from "@/lib/types/pick";
-import { RankingMode } from "@/lib/types/pick";
+import type { GroupPick, RankingMode } from "@/lib/types/pick";
 
 export const PICK_CLOSED_API_ERROR = "Pick is closed";
 const PICK_CLOSED_ERROR = "Pick is closed and no longer accepts changes.";

--- a/src/server/data/picks.ts
+++ b/src/server/data/picks.ts
@@ -7,6 +7,7 @@ import {
   pickToFirebase,
 } from "@/lib/firebase/schema/pick";
 import type { GroupPick } from "@/lib/types/pick";
+import { RankingMode } from "@/lib/types/pick";
 
 export const PICK_CLOSED_API_ERROR = "Pick is closed";
 const PICK_CLOSED_ERROR = "Pick is closed and no longer accepts changes.";
@@ -126,6 +127,7 @@ export async function createPick(
   pick: Pick<GroupPick, "title" | "categoryId" | "creatorId" | "topCount"> & {
     description?: string;
     dueDate?: Date;
+    rankingMode?: RankingMode;
   },
 ): Promise<{ id: string; createdAt: Date }> {
   const db = getDatabase(getAdminApp());

--- a/src/server/data/rankings.spec.ts
+++ b/src/server/data/rankings.spec.ts
@@ -112,7 +112,7 @@ describe("saveRanking", () => {
 
     const assignments = {
       "opt-1": RankingTier.Yes,
-      "opt-2": RankingTier.NotReally,
+      "opt-2": RankingTier.NotForMe,
     };
     await saveRanking("pick-42", "user-99", assignments);
 

--- a/src/services/picks.ts
+++ b/src/services/picks.ts
@@ -1,3 +1,5 @@
+import type { RankingMode } from "@/lib/types/pick";
+
 export async function createPick(
   groupId: string,
   categoryId: string,
@@ -5,13 +7,20 @@ export async function createPick(
   description: string | undefined,
   topCount: number,
   dueDate?: string,
+  rankingMode?: RankingMode,
 ): Promise<{ pickId: string; createdAt: Date }> {
   const response = await fetch(
     `/api/groups/${groupId}/categories/${categoryId}/picks`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title, description, topCount, dueDate }),
+      body: JSON.stringify({
+        title,
+        description,
+        topCount,
+        dueDate,
+        rankingMode,
+      }),
     },
   );
   if (!response.ok) throw new Error("Failed to create pick");


### PR DESCRIPTION
Adds `RankingMode` to the `GroupPick` type and wires it through the Firebase schema, API route, and server data layer. Renames `RankingTier.NotReally` → `NotForMe` to match the updated copy. Adds a ranking mode selector to the Create Pick form (Tier Buckets enabled; Stack Rank and Head-to-Head disabled as post-MVP).

Key changes: `rankingMode` is a required field on `GroupPick` defaulting to `TierBuckets` on read; the Create Pick form exposes radio buttons for all three modes; the `NotForMe` rename updates the tier scoring map and all existing tests/stories.

## Acceptance Criteria
- [x] `RankingMode` enum (`TierBuckets`, `StackRank`, `HeadToHead`) added to `GroupPick`
- [x] Firebase schema serialises/deserialises `rankingMode` with `TierBuckets` default
- [x] `RankingTier.NotReally` renamed to `NotForMe` with updated copy
- [x] Create Pick form renders ranking mode selector (Tier Buckets enabled, others disabled)
- [x] `onRankingModeChange` callback fires when Tier Buckets is selected

## Tests
31 tests added, all passing (692 total).

Closes #117

---
*Created by Claude Sonnet 4.5*