### PR TITLE
chore(deps): group only minor/patch npm bumps, isolate major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,22 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # Group only minor and patch bumps into one PR per dependency type. Major
+    # bumps match no group and are raised as individual PRs, since they are the
+    # most likely to need a code change and warrant isolated review.
     groups:
       dev-dependencies:
         dependency-type: development
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
       production-dependencies:
         dependency-type: production
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
 


### PR DESCRIPTION
Restricts the npm Dependabot groups to minor and patch updates so major bumps are raised individually.

## Why

Major version bumps are the ones most likely to introduce breaking API changes that need a code change. Bundling them into the batched group PR makes that PR risky to merge wholesale and hard to bisect. By limiting the groups to minor/patch (low-risk) updates, major bumps fall out of every group and Dependabot opens a dedicated PR per major — so each can be reviewed and adapted in isolation, while routine minor/patch churn stays batched to keep PR volume down.

## Change

Adds `update-types: [minor, patch]` to the `dev-dependencies` and `production-dependencies` npm groups:

```yaml
groups:
  dev-dependencies:
    dependency-type: development
    update-types: ["minor", "patch"]
    patterns: ["*"]
  production-dependencies:
    dependency-type: production
    update-types: ["minor", "patch"]
    patterns: ["*"]
```

The 7-day cooldown, weekly schedule, and the `github-actions` ecosystem (already ungrouped → one PR per action) are unchanged. Mirrors the pattern in `rmartz/vercel-deploy-scripts`.

## Testing

Config-only change, validated by `pre-push-verify.py` (format/lint/typecheck/test) and a YAML parse confirming both npm groups carry `update-types: [minor, patch]`. GitHub validates the Dependabot config on `main` after merge.

---
*Created by Claude Opus 4.8*