### PR TITLE
feat(schema): add Zod validation to firebaseTo{Domain}() converters

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-dom": "19.2.7",
     "react-redux": "^9.3.0",
     "tailwind-merge": "^3.6.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1127,89 +1130,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1370,30 +1389,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-arm64-musl@1.2.0':
     resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
     resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-gnu@1.2.0':
     resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-musl@1.2.0':
     resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
     resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
@@ -1452,24 +1476,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.9':
     resolution: {integrity: sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.9':
     resolution: {integrity: sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.9':
     resolution: {integrity: sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.9':
     resolution: {integrity: sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==}
@@ -1605,48 +1633,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -1725,41 +1761,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -1828,48 +1872,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.111.0':
     resolution: {integrity: sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
     resolution: {integrity: sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
     resolution: {integrity: sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
     resolution: {integrity: sha512-tzGCohGxaeH6KRJjfYZd4mHCoGjCai6N+zZi1Oj+tSDMAAdyvs1dRzYb8PNUGnybCg3Te4M0jLPzWZaSmnKraQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
     resolution: {integrity: sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.111.0':
     resolution: {integrity: sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.111.0':
     resolution: {integrity: sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.111.0':
     resolution: {integrity: sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==}
@@ -2014,60 +2066,70 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
     resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
@@ -2173,66 +2235,79 @@ packages:
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.0':
     resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
@@ -2591,24 +2666,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -4585,24 +4664,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6341,8 +6424,8 @@ packages:
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -9950,8 +10033,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 10.5.0(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -11849,7 +11932,7 @@ snapshots:
       '@vercel/sandbox': 2.1.1
       async-retry: 1.3.3
       debug: 4.4.3
-      zod: 4.1.11
+      zod: 4.4.3
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -12784,9 +12867,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.22.4: {}
 
@@ -12796,4 +12879,4 @@ snapshots:
 
   zod@4.1.11: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/src/lib/firebase/schema/category.spec.ts
+++ b/src/lib/firebase/schema/category.spec.ts
@@ -92,3 +92,15 @@ describe("firebaseToCategory", () => {
     expect(result.creatorId).toBe(original.creatorId);
   });
 });
+
+describe("firebaseToCategory rejects malformed input", () => {
+  it("throws when a required field is missing", () => {
+    expect(() => firebaseToCategory("cat-1", { name: "Orphan" })).toThrow();
+  });
+
+  it("throws when a field has the wrong type", () => {
+    const data = { ...makeFirebaseCategoryPublic(), createdAt: "not-a-number" };
+
+    expect(() => firebaseToCategory("cat-1", data)).toThrow();
+  });
+});

--- a/src/lib/firebase/schema/category.ts
+++ b/src/lib/firebase/schema/category.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { Category } from "@/lib/types/category";
 
 export interface FirebaseCategoryPublic {
@@ -7,6 +9,15 @@ export interface FirebaseCategoryPublic {
   createdAt: number;
   creatorId: string;
 }
+
+// Runtime shape of a persisted category's public node, parsed on read.
+const FirebaseCategoryPublicSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  groupId: z.string(),
+  createdAt: z.number(),
+  creatorId: z.string(),
+});
 
 export function categoryToFirebase(
   category: Pick<
@@ -23,16 +34,14 @@ export function categoryToFirebase(
   };
 }
 
-export function firebaseToCategory(
-  id: string,
-  data: FirebaseCategoryPublic,
-): Category {
+export function firebaseToCategory(id: string, data: unknown): Category {
+  const parsed = FirebaseCategoryPublicSchema.parse(data);
   return {
     id,
-    name: data.name,
-    description: data.description,
-    groupId: data.groupId,
-    createdAt: new Date(data.createdAt),
-    creatorId: data.creatorId,
+    name: parsed.name,
+    description: parsed.description,
+    groupId: parsed.groupId,
+    createdAt: new Date(parsed.createdAt),
+    creatorId: parsed.creatorId,
   };
 }

--- a/src/lib/firebase/schema/group.spec.ts
+++ b/src/lib/firebase/schema/group.spec.ts
@@ -148,3 +148,15 @@ describe("firebaseToGroup", () => {
     expect(result.picksRestricted).toBe(false);
   });
 });
+
+describe("firebaseToGroup rejects malformed input", () => {
+  it("throws when a required field is missing", () => {
+    expect(() => firebaseToGroup("group-1", { name: "Orphan" }, [])).toThrow();
+  });
+
+  it("throws when a field has the wrong type", () => {
+    const data = { ...makeFirebaseGroupPublic(), createdAt: "not-a-number" };
+
+    expect(() => firebaseToGroup("group-1", data, [])).toThrow();
+  });
+});

--- a/src/lib/firebase/schema/group.ts
+++ b/src/lib/firebase/schema/group.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { Group } from "@/lib/types/group";
 
 export interface FirebaseGroupPublic {
@@ -8,6 +10,17 @@ export interface FirebaseGroupPublic {
   adminIds?: Record<string, true>;
   picksRestricted?: boolean;
 }
+
+// Runtime shape of a persisted group's public node. Parsed on read so a
+// malformed document fails loudly instead of producing silent undefined bugs.
+const FirebaseGroupPublicSchema = z.object({
+  name: z.string(),
+  createdAt: z.number(),
+  creatorId: z.string(),
+  inviteToken: z.string(),
+  adminIds: z.record(z.string(), z.literal(true)).optional(),
+  picksRestricted: z.boolean().optional(),
+});
 
 export function groupToFirebase(
   group: Pick<
@@ -32,20 +45,21 @@ export function groupToFirebase(
 
 export function firebaseToGroup(
   id: string,
-  data: FirebaseGroupPublic,
+  data: unknown,
   memberIds: string[],
 ): Group {
-  const adminIds = data.adminIds
-    ? Object.keys(data.adminIds)
-    : [data.creatorId];
+  const parsed = FirebaseGroupPublicSchema.parse(data);
+  const adminIds = parsed.adminIds
+    ? Object.keys(parsed.adminIds)
+    : [parsed.creatorId];
   return {
     id,
-    name: data.name,
-    createdAt: new Date(data.createdAt),
-    creatorId: data.creatorId,
+    name: parsed.name,
+    createdAt: new Date(parsed.createdAt),
+    creatorId: parsed.creatorId,
     memberIds,
     adminIds,
-    picksRestricted: data.picksRestricted ?? false,
-    inviteToken: data.inviteToken,
+    picksRestricted: parsed.picksRestricted ?? false,
+    inviteToken: parsed.inviteToken,
   };
 }

--- a/src/lib/firebase/schema/invite.spec.ts
+++ b/src/lib/firebase/schema/invite.spec.ts
@@ -106,3 +106,17 @@ describe("firebaseToGroupInvite", () => {
     expect(result.mode).toBe(InviteMode.Group);
   });
 });
+
+describe("firebaseToGroupInvite rejects malformed input", () => {
+  it("throws when required fields are missing", () => {
+    expect(() =>
+      firebaseToGroupInvite("token-xyz", { groupId: "g", active: true }),
+    ).toThrow();
+  });
+
+  it("throws when active has the wrong type", () => {
+    const data = { ...makeFirebaseGroupInvite(), active: "yes" };
+
+    expect(() => firebaseToGroupInvite("token-xyz", data)).toThrow();
+  });
+});

--- a/src/lib/firebase/schema/invite.ts
+++ b/src/lib/firebase/schema/invite.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { type GroupInvite, InviteMode } from "@/lib/types/invite";
 
 export interface FirebaseGroupInvite {
@@ -7,6 +9,17 @@ export interface FirebaseGroupInvite {
   active: boolean;
   mode?: InviteMode;
 }
+
+// Runtime shape of a persisted invite node, parsed on read. `mode` is left
+// permissive (validated post-parse by isInviteMode) so an unknown mode value
+// falls back to the default rather than throwing.
+export const FirebaseGroupInviteSchema = z.object({
+  groupId: z.string(),
+  createdAt: z.number(),
+  expiresAt: z.number().nullable(),
+  active: z.boolean(),
+  mode: z.unknown().optional(),
+});
 
 function isInviteMode(value: unknown): value is InviteMode {
   return (
@@ -32,14 +45,16 @@ export function groupInviteToFirebase(
 
 export function firebaseToGroupInvite(
   token: string,
-  data: FirebaseGroupInvite,
+  data: unknown,
 ): GroupInvite {
+  const parsed = FirebaseGroupInviteSchema.parse(data);
   return {
     token,
-    groupId: data.groupId,
-    createdAt: new Date(data.createdAt),
-    expiresAt: data.expiresAt !== null ? new Date(data.expiresAt) : undefined,
-    active: data.active,
-    mode: isInviteMode(data.mode) ? data.mode : InviteMode.Group,
+    groupId: parsed.groupId,
+    createdAt: new Date(parsed.createdAt),
+    expiresAt:
+      parsed.expiresAt !== null ? new Date(parsed.expiresAt) : undefined,
+    active: parsed.active,
+    mode: isInviteMode(parsed.mode) ? parsed.mode : InviteMode.Group,
   };
 }

--- a/src/lib/firebase/schema/option.spec.ts
+++ b/src/lib/firebase/schema/option.spec.ts
@@ -54,3 +54,15 @@ describe("firebaseToOption", () => {
     expect(result.ownerIds).toEqual([]);
   });
 });
+
+describe("firebaseToOption rejects malformed input", () => {
+  it("throws when title is missing", () => {
+    expect(() =>
+      firebaseToOption("opt-1", "pick-42", { ownerIds: { "user-1": true } }),
+    ).toThrow();
+  });
+
+  it("throws when title has the wrong type", () => {
+    expect(() => firebaseToOption("opt-1", "pick-42", { title: 42 })).toThrow();
+  });
+});

--- a/src/lib/firebase/schema/option.ts
+++ b/src/lib/firebase/schema/option.ts
@@ -1,9 +1,17 @@
+import { z } from "zod";
+
 import type { Option } from "@/lib/types/option";
 
 export interface FirebaseOption {
   title: string;
   ownerIds?: Record<string, true>;
 }
+
+// Runtime shape of a persisted option node, parsed on read.
+const FirebaseOptionSchema = z.object({
+  title: z.string(),
+  ownerIds: z.record(z.string(), z.literal(true)).optional(),
+});
 
 export function optionToFirebase(
   option: Pick<Option, "title" | "ownerIds">,
@@ -17,12 +25,13 @@ export function optionToFirebase(
 export function firebaseToOption(
   id: string,
   pickId: string,
-  data: FirebaseOption,
+  data: unknown,
 ): Option {
+  const parsed = FirebaseOptionSchema.parse(data);
   return {
     id,
-    title: data.title,
+    title: parsed.title,
     pickId,
-    ownerIds: Object.keys(data.ownerIds ?? {}),
+    ownerIds: Object.keys(parsed.ownerIds ?? {}),
   };
 }

--- a/src/lib/firebase/schema/pick.spec.ts
+++ b/src/lib/firebase/schema/pick.spec.ts
@@ -366,3 +366,15 @@ describe("removeOwnerFromPickOptions", () => {
     expect(result).toEqual([]);
   });
 });
+
+describe("firebaseToPick rejects malformed input", () => {
+  it("throws when a required field is missing", () => {
+    expect(() => firebaseToPick("pick-1", { title: "Orphan" })).toThrow();
+  });
+
+  it("throws when a field has the wrong type", () => {
+    const data = { ...makeFirebasePickPublic(), createdAt: "not-a-number" };
+
+    expect(() => firebaseToPick("pick-1", data)).toThrow();
+  });
+});

--- a/src/lib/firebase/schema/pick.ts
+++ b/src/lib/firebase/schema/pick.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { GroupPick, PickOption } from "@/lib/types/pick";
 import { RankingMode } from "@/lib/types/pick";
 
@@ -19,6 +21,31 @@ export interface FirebasePickPublic {
   creatorId: string;
   rankingMode?: string;
 }
+
+const FirebasePickOptionSchema = z.object({
+  ownerIds: z.array(z.string()),
+  title: z.string(),
+});
+
+// Runtime shape of a persisted pick's public node, parsed on read. Optional and
+// loosely-typed fields (topCount, rankingMode, closedAt) are normalised by the
+// transform below, so the schema only enforces presence/type, not defaults.
+const FirebasePickPublicSchema = z.object({
+  options: z.record(z.string(), FirebasePickOptionSchema).optional(),
+  title: z.string(),
+  description: z.string().optional(),
+  topCount: z.number().optional(),
+  dueDate: z.number().optional(),
+  categoryId: z.string(),
+  // closedAt is sanitised post-parse (isValidClosedAt below): a non-finite or
+  // out-of-range value means "still open", so NaN must pass the schema rather
+  // than throw (Zod v4's z.number() rejects NaN by default).
+  closedAt: z.union([z.number(), z.nan()]).optional(),
+  closedManually: z.boolean().optional(),
+  createdAt: z.number(),
+  creatorId: z.string(),
+  rankingMode: z.string().optional(),
+});
 
 function pickOptionToFirebase(option: PickOption): FirebasePickOption {
   return {
@@ -78,46 +105,45 @@ export function pickToFirebase(
   };
 }
 
-export function firebaseToPick(
-  id: string,
-  data: FirebasePickPublic,
-): GroupPick {
+export function firebaseToPick(id: string, data: unknown): GroupPick {
+  const parsed = FirebasePickPublicSchema.parse(data);
+
   const isValidClosedAt =
-    typeof data.closedAt === "number" &&
-    Number.isFinite(data.closedAt) &&
-    data.closedAt > 0 &&
-    data.closedAt <= Date.now();
+    typeof parsed.closedAt === "number" &&
+    Number.isFinite(parsed.closedAt) &&
+    parsed.closedAt > 0 &&
+    parsed.closedAt <= Date.now();
 
   const options =
-    data.options === undefined
+    parsed.options === undefined
       ? undefined
-      : Object.entries(data.options).map(([optionId, optionData]) =>
+      : Object.entries(parsed.options).map(([optionId, optionData]) =>
           firebaseToPickOption(optionId, optionData),
         );
 
   const rankingMode =
-    data.rankingMode === RankingMode.StackRank
+    parsed.rankingMode === RankingMode.StackRank
       ? RankingMode.StackRank
-      : data.rankingMode === RankingMode.HeadToHead
+      : parsed.rankingMode === RankingMode.HeadToHead
         ? RankingMode.HeadToHead
         : RankingMode.TierBuckets;
 
   return {
     id,
     options,
-    title: data.title,
-    description: data.description,
-    topCount: typeof data.topCount === "number" ? data.topCount : 1,
+    title: parsed.title,
+    description: parsed.description,
+    topCount: typeof parsed.topCount === "number" ? parsed.topCount : 1,
     dueDate:
-      typeof data.dueDate === "number" ? new Date(data.dueDate) : undefined,
-    categoryId: data.categoryId,
-    createdAt: new Date(data.createdAt),
-    creatorId: data.creatorId,
+      typeof parsed.dueDate === "number" ? new Date(parsed.dueDate) : undefined,
+    categoryId: parsed.categoryId,
+    createdAt: new Date(parsed.createdAt),
+    creatorId: parsed.creatorId,
     closedAt:
-      isValidClosedAt && data.closedAt !== undefined
-        ? new Date(data.closedAt)
+      isValidClosedAt && parsed.closedAt !== undefined
+        ? new Date(parsed.closedAt)
         : undefined,
-    closedManually: data.closedManually,
+    closedManually: parsed.closedManually,
     rankingMode,
   };
 }

--- a/src/server/data/categories.ts
+++ b/src/server/data/categories.ts
@@ -3,7 +3,6 @@ import { getDatabase } from "firebase-admin/database";
 import { getAdminApp } from "@/lib/firebase/admin";
 import {
   categoryToFirebase,
-  type FirebaseCategoryPublic,
   firebaseToCategory,
 } from "@/lib/firebase/schema/category";
 import type { Category } from "@/lib/types/category";
@@ -27,8 +26,7 @@ export async function getCategoriesByGroupId(
   snap.forEach((child) => {
     const id = child.key;
     if (!id) return;
-    const publicData = (child.val() as { public: FirebaseCategoryPublic })
-      .public;
+    const publicData = (child.val() as { public: unknown }).public;
     categories.push(firebaseToCategory(id, publicData));
   });
 
@@ -43,7 +41,7 @@ export async function getCategoryById(
 
   if (!snap.exists()) return undefined;
 
-  const data = snap.val() as FirebaseCategoryPublic;
+  const data: unknown = snap.val();
   return firebaseToCategory(id, data);
 }
 

--- a/src/server/data/groups.ts
+++ b/src/server/data/groups.ts
@@ -1,10 +1,7 @@
 import { getDatabase } from "firebase-admin/database";
 
 import { getAdminApp, getAdminAuth } from "@/lib/firebase/admin";
-import {
-  type FirebaseGroupPublic,
-  firebaseToGroup,
-} from "@/lib/firebase/schema/group";
+import { firebaseToGroup } from "@/lib/firebase/schema/group";
 import type { Group } from "@/lib/types/group";
 
 export async function getGroupById(id: string): Promise<Group | undefined> {
@@ -17,7 +14,7 @@ export async function getGroupById(id: string): Promise<Group | undefined> {
 
   if (!publicSnap.exists()) return undefined;
 
-  const publicData = publicSnap.val() as FirebaseGroupPublic;
+  const publicData: unknown = publicSnap.val();
   const memberIds = membersSnap.exists()
     ? Object.keys(membersSnap.val() as Record<string, unknown>)
     : [];

--- a/src/server/data/invites.ts
+++ b/src/server/data/invites.ts
@@ -3,7 +3,6 @@ import { getDatabase } from "firebase-admin/database";
 
 import { getAdminApp } from "@/lib/firebase/admin";
 import {
-  type FirebaseGroupInvite,
   firebaseToGroupInvite,
   groupInviteToFirebase,
 } from "@/lib/firebase/schema/invite";
@@ -14,26 +13,19 @@ export const INVITE_TTL_GROUP = 30 * 24 * 60 * 60 * 1000;
 
 export type CreatedGroupInvite = GroupInvite & { expiresAt: Date };
 
-function isFirebaseGroupInvite(data: unknown): data is FirebaseGroupInvite {
-  if (typeof data !== "object" || data === null) return false;
-  const d = data as Record<string, unknown>;
-  return (
-    typeof d["groupId"] === "string" &&
-    typeof d["createdAt"] === "number" &&
-    (d["expiresAt"] == null || typeof d["expiresAt"] === "number") &&
-    typeof d["active"] === "boolean"
-  );
-}
-
 export async function getGroupInviteByToken(
   token: string,
 ): Promise<GroupInvite | undefined> {
   const db = getDatabase(getAdminApp());
   const snap = await db.ref(`invites/${token}`).get();
   if (!snap.exists()) return undefined;
-  const raw: unknown = snap.val();
-  if (!isFirebaseGroupInvite(raw)) return undefined;
-  return firebaseToGroupInvite(token, raw);
+  // A malformed invite node is treated as "no such invite" (404) rather than
+  // an error, so the converter's parse is caught here and mapped to undefined.
+  try {
+    return firebaseToGroupInvite(token, snap.val());
+  } catch {
+    return undefined;
+  }
 }
 
 export async function createGroupInvite(

--- a/src/server/data/options.ts
+++ b/src/server/data/options.ts
@@ -2,7 +2,6 @@ import { getDatabase } from "firebase-admin/database";
 
 import { getAdminApp } from "@/lib/firebase/admin";
 import {
-  type FirebaseOption,
   firebaseToOption,
   optionToFirebase,
 } from "@/lib/firebase/schema/option";
@@ -14,7 +13,7 @@ export async function getOptionsByPick(pickId: string): Promise<Option[]> {
 
   if (!snap.exists()) return [];
 
-  const data = snap.val() as Record<string, FirebaseOption>;
+  const data = snap.val() as Record<string, unknown>;
   return Object.entries(data).map(([id, optionData]) =>
     firebaseToOption(id, pickId, optionData),
   );
@@ -92,7 +91,7 @@ export async function getOptionsByCategory(
   for (const [i, snap] of snapshots.entries()) {
     const pickId = pickIds[i];
     if (!snap.exists() || !pickId) continue;
-    const data = snap.val() as Record<string, FirebaseOption>;
+    const data = snap.val() as Record<string, unknown>;
     for (const [id, optionData] of Object.entries(data)) {
       options.push(firebaseToOption(id, pickId, optionData));
     }

--- a/src/server/data/picks.ts
+++ b/src/server/data/picks.ts
@@ -48,7 +48,7 @@ export async function getPicksByCategory(
 
   if (!snap.exists()) return [];
 
-  const data = snap.val() as Record<string, FirebasePickPublic>;
+  const data = snap.val() as Record<string, unknown>;
   return Object.entries(data).map(([id, pickData]) =>
     firebaseToPick(id, pickData),
   );
@@ -75,7 +75,7 @@ export async function getPickById(
 
   if (!snap.exists()) return undefined;
 
-  return firebaseToPick(pickId, snap.val() as FirebasePickPublic);
+  return firebaseToPick(pickId, snap.val());
 }
 
 export async function assertPickIsOpenForWrite(
@@ -106,10 +106,7 @@ export async function assertPickIsOpenForWrite(
     throw new PickNotFoundError();
   }
 
-  const pick = firebaseToPick(
-    pickId,
-    result.snapshot.val() as FirebasePickPublic,
-  );
+  const pick = firebaseToPick(pickId, result.snapshot.val());
 
   if (pick.closedAt !== undefined) {
     throw new PickWriteClosedError(
@@ -194,10 +191,7 @@ export async function updatePickIfOpen(
     throw new PickNotFoundError();
   }
 
-  const pick = firebaseToPick(
-    pickId,
-    result.snapshot.val() as FirebasePickPublic,
-  );
+  const pick = firebaseToPick(pickId, result.snapshot.val());
 
   if (pick.closedAt !== undefined) {
     throw new PickWriteClosedError(


### PR DESCRIPTION
Adds runtime Zod validation to the read path so a malformed persisted document fails loudly instead of producing silent `undefined`/`null` values once the database holds real (non-wipeable) data. A pre-launch hardening of the schema boundary documented in `AGENTS.md`.

Each `firebaseTo{Domain}()` now takes `unknown` and `Schema.parse(data)`s before transforming. The now-unnecessary `snap.val() as FirebaseX` casts at the call sites are dropped. The public invite read path keeps its graceful "return undefined on bad data" behavior (try/catch around the throwing converter), replacing the previous hand-rolled `isFirebaseGroupInvite` type guard. All existing tolerant defaulting is preserved — pick `topCount`/`rankingMode` defaults and the `NaN`/out-of-range `closedAt` sanitisation, and the invite `mode` fallback. Write-path `{domain}ToFirebase()` functions are untouched.

**Premise correction:** the issue framed this around Firestore and in-converter `data.name as string` casts. The code actually uses Realtime Database, and the unchecked cast is `snap.val() as FirebaseX` at the data-layer call sites — the converters received already-typed data. The fix targets that real boundary: validation now lives in the converters.

## Acceptance Criteria
- [x] Add `zod` to dependencies
- [x] Define a Zod schema for each domain with a `firebaseTo{Domain}()` converter (group, category, invite, option, pick)
- [x] Replace cast-based field access with `Schema.parse(data)` in each converter
- [x] No changes to `{domain}ToFirebase()` functions
- [x] Add converter tests covering parse errors on malformed input

## Tests
10 new malformed-input tests (2 per converter); all 107 schema + data-layer tests pass. `pre-push-verify.py` (format / lint / typecheck / test) green.

## Follow-up (not in scope)
`src/lib/firebase/schema/pick.spec.ts` is now ~382 lines, over the 300-line soft limit (well under the 600 hard cap). Worth splitting into a `pick-tests/` directory in a separate change.

Closes #252

---
*Created by Claude Opus 4.8*