### PR TITLE
test(invites): guard addGroupMember dual-write against regression

### DIFF
--- a/src/server/data/invites.spec.ts
+++ b/src/server/data/invites.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUpdate, mockRef } = vi.hoisted(() => ({
+  mockUpdate: vi.fn(),
+  mockRef: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/admin", () => ({
+  getAdminApp: () => ({}),
+}));
+
+vi.mock("firebase-admin/database", () => ({
+  getDatabase: () => ({
+    ref: mockRef,
+  }),
+}));
+
+const { addGroupMember } = await import("./invites");
+
+describe("addGroupMember writes both membership paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRef.mockReturnValue({ update: mockUpdate });
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it("writes the group member set entry", async () => {
+    await addGroupMember("group-7", "user-3");
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate.mock.calls[0]?.[0]).toMatchObject({
+      "groups/group-7/members/user-3": true,
+    });
+  });
+
+  it("writes the user-to-group index entry so the group appears in My Groups", async () => {
+    await addGroupMember("group-7", "user-3");
+
+    expect(mockUpdate.mock.calls[0]?.[0]).toMatchObject({
+      "users/user-3/groups/group-7": true,
+    });
+  });
+
+  it("writes both paths in a single atomic multi-path update", async () => {
+    await addGroupMember("group-7", "user-3");
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      "groups/group-7/members/user-3": true,
+      "users/user-3/groups/group-7": true,
+    });
+  });
+});


### PR DESCRIPTION
Adds the first `invites.spec.ts`, covering `addGroupMember`'s dual-write: it must write both `groups/{groupId}/members/{uid}` and `users/{uid}/groups/{groupId}` in a single atomic update, so a group joined via invite appears in `getGroupsByUserId`.

This is a regression guard, not a fix — the bug described in #294 (the user-index write going missing in the join flow) was already resolved on `main` by #213, but nothing tested it. Three cases: the member-set write, the user-index write, and the single-update atomicity guarantee.

## Tests
3 tests added, all passing. Test-only change — UAT-exempt.

Resolves the test-coverage gap from #294 (the underlying bug was fixed in #213).

---
*Created by Claude Opus 4.8*