### PR TITLE
feat(docs): structure docs/ as an OKF-conformant knowledge directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ Public (non-secret) environment config lives in `deployment/{env}.yml` and is va
 ## Documentation
 
 - Keep documentation in sync with the code — outdated docs are worse than no docs.
+- **`docs/` is an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)-conformant knowledge base** — curated reference background an agent retrieves before a task (architecture, data model, per-domain notes). It is _pull/retrieval_ reference, distinct from this file's always-in-context _policy_. Detailed explanatory background belongs in `docs/`; behavioral rules belong here. See [`docs/index.md`](docs/index.md).
+- **Every `docs/` page must carry OKF YAML frontmatter.** `type` is required and must be one of the canonical vocabulary — `Index`, `Architecture`, `DataModel`, `Domain`, `Workflow` (defined in [`docs/index.md`](docs/index.md)). `title`, `description`, `resource` (relative path to the primary source file/module the page documents), and `tags` are recommended. Cross-link related pages with normal markdown links.
+- **When adding or removing a `docs/` page, update [`docs/index.md`](docs/index.md)** so the directory listing stays in sync.
 
 ## React / Next.js Standards
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,37 @@
+---
+type: Architecture
+title: Architecture overview
+description: The Next.js App Router + Firebase stack and the server data-layer / schema-converter / type-module layering.
+resource: src/server/data
+tags: [architecture, nextjs, firebase, layering]
+---
+
+# Architecture overview
+
+group-picks is a [Next.js](https://nextjs.org/) App Router application backed by [Firebase](https://firebase.google.com/). Server-side data access is layered so that the persistence shape stays isolated behind a small set of converters.
+
+## Layers
+
+| Layer              | Location                       | Responsibility                                                                                  |
+| ------------------ | ------------------------------ | ----------------------------------------------------------------------------------------------- |
+| Route handlers     | `src/app/api/**/route.ts`      | HTTP entry points; validate input, call the data layer, shape the response.                     |
+| Server data layer  | `src/server/data/*.ts`         | All reads/writes against Firebase. One module per domain (picks, groups, invites, …).           |
+| Schema converters  | `src/lib/firebase/schema/*.ts` | Translate between the persisted Firebase shape and the app's domain types. The schema boundary. |
+| Domain types       | `src/lib/types/*.ts`           | The app-facing TypeScript shapes (`Group`, `GroupPick`, `Option`, `GroupInvite`, `Category`).   |
+| Firebase admin/SDK | `src/lib/firebase/`            | `admin.ts` (server, `firebase-admin`) and `client.ts` (browser SDK).                            |
+
+A request flows **route handler → data-layer function → schema converter → Firebase**, and back out the same way. Route handlers never touch raw Firebase field names; the data layer never returns a raw Firebase object.
+
+## The schema boundary
+
+Every persisted shape has a paired converter in `src/lib/firebase/schema/`:
+
+- `{domain}ToFirebase(domainObject)` — domain type → Firebase shape (on write).
+- `firebaseTo{Domain}(id, firebaseData, …)` — Firebase shape → domain type (on read).
+
+Domain types use `Date`; the Firebase shapes use epoch-millisecond `number`s. Converters do that translation in one place, so when the persisted shape changes only the converter and its spec change — raw field names never scatter across the codebase. See [the data model](data-model.md) for the full tree and per-domain shapes.
+
+## Related
+
+- [Data model](data-model.md)
+- [Picks](picks.md) · [Groups](groups.md) · [Invites](invites.md)

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,75 @@
+---
+type: DataModel
+title: Data model
+description: The Firebase Realtime Database tree and the {domain}ToFirebase() / firebaseTo{Domain}() schema boundary.
+resource: src/lib/firebase/schema
+tags: [data-model, firebase, realtime-database, schema]
+---
+
+# Data model
+
+Persistence is **Firebase Realtime Database** (accessed via `firebase-admin/database` and `db.ref(...)` in the [server data layer](architecture.md)). Data is a single JSON tree; the paths below are the live shape the code reads and writes.
+
+All reads/writes cross the schema boundary in `src/lib/firebase/schema/*.ts`: domain types (using `Date`) on one side, Firebase shapes (epoch-millisecond `number`s) on the other.
+
+## Tree
+
+```
+groups/
+  {groupId}/
+    public/                FirebaseGroupPublic
+    members/
+      {uid}: true
+categories/
+  {categoryId}/
+    public/                FirebaseCategoryPublic   (.indexOn: ["public/groupId"])
+    picks/
+      {pickId}/            FirebasePickPublic
+picks/
+  {pickId}/
+    options/
+      {optionId}/          FirebaseOption
+invites/
+  {token}/                 FirebaseGroupInvite
+users/
+  {uid}/
+    groups/
+      {groupId}: <truthy>  membership index
+```
+
+Note the two read paths for options. A pick under `categories/{categoryId}/picks/{pickId}` may carry an embedded `options` map (`FirebasePickPublic.options`), while the options data layer (`src/server/data/options.ts`) reads and writes the separate `picks/{pickId}/options` subtree. Treat both as authoritative for what each module actually touches.
+
+## Persisted shapes
+
+Each shape has a converter pair in `src/lib/firebase/schema/`. Fields marked optional (`?`) may be absent in the database.
+
+### FirebaseGroupPublic — `groups/{groupId}/public`
+
+`name`, `createdAt` (ms), `creatorId`, `inviteToken`, `adminIds?` (`{uid: true}`), `picksRestricted?`. Converter: [`group.ts`](../src/lib/firebase/schema/group.ts). On read, `adminIds` defaults to `[creatorId]` and `picksRestricted` to `false`. See [Groups](groups.md).
+
+### FirebaseCategoryPublic — `categories/{categoryId}/public`
+
+`name`, `description?`, `groupId`, `createdAt` (ms), `creatorId`. Indexed on `public/groupId` so categories can be queried by group. Converter: [`category.ts`](../src/lib/firebase/schema/category.ts).
+
+### FirebasePickPublic — `categories/{categoryId}/picks/{pickId}`
+
+`title`, `description?`, `topCount?` (defaults to `1` on read), `dueDate?` (ms), `categoryId`, `createdAt` (ms), `creatorId`, `closedAt?` (ms), `closedManually?`, `options?` (`{optionId: {ownerIds, title}}`). Converter: [`pick.ts`](../src/lib/firebase/schema/pick.ts). `closedAt` is validated on read (finite, positive, not in the future). See [Picks](picks.md).
+
+### FirebaseOption — `picks/{pickId}/options/{optionId}`
+
+`title`, `ownerIds?` (`{uid: true}`). Converter: [`option.ts`](../src/lib/firebase/schema/option.ts). An option with no owners is deleted rather than persisted empty.
+
+### FirebaseGroupInvite — `invites/{token}`
+
+`groupId`, `createdAt` (ms), `expiresAt` (`number | null` — `null` means never expires), `active`. Converter: [`invite.ts`](../src/lib/firebase/schema/invite.ts). This is the one shape that intentionally uses `null` (Realtime Database compatibility for "no expiry"). See [Invites](invites.md).
+
+## Conventions
+
+- **Pre-launch, database state is ephemeral** — breaking schema changes do not require a migration; the database can be wiped and re-seeded. Post-launch, subtractive changes require a migration. (See `AGENTS.md` → Firebase & Data Model.)
+- **Additive changes are safe**; removing a field, changing its type, or making an optional field required is breaking.
+- **Change the converter, not the call sites** — when a persisted shape changes, update the converter in `src/lib/firebase/schema/` and its `.spec.ts`.
+
+## Related
+
+- [Architecture overview](architecture.md)
+- [Picks](picks.md) · [Groups](groups.md) · [Invites](invites.md)

--- a/docs/deployment-config.md
+++ b/docs/deployment-config.md
@@ -1,0 +1,36 @@
+---
+type: Workflow
+title: Deployment config
+description: Public (non-secret) env config in deployment/{env}.yml, schema validation, and the sync-env deploy flow.
+resource: deployment
+tags: [deployment, config, env, vercel, sync-env]
+---
+
+# Deployment config
+
+Public (non-secret) environment configuration lives in `deployment/{env}.yml` and is validated against `deployment/schema.yml`. Only `NEXT_PUBLIC_*` and explicitly allowlisted keys are permitted; keys matching `*SECRET*`, `*_TOKEN*`, or `*PRIVATE_KEY*` are hard-denied. Secrets are managed separately through Vercel and the `sync-env` tooling, never in these files.
+
+## Editing config
+
+- Set a value: `scripts/update-config.sh --env=<env> KEY=value`
+- Load from a Firebase console JSON download: `scripts/update-config.sh --env=<env> --firebase-config=path/to/config.json` (accepts strict JSON or the JS object-literal format the console produces)
+- Edit and deploy in one step: add `--sync` to either command
+- Validate config files against the schema: `pnpm run env:validate`
+
+## Deploying
+
+All deployment tooling comes from `vercel-deploy-scripts` (a devDependency) — no global `vercel` install is required.
+
+- Deploy the current YAML without modifying it: `pnpm exec sync-env --env=<env>`
+- Deploy one env's config to a different Vercel target: `pnpm exec sync-env --env=production`, then set `VERCEL_ENV=preview` (used while staging is disabled)
+- Rotate all secrets (Firebase + Sentry + Vercel): `pnpm exec sync-env --rotate-keys --env=<env>`
+- Pull `.env.local` from Vercel: `pnpm run env:pull`
+
+## Secret scanning
+
+A secrets check runs on every commit via `.husky/pre-commit` (config validation + a gitleaks scan) and is enforced in CI by `.github/workflows/secret-scan.yml`. Run it manually with `pnpm run secrets-check`.
+
+## Related
+
+- `AGENTS.md` → Deployment Config (the authoritative command reference)
+- [Architecture overview](architecture.md) — where config feeds the Firebase client/admin setup

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -1,0 +1,49 @@
+---
+type: Domain
+title: Groups
+description: Groups, membership, admin roles, and the user→group membership index.
+resource: src/server/data/groups.ts
+tags: [groups, membership, admins]
+---
+
+# Groups
+
+A **group** is the top-level container: members, admins, and (through categories) picks. Public metadata lives at `groups/{groupId}/public`; membership at `groups/{groupId}/members/{uid}: true`. Data layer: [`src/server/data/groups.ts`](../src/server/data/groups.ts).
+
+## Reads
+
+- `getGroupById(id)` — reads `public` and `members` in parallel and returns a `Group` (with `memberIds`), or `undefined` if the group does not exist.
+- `getGroupsByUserId(uid)` — reads the user's membership index at `users/{uid}/groups`, then fetches each group. The index is what makes "my groups" a single lookup instead of a scan.
+- `getMemberDisplayNames(uids)` — resolves member UIDs to display names via Firebase Auth (`getUsers`), falling back to email then UID.
+
+## Membership
+
+Membership is stored two ways that must stay in sync:
+
+- `groups/{groupId}/members/{uid}: true` — the group's member set.
+- `users/{uid}/groups/{groupId}` — the per-user index (powers `getGroupsByUserId`).
+
+`removeMember(groupId, uid)` removes the caller from a group using a **transaction** on the members map:
+
+- If the caller is the **last** member, the transaction aborts (no write) and it returns `{ lastMember: true }` — the caller decides what to do with a soon-to-be-empty group.
+- Otherwise it writes back the members map without the caller, then best-effort clears the user-index entry, and returns `{ lastMember: false }`.
+
+The transaction is load-bearing: without it, two concurrent removals in a two-member group could both pass the last-member guard and empty the group.
+
+Members are **added** through the invite flow — see [Invites](invites.md) (`addGroupMember`).
+
+## Admins & restrictions
+
+`FirebaseGroupPublic` carries `adminIds?` (`{uid: true}`) and `picksRestricted?`. On read (`firebaseToGroup`):
+
+- `adminIds` defaults to `[creatorId]` when absent — the creator is always an admin.
+- `picksRestricted` defaults to `false`. When true, pick creation is limited to admins.
+
+## Data shape
+
+`FirebaseGroupPublic` — see [the data model](data-model.md). Converter: [`group.ts`](../src/lib/firebase/schema/group.ts).
+
+## Related
+
+- [Data model](data-model.md) · [Architecture overview](architecture.md)
+- [Invites](invites.md) — how members join. [Picks](picks.md) — what groups decide on.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+---
+type: Index
+title: group-picks knowledge base
+description: OKF-conformant reference knowledge for the group-picks codebase — architecture, data model, and per-domain notes agents retrieve before a task.
+tags: [okf, index, reference]
+---
+
+# group-picks knowledge base
+
+This directory is an [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle: one markdown file per concept, each carrying YAML frontmatter, linked together as a traversable graph. It holds **curated reference knowledge an agent retrieves before a task** — the detailed background that is too verbose to live in the always-in-context directive files (`AGENTS.md` / `CLAUDE.md`).
+
+Directives are policy (always in context); these pages are pull/retrieval reference. Keep that boundary: behavioral rules belong in `AGENTS.md`, explanatory background belongs here.
+
+## `type` vocabulary
+
+Every page declares one `type` in its frontmatter. The canonical vocabulary for this repo:
+
+| `type`         | Use for                                                               |
+| -------------- | --------------------------------------------------------------------- |
+| `Index`        | This file — the directory listing (reserved OKF convention).          |
+| `Architecture` | Cross-cutting structure: layering, the stack, how pieces fit.         |
+| `DataModel`    | Persistence shape: database paths, document schemas, converters.      |
+| `Domain`       | A single product domain: its lifecycle, rules, and data-layer module. |
+| `Workflow`     | A repeatable operational process: deploy, config, release.            |
+
+## Pages
+
+### Architecture
+
+- [Architecture overview](architecture.md) — the Next.js + Firebase stack and the server data-layer / schema-converter / type-module layering.
+
+### Data model
+
+- [Data model](data-model.md) — the Firebase Realtime Database tree and the `{domain}ToFirebase()` / `firebaseTo{Domain}()` schema boundary.
+
+### Domains
+
+- [Picks](picks.md) — ranked-choice pick lifecycle: open, vote, close, results.
+- [Groups](groups.md) — groups, membership, and admin roles.
+- [Invites](invites.md) — token-based group invites with TTL expiry.
+
+### Workflows
+
+- [Deployment config](deployment-config.md) — public env config in `deployment/{env}.yml` and the `sync-env` deploy flow.
+
+## Authoring
+
+When adding a page, give it frontmatter (`type` is required; `title`, `description`, `resource`, `tags` are recommended) and add it to the relevant section above. See the docs-authoring directive in `AGENTS.md`.

--- a/docs/invites.md
+++ b/docs/invites.md
@@ -1,0 +1,37 @@
+---
+type: Domain
+title: Invites
+description: Token-based group invites with TTL expiry, rotation, and the join flow.
+resource: src/server/data/invites.ts
+tags: [invites, tokens, expiry, membership]
+---
+
+# Invites
+
+An **invite** is a shareable token that lets someone join a group. Tokens live at `invites/{token}`; the group's currently-active token is mirrored at `groups/{groupId}/public/inviteToken`. Data layer: [`src/server/data/invites.ts`](../src/server/data/invites.ts).
+
+## Token shape
+
+A token is a `randomUUID()` with dashes stripped. `FirebaseGroupInvite` carries `groupId`, `createdAt`, `expiresAt` (`number | null`), and `active`. `INVITE_TTL` is **7 days**; `createGroupInvite` sets `expiresAt = createdAt + INVITE_TTL`.
+
+`expiresAt: null` means **never expires** — this is the one place in the data model that intentionally uses `null` (Realtime Database has no `undefined`, and the converter maps `null ↔ undefined`).
+
+## Operations
+
+- `createGroupInvite(groupId, oldToken?)` — mints a fresh token, writes `invites/{token}` and `groups/{groupId}/public/inviteToken` in one multi-path update, and (if `oldToken` is given) flips the previous token's `active` to `false`. Rotation is atomic: the group always points at exactly one active token.
+- `getGroupInviteByToken(token)` — reads and **validates** the raw node (`isFirebaseGroupInvite`) before converting; malformed or missing data returns `undefined` rather than throwing.
+- `updateGroupInviteExpiry(token, expiresAt | null)` — sets a new expiry, or `null` to make the token permanent.
+- `addGroupMember(groupId, uid)` — writes `groups/{groupId}/members/{uid}: true`, completing the join. (Pair with the user-index write described in [Groups](groups.md).)
+
+## Validation on read
+
+`getGroupInviteByToken` runs `isFirebaseGroupInvite` as a runtime type guard: `groupId` and `createdAt` must be present and correctly typed, `expiresAt` must be a number or null, and `active` must be a boolean. This guards against tampered or stale token nodes — an invalid node is treated as "no such invite."
+
+## Data shape
+
+`FirebaseGroupInvite` — see [the data model](data-model.md). Converter: [`invite.ts`](../src/lib/firebase/schema/invite.ts).
+
+## Related
+
+- [Data model](data-model.md) · [Architecture overview](architecture.md)
+- [Groups](groups.md) — what an invite grants membership to.

--- a/docs/picks.md
+++ b/docs/picks.md
@@ -1,0 +1,47 @@
+---
+type: Domain
+title: Picks
+description: Ranked-choice pick lifecycle — open, vote, close, results — and the options attached to a pick.
+resource: src/server/data/picks.ts
+tags: [picks, options, ranked-choice, lifecycle]
+---
+
+# Picks
+
+A **pick** is a ranked-choice decision within a category: a title, a set of options members can own/join, and a `topCount` of how many winners to surface. Picks live at `categories/{categoryId}/picks/{pickId}`. Data layer: [`src/server/data/picks.ts`](../src/server/data/picks.ts); options at [`src/server/data/options.ts`](../src/server/data/options.ts).
+
+## Lifecycle
+
+1. **Create** — `createPick({ title, categoryId, creatorId, topCount, description?, dueDate? })` pushes a new pick and returns `{ id, createdAt }`. It starts open (`closedAt` undefined).
+2. **Open / vote** — members add and join options (see below). Writes are gated by `assertPickIsOpenForWrite`.
+3. **Close** — a pick closes either automatically (its `dueDate` passes) or manually (`closePick`, which sets `closedManually: true`).
+4. **Reopen** — `reopenPick` clears `closedAt` and `closedManually`.
+
+## Open-for-write gate
+
+`assertPickIsOpenForWrite(categoryId, pickId, now?)` is the guard every mutation runs through. It uses a Realtime Database **transaction** to atomically auto-close a pick whose `dueDate` has passed, then:
+
+- throws `PickNotFoundError` (`code: "pick_not_found"`) if the pick does not exist;
+- throws `PickWriteClosedError` (`code: "pick_closed"`) if the pick is closed — with a message distinguishing a freshly-passed due date from an already-closed pick;
+- otherwise returns the open `GroupPick`.
+
+`PICK_CLOSED_API_ERROR` (`"Pick is closed"`) is the string surfaced to API callers.
+
+## Options
+
+Options are owned by members (`ownerIds`), so the same option can represent several people who chose it.
+
+- `addOption(pickId, title, ownerUid)` — create an option owned by the caller.
+- `joinOption(pickId, optionId, ownerUid)` — add the caller to an existing option's owners.
+- `unjoinOption(pickId, optionId, ownerUid)` — remove the caller; if they were the **last** owner, the whole option node is deleted. A transaction prevents two concurrent unjoins from both declining to delete and leaving an empty-owner option.
+
+`removeOwnerFromPickOptions` (in [`pick.ts`](../src/lib/firebase/schema/pick.ts)) is the pure equivalent for in-memory option lists, dropping an owner and pruning options left with no owners.
+
+## Data shape
+
+`FirebasePickPublic` and `FirebaseOption` — see [the data model](data-model.md). `topCount` defaults to `1` and `closedAt` is validated on read.
+
+## Related
+
+- [Data model](data-model.md) · [Architecture overview](architecture.md)
+- [Groups](groups.md) — picks belong to a category, which belongs to a group.


### PR DESCRIPTION
Establishes `docs/` as an [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle — curated reference knowledge an agent retrieves before a task, distinct from the always-in-context directive in `AGENTS.md`. The directory was previously empty (just a `.gitkeep`).

The canonical `type` vocabulary is `Index`, `Architecture`, `DataModel`, `Domain`, `Workflow`, defined in `docs/index.md` and exercised across the seed pages. Every page carries OKF YAML frontmatter and cross-links related pages as a traversable graph. A new `AGENTS.md` directive requires frontmatter on future pages and keeps `docs/index.md` in sync.

## Acceptance Criteria
- [x] Decide on the canonical `type` vocabulary for this repo (`Index`, `Architecture`, `DataModel`, `Domain`, `Workflow`)
- [x] Add `docs/index.md` satisfying the OKF index convention
- [x] Seed reference pages for the highest-traffic domains (picks, groups, invites) plus the Firebase data model, an architecture overview, and a deployment-config workflow
- [x] Add a docs-authoring directive to `AGENTS.md` requiring OKF frontmatter and index sync
- [ ] (Optional) Verify a sample bundle renders in OKF's static visualizer

## Tests
No unit tests apply to markdown content. Validation instead confirms all frontmatter parses as YAML with a `type` from the vocabulary, and every relative markdown link resolves. `pre-push-verify.py` (format / lint / typecheck / test) passes.

Closes #292

---
*Created by Claude Opus 4.8*