### PR TITLE
ci: scope Storybook Screenshots concurrency per-ref to stop cross-PR eviction

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -127,13 +127,15 @@ jobs:
 
   storybook-screenshots:
     name: Storybook Screenshots
-    # Serialize this job across every PR run. The screenshots action pushes to
-    # the shared gh-screenshots branch, so two overlapping runs race and the
-    # loser fails with "Update is not a fast forward" (#268). A single global
-    # concurrency group with cancel-in-progress: false queues the runs so each
-    # push lands as a clean fast-forward instead of racing.
+    # Per-ref concurrency: serialize only same-branch runs, not across PRs. A
+    # single global group caused cross-PR eviction — GitHub keeps only the most
+    # recent pending run in a group and cancels the rest, so an unrelated PR's
+    # run would cancel this one at ~3s and report a blocking "cancelled". The
+    # global group originally existed to stop two PRs racing on the shared
+    # gh-screenshots push (#268); that race is now non-fatal because the capture
+    # step is advisory (continue-on-error, #329/#330), so a per-ref group is safe.
     concurrency:
-      group: storybook-screenshots-push
+      group: storybook-screenshots-push-${{ github.ref }}
       cancel-in-progress: false
     needs: detect-changes
     # Only when a Storybook test/story actually changed (#331): a story change


### PR DESCRIPTION
Keys the `storybook-screenshots` concurrency group by `github.ref` so only same-branch runs serialize, eliminating the cross-PR eviction that produced spurious 3-second `cancelled` checks.

## Background

The global `storybook-screenshots-push` group meant every PR (and push to `main`) competed in one concurrency group. GitHub keeps only the most recent *pending* run in a group and cancels the older ones, so an unrelated PR's screenshots run would evict this one at ~3s — a run-level cancellation `continue-on-error` cannot catch (it's not a step failure). This is the residual cancel mode that #330 (advisory) and #333 (story-gating) didn't address.

## Change

```yaml
group: storybook-screenshots-push-${{ github.ref }}   # was: storybook-screenshots-push
```

`cancel-in-progress: false` is kept, so rapid pushes on the *same* branch still serialize cleanly.

## Why this is safe now

The global group originally existed to stop two PRs racing on the shared `gh-screenshots` push (#268), where the loser failed with "Update is not a fast forward". That race is now **non-fatal**: #330 made the capture step advisory (`continue-on-error`), so a push race is swallowed (at worst a screenshot doesn't post) rather than failing the check. So per-ref serialization is sufficient.

## Effect

Combined with #333's story-gating, the screenshots check stops producing blocking `cancelled` results: non-story PRs skip the job; story PRs run it in their own per-ref group (advisory). This makes the previously-escalated backlog safely re-runnable in bulk.

Context: #329, #330, #331 (#331 flagged this de-globalization as the companion fix).

---
*Created by Claude Opus 4.8*