### PR TITLE
ci: serialize Storybook Screenshots job to avoid gh-screenshots push race

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -53,6 +53,14 @@ jobs:
 
   storybook-screenshots:
     name: Storybook Screenshots
+    # Serialize this job across every PR run. The screenshots action pushes to
+    # the shared gh-screenshots branch, so two overlapping runs race and the
+    # loser fails with "Update is not a fast forward" (#268). A single global
+    # concurrency group with cancel-in-progress: false queues the runs so each
+    # push lands as a clean fast-forward instead of racing.
+    concurrency:
+      group: storybook-screenshots-push
+      cancel-in-progress: false
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Fixes the flaky "Update is not a fast forward" failure on the **Storybook Screenshots** CI job. The `yoavf/auto-pr-screenshots-action` pushes captured images to the shared `gh-screenshots` branch; when two PR runs overlap, the second push loses the race and the job fails — unrelated to the PR's code.

Adds a global job-level `concurrency` group (`storybook-screenshots-push`, `cancel-in-progress: false`) so the screenshot jobs across all PRs queue and push one at a time, making each push a clean fast-forward. This is the only lever available at the workflow level — the push/rebase logic lives inside the third-party action.

This serializes (tightens) the job; it does not disable or loosen any check.

## Acceptance Criteria
- [x] Overlapping Storybook Screenshots runs no longer race on the `gh-screenshots` push (serialized via concurrency group)
- [x] Successfully-captured screenshots still persist (queued runs complete in turn rather than being dropped)

## Tests
N/A — CI workflow change. Validated by YAML parse + `pre-push-verify.py` (format/lint/typecheck/test) passing. Behavior is observable only on GitHub Actions across concurrent PR runs.

## Note
A known edge remains: GitHub allows only one *pending* run per concurrency group, so 3+ simultaneous runs can cancel the oldest pending one. That is far rarer than the current "any two overlapping runs fail" behavior and would need either an upstream action fix (retry-with-rebase) or a dedicated per-run branch slot to fully eliminate.

Closes #268

---
*Created by Claude Opus 4.8*