### PR TITLE
ci!: add type-check job to CI workflow

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -34,6 +34,14 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm run format:check
 
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm tsc
+
   storybook-tests:
     name: Storybook Tests
     runs-on: ubuntu-latest

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreatePickFormView.spec.tsx
@@ -205,7 +205,7 @@ describe("CreatePickFormView", () => {
       const tierBucketsButton = screen.getByRole("radio", {
         name: CREATE_PICK_COPY.rankingModes.tierBuckets,
       });
-      expect(tierBucketsButton.disabled).toBe(false);
+      expect(tierBucketsButton.hasAttribute("disabled")).toBe(false);
     });
 
     it("renders the Stack Rank option as disabled", () => {
@@ -213,7 +213,7 @@ describe("CreatePickFormView", () => {
       const stackRankButton = screen.getByRole("radio", {
         name: new RegExp(CREATE_PICK_COPY.rankingModes.stackRank),
       });
-      expect(stackRankButton.disabled).toBe(true);
+      expect(stackRankButton.hasAttribute("disabled")).toBe(true);
     });
 
     it("renders the Head-to-Head option as disabled", () => {
@@ -221,7 +221,7 @@ describe("CreatePickFormView", () => {
       const headToHeadButton = screen.getByRole("radio", {
         name: new RegExp(CREATE_PICK_COPY.rankingModes.headToHead),
       });
-      expect(headToHeadButton.disabled).toBe(true);
+      expect(headToHeadButton.hasAttribute("disabled")).toBe(true);
     });
 
     it("calls onRankingModeChange when Tier Buckets is selected", () => {


### PR DESCRIPTION
Adds a `type-check` job to the CI workflow that runs `pnpm tsc` on every push and pull request, catching TypeScript errors in CI before they reach production.

The new job follows the same pattern as the existing `tests`, `lint`, and `format` jobs.

---
*Created by Claude Sonnet 4.6*