### PR TITLE
chore(deps): remove vercel-deploy-scripts devDependency

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 [ -f ".git" ] && exit 0
 bash scripts/check-conflict-markers.sh --staged
 pnpm exec lint-staged
-pnpm run secrets-check
+pnpm run env:validate
 bash scripts/check-file-length.sh --staged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,7 @@ pnpm test             # Run tests with Vitest
 pnpm tsc              # Type check
 pnpm storybook        # Start Storybook dev server (port 6006)
 pnpm build-storybook  # Build static Storybook
-pnpm run env:pull     # Pull .env.local from Vercel
-pnpm run env:deploy   # Deploy deployment YAML to Vercel (requires --env=<staging|production>)
 pnpm run env:validate # Validate deployment config files against schema
-pnpm run secrets-check # Config validation + gitleaks scan (also runs pre-commit)
 ```
 
 ## Worktree Setup
@@ -48,12 +45,9 @@ Public (non-secret) environment config lives in `deployment/{env}.yml` and is va
 
 - To update a public config value: `scripts/update-config.sh --env=<env> KEY=value`
 - To load public config from a Firebase console JSON download: `scripts/update-config.sh --env=<env> --firebase-config=path/to/config.json` (accepts both strict JSON and the JS object literal format produced by the Firebase console)
-- To update and immediately deploy to Vercel: add `--sync` to the above commands
-- To deploy the current YAML to Vercel without modifying it: `pnpm exec sync-env --env=<env>`
-- To deploy one env's config to a different Vercel target: `pnpm exec sync-env --env=production` then set `VERCEL_ENV=preview` (used while staging is disabled)
-- To rotate all secrets (Firebase + Sentry + Vercel): `pnpm exec sync-env --rotate-keys --env=<env>`
-- Secrets checks run automatically on every commit via `.husky/pre-commit`; also enforced in CI via `.github/workflows/secret-scan.yml`
-- All deployment tooling is provided by `vercel-deploy-scripts` (a devDependency); no global vercel install required
+- `scripts/update-config.sh` only writes and validates the local YAML; it does not push to Vercel. Validate explicitly with `pnpm run env:validate`.
+- Pushing config to Vercel and pulling a local `.env.local` will be handled by the `envctl` CLI (usage TBD) — a local-only tool, intentionally not wired into CI. Until it lands, use the `vercel` CLI directly. The previous `vercel-deploy-scripts` tooling (`sync-env` / `generate-local-env`) has been removed.
+- Secret scanning runs in CI via `.github/workflows/secret-scan.yml`. There is no local pre-commit secret scan; the pre-commit hook runs `pnpm run env:validate` (config validation) only.
 
 ## TypeScript
 

--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -5,9 +5,9 @@
 # will be rejected by the pre-commit hook and CI.
 #
 # Sensitive variables are managed directly in Vercel and are never committed.
-# Run `pnpm env:pull` to generate a local .env.local from Vercel's stored values.
+# Pulling a local .env.local from Vercel is handled by envctl (TBD).
 #
-# To update these values and sync them to Vercel: scripts/update-config.sh --env=production
+# To update these public values: scripts/update-config.sh --env=production
 
 environment: production
 

--- a/deployment/staging.yml
+++ b/deployment/staging.yml
@@ -5,9 +5,9 @@
 # will be rejected by the pre-commit hook and CI.
 #
 # Sensitive variables are managed directly in Vercel and are never committed.
-# Run `pnpm env:pull` to generate a local .env.local from Vercel's stored values.
+# Pulling a local .env.local from Vercel is handled by envctl (TBD).
 #
-# To update these values and sync them to Vercel: scripts/update-config.sh --env=staging
+# To update these public values: scripts/update-config.sh --env=staging
 
 environment: staging
 

--- a/docs/deployment-config.md
+++ b/docs/deployment-config.md
@@ -1,34 +1,30 @@
 ---
 type: Workflow
 title: Deployment config
-description: Public (non-secret) env config in deployment/{env}.yml, schema validation, and the sync-env deploy flow.
+description: Public (non-secret) env config in deployment/{env}.yml and schema validation.
 resource: deployment
-tags: [deployment, config, env, vercel, sync-env]
+tags: [deployment, config, env, vercel]
 ---
 
 # Deployment config
 
-Public (non-secret) environment configuration lives in `deployment/{env}.yml` and is validated against `deployment/schema.yml`. Only `NEXT_PUBLIC_*` and explicitly allowlisted keys are permitted; keys matching `*SECRET*`, `*_TOKEN*`, or `*PRIVATE_KEY*` are hard-denied. Secrets are managed separately through Vercel and the `sync-env` tooling, never in these files.
+Public (non-secret) environment configuration lives in `deployment/{env}.yml` and is validated against `deployment/schema.yml`. Only `NEXT_PUBLIC_*` and explicitly allowlisted keys are permitted; keys matching `*SECRET*`, `*_TOKEN*`, or `*PRIVATE_KEY*` are hard-denied. Secrets are managed separately through Vercel, never in these files.
 
 ## Editing config
 
 - Set a value: `scripts/update-config.sh --env=<env> KEY=value`
 - Load from a Firebase console JSON download: `scripts/update-config.sh --env=<env> --firebase-config=path/to/config.json` (accepts strict JSON or the JS object-literal format the console produces)
-- Edit and deploy in one step: add `--sync` to either command
 - Validate config files against the schema: `pnpm run env:validate`
 
-## Deploying
+`scripts/update-config.sh` only writes and validates the local YAML.
 
-All deployment tooling comes from `vercel-deploy-scripts` (a devDependency) — no global `vercel` install is required.
+## Deploying to Vercel
 
-- Deploy the current YAML without modifying it: `pnpm exec sync-env --env=<env>`
-- Deploy one env's config to a different Vercel target: `pnpm exec sync-env --env=production`, then set `VERCEL_ENV=preview` (used while staging is disabled)
-- Rotate all secrets (Firebase + Sentry + Vercel): `pnpm exec sync-env --rotate-keys --env=<env>`
-- Pull `.env.local` from Vercel: `pnpm run env:pull`
+The previous deploy tooling (`vercel-deploy-scripts`, providing `sync-env` / `generate-local-env`) has been removed. Pushing the YAML values to Vercel and pulling a local `.env.local` will be handled by a dedicated CLI, **`envctl`** (usage TBD) — a local-only env-management tool that is intentionally not wired into CI. Until it lands, manage env values directly with the `vercel` CLI (a devDependency).
 
 ## Secret scanning
 
-A secrets check runs on every commit via `.husky/pre-commit` (config validation + a gitleaks scan) and is enforced in CI by `.github/workflows/secret-scan.yml`. Run it manually with `pnpm run secrets-check`.
+Secret scanning runs in CI via `.github/workflows/secret-scan.yml`. There is no local pre-commit secret scan; the pre-commit hook validates the deployment config (`pnpm run env:validate`) but does not run gitleaks.
 
 ## Related
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Every page declares one `type` in its frontmatter. The canonical vocabulary for 
 
 ### Workflows
 
-- [Deployment config](deployment-config.md) — public env config in `deployment/{env}.yml` and the `sync-env` deploy flow.
+- [Deployment config](deployment-config.md) — public env config in `deployment/{env}.yml` and schema validation.
 
 ## Authoring
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
     "build-storybook": "storybook build",
     "storybook-tests": "vitest --project=storybook",
     "prepare": "husky",
-    "env:pull": "generate-local-env",
-    "env:deploy": "sync-env",
-    "env:validate": "node scripts/validate-config.mjs",
-    "secrets-check": "pnpm run env:validate && secrets-check --config .gitleaks.toml"
+    "env:validate": "node scripts/validate-config.mjs"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -82,7 +79,6 @@
     "typescript": "^6",
     "typescript-eslint": "^8.61.0",
     "vercel": "^54.14.0",
-    "vercel-deploy-scripts": "github:rmartz/vercel-deploy-scripts#v3.1.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.9"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,9 +153,6 @@ importers:
       vercel:
         specifier: ^54.14.0
         version: 54.14.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)(rollup@4.62.0)
-      vercel-deploy-scripts:
-        specifier: github:rmartz/vercel-deploy-scripts#v3.1.0
-        version: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -6117,12 +6114,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f:
-    resolution: {integrity: sha512-1ZYXLjyeIN0hd1FOuQrKx0incfrZe9uJ8RpYixlFam2r3HHvzPzramXEeuTBDK9Uz4vjyumEvG9QVHZhovEKTw==, tarball: https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f}
-    version: 0.0.0
-    engines: {node: '>=18', pnpm: '>=9'}
-    hasBin: true
 
   vercel@54.14.0:
     resolution: {integrity: sha512-C753akCiJtBfcH+2kh+n3V7awcw/ESUxLzg6KC+SjDFociFWAm6queymFgILvaa9kHi3ouXosurvqhVtnLrjRA==}
@@ -12555,10 +12546,6 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
-
-  vercel-deploy-scripts@https://codeload.github.com/rmartz/vercel-deploy-scripts/tar.gz/8d0b949e18567992e5c18cd800005f5fde28602f:
-    dependencies:
-      js-yaml: 4.1.1
 
   vercel@54.14.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)(rollup@4.62.0):
     dependencies:

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -5,5 +5,5 @@
 [ -d "node_modules" ] || pnpm install --frozen-lockfile --prefer-offline
 bash scripts/check-conflict-markers.sh --staged
 pnpm exec lint-staged
-pnpm run secrets-check
+pnpm run env:validate
 bash scripts/check-file-length.sh --staged

--- a/scripts/update-config.sh
+++ b/scripts/update-config.sh
@@ -4,18 +4,14 @@
 # Usage:
 #   scripts/update-config.sh --env=staging KEY=value [KEY=value ...]
 #   scripts/update-config.sh --env=production --firebase-config=/path/to/config.json
-#   scripts/update-config.sh --env=staging --firebase-config=... --sync
 #
 # The --firebase-config flag accepts the path to a JSON file containing the
 # firebaseConfig object exported from the Firebase console. It extracts and maps
 # the relevant NEXT_PUBLIC_FIREBASE_* keys automatically. Both strict JSON and
 # the JavaScript object literal format produced by the Firebase console are accepted.
 #
-# Pass --sync to also push the updated values to Vercel immediately after writing
-# the YAML (calls deploy-config.sh). Without --sync, only the local YAML is updated.
-#
-# To deploy without modifying the YAML, run deploy-config.sh directly:
-#   scripts/deploy-config.sh --env=staging
+# This script only writes and validates the local deployment YAML. Pushing the
+# values to Vercel is handled separately by the envctl tool (TBD).
 #
 # Sensitive values must NEVER be passed as KEY=value arguments — they will appear
 # in shell history and ps output. Use `pnpm exec vercel env add` directly for secrets.
@@ -32,14 +28,12 @@ DEPLOYMENT_DIR="$PROJECT_ROOT/deployment"
 
 ENV_NAME=""
 FIREBASE_CONFIG_FILE=""
-SYNC=false
 declare -a KEY_VALUE_PAIRS=()
 
 for arg in "$@"; do
   case "$arg" in
     --env=*) ENV_NAME="${arg#--env=}" ;;
     --firebase-config=*) FIREBASE_CONFIG_FILE="${arg#--firebase-config=}" ;;
-    --sync) SYNC=true ;;
     *=*) KEY_VALUE_PAIRS+=("$arg") ;;
     *) echo "ERROR: Unknown argument: $arg"; exit 1 ;;
   esac
@@ -196,12 +190,5 @@ echo ""
 echo "Validating against schema..."
 node "$SCRIPT_DIR/validate-config.mjs" --env="$ENV_NAME"
 
-# ── Sync to Vercel (optional) ─────────────────────────────────────────────────
-
-if [[ "$SYNC" == "true" ]]; then
-  echo ""
-  exec pnpm exec sync-env --env="$ENV_NAME"
-fi
-
 echo ""
-echo "YAML updated. Run 'pnpm exec sync-env --env=$ENV_NAME' to push to Vercel."
+echo "YAML updated. Push to Vercel with envctl (TBD) when available."


### PR DESCRIPTION
Removes the `vercel-deploy-scripts` devDependency and the npm scripts that relied on its binaries, in preparation for a dedicated local-only env-management CLI (**`envctl`**, usage TBD). The public env YAML configs in `deployment/` are kept exactly as-is.

## What changed

- **Dependency**: dropped `vercel-deploy-scripts` from `devDependencies` and regenerated `pnpm-lock.yaml`.
- **package.json scripts**: removed `env:pull` (`generate-local-env`), `env:deploy` (`sync-env`), and `secrets-check`. `env:validate` (local `validate-config.mjs`) is retained.
- **update-config.sh**: removed the `--sync` path and the `sync-env` follow-up message; it now only writes and validates the local YAML.
- **Pre-commit hooks** (`.husky/pre-commit`, `scripts/hooks/pre-commit`): the local gitleaks secret scan is dropped; both now run `pnpm run env:validate` (config validation) in its place.
- **Docs** (`AGENTS.md`/`CLAUDE.md`, `docs/deployment-config.md`, `docs/index.md`, the `deployment/*.yml` headers): describe the `envctl` migration and the removed tooling.

## Scope boundaries (intentional)

- **YAML configs kept** — `deployment/staging.yml` and `deployment/production.yml` are unchanged except for header comments referencing removed commands.
- **CI untouched** — `.github/workflows/secret-scan.yml` still consumes the `rmartz/vercel-deploy-scripts` *reusable workflow* (a GitHub Actions ref, not the npm dependency). `envctl` is local-only and not wired into CI, so CI secret scanning is the remaining enforced gate and is deliberately left in place.
- **Local secret scan dropped** — per the chosen approach, the pre-commit gitleaks scan is removed; secrets are now caught only by the CI workflow above. `.gitleaks.toml` is retained (CI references it).

## Verification

`format` / `lint` / `tsc` / `test` all pass via the pre-push gate; `update-config.sh` and both pre-commit hooks pass `bash -n`; `pnpm run env:validate` runs clean.

---
*Created by Claude Opus 4.8*
