### PR TITLE
ci: add timeout-minutes to pr-title-lint job

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -11,6 +11,7 @@ jobs:
   pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check PR title format
         env:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -11,7 +11,7 @@ jobs:
   pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 1
     steps:
       - name: Check PR title format
         env:


### PR DESCRIPTION
Adds `timeout-minutes: 1` to the `pr-title-lint` job. The check completes in milliseconds so this will never trigger in practice, but it prevents a hung runner from consuming CI minutes indefinitely.

---
*Created by Claude Sonnet 4.6*