### PR TITLE
ci: run deployment-config validation only when config changes

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -1,9 +1,21 @@
 name: Validate Config
 
+# Run only when the deployment config or its validator changes — this check's
+# entire input surface is deployment/** plus the validator script, so a paths
+# allowlist is safe here (unlike the test/build suite, which any code can
+# affect). See #334.
 on:
   pull_request:
+    paths:
+      - "deployment/**"
+      - "scripts/validate-config.mjs"
+      - ".github/workflows/validate-config.yml"
   push:
     branches: [main]
+    paths:
+      - "deployment/**"
+      - "scripts/validate-config.mjs"
+      - ".github/workflows/validate-config.yml"
 
 jobs:
   validate-config:


### PR DESCRIPTION
Gates the `Validate deployment config` workflow with a `paths` filter so it runs only when its inputs change.

## Why an allowlist here (vs the denylist in #332)

This check's entire input surface is enumerable: `scripts/validate-config.mjs` reads only `deployment/{env}.yml` + `deployment/schema.yml`. Nothing else can change its result, so a `paths:` **allowlist** is correct and safe. (Contrast #332's test/build suite, where *any* code can affect the outcome, forcing a default-run denylist.) Because the workflow is single-purpose, a **workflow-level** `paths` filter is the right mechanism — unlike `ci-actions.yml` (#333), which needs a per-job `detect-changes` gate so `Format` still runs.

Triggers (on both `pull_request` and `push` to `main`):
- `deployment/**`
- `scripts/validate-config.mjs`
- `.github/workflows/validate-config.yml`

## Notes

- Based on `main` — #324 (which created `validate-config.yml`) has already merged, so no stacking is needed.
- This PR edits the workflow file itself, which is in the allowlist, so the `Validate deployment config` check still runs on this PR.
- Modest CI-time payoff (the job is ~15s); the value is consistency with the "run checks only when relevant" approach.
- `main` is unprotected, so a non-triggered workflow simply produces no check (not a stuck required check). Revisit if branch protection is added.

Closes #334

---
*Created by Claude Opus 4.8*