### PR TITLE
chore(deps): add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Wait 7 days after a version is published before opening an update PR, so a
+    # compromised release has time to be detected and yanked before we pull it
+    # in (supply-chain exposure reduction).
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -21,6 +26,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Adds a 7-day `cooldown` to the Dependabot config on both the `npm` and `github-actions` ecosystems, so Dependabot waits a week after a version is published before opening an update PR.

## Why

Supply-chain attacks via compromised package releases are typically detected and the malicious version yanked within a few days of publication. Letting updates age 7 days before we ingest them avoids pulling in a bad release during that brief exposure window, at the cost of applying legitimate updates a week later than today.

## Change

```yaml
cooldown:
  default-days: 7
```

`default-days` applies to all semver levels (major/minor/patch). The weekly schedule and dependency grouping are unchanged — Dependabot applies the per-dependency cooldown first, then groups the eligible updates as before.

## Testing

Config-only change, validated by `pre-push-verify.py` (format/lint/typecheck/test) and a YAML parse. Dependabot config is not exercised by app CI; GitHub validates it on the default branch after merge.

---
*Created by Claude Opus 4.8*