### PR TITLE
ci!: correct file-length hard cap to 2× recommended limit

### DIFF
--- a/.github/workflows/file-length.yml
+++ b/.github/workflows/file-length.yml
@@ -17,11 +17,11 @@ jobs:
 
       - name: Check changed file lengths
         run: |
-          # Thresholds from CLAUDE.md — 2× the split threshold ("+100% of recommended max")
-          # Source files: recommended split at ~240 lines → CI fails at 480+
-          # Test files:   recommended split at ~360 lines → CI fails at 720+
-          SOURCE_LIMIT=480
-          TEST_LIMIT=720
+          # Thresholds from CLAUDE.md — 2× the recommended limit (split threshold is +20%)
+          # Source files: recommended ~200 lines, split at ~240 → CI hard cap at 400+
+          # Test files:   recommended ~300 lines, split at ~360 → CI hard cap at 600+
+          SOURCE_LIMIT=400
+          TEST_LIMIT=600
 
           failed=0
 
@@ -58,8 +58,8 @@ jobs:
           if [ "$failed" -ne 0 ]; then
             echo ""
             echo "One or more files exceed the maximum allowed line count."
-            echo "  Source files: split at ~240 lines, CI fails at ${SOURCE_LIMIT}+"
-            echo "  Test files:   split at ~360 lines, CI fails at ${TEST_LIMIT}+"
+            echo "  Source files: recommended ~200 lines, split at ~240, CI hard cap at ${SOURCE_LIMIT}+"
+            echo "  Test files:   recommended ~300 lines, split at ~360, CI hard cap at ${TEST_LIMIT}+"
             echo "Split large files by logical concern before merging."
             exit 1
           fi


### PR DESCRIPTION
The original thresholds anchored on the *split* thresholds (240/360 lines), giving CI hard caps of 480/720. The intended semantics per CLAUDE.md are 2× the *recommended* limits (200/300), yielding hard caps of **400 for source files** and **600 for test files**.

The three-tier model is now consistent:
- Recommended: ~200 / ~300 lines
- Review pushback ("split"): ~240 / ~360 lines (+20%)
- CI hard cap: 400 / 600 lines (+100% of recommended)

---
*Created by Claude Sonnet 4.6*