### PR TITLE
ci: enable cancel-in-progress on the screenshots concurrency group

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -134,9 +134,14 @@ jobs:
     # global group originally existed to stop two PRs racing on the shared
     # gh-screenshots push (#268); that race is now non-fatal because the capture
     # step is advisory (continue-on-error, #329/#330), so a per-ref group is safe.
+    # cancel-in-progress: true then supersedes stale same-branch runs — a new
+    # commit cancels the prior commit's run, since only the latest commit's
+    # screenshots matter (the per-ref key, not this flag, is what stops cross-PR
+    # cancellation; on a global group cancel-in-progress would instead kill
+    # another PR's in-progress run).
     concurrency:
       group: storybook-screenshots-push-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     needs: detect-changes
     # Only when a Storybook test/story actually changed (#331): a story change
     # signals an intended visual change worth validating with a screenshot. The


### PR DESCRIPTION
Follow-up to #336. The per-ref concurrency group landed on `main`, but `cancel-in-progress` stayed `false` — #336 merged at its first commit before the amending commit that flipped it propagated to the PR. This sets it to `true`.

## Change

```yaml
concurrency:
  group: storybook-screenshots-push-${{ github.ref }}
  cancel-in-progress: true   # was: false
```

## Why

With the group keyed per-ref (from #336), `cancel-in-progress: true` cancels a *stale same-branch* run when a new commit is pushed — only the latest commit's screenshots matter, so this saves a runner. It is safe because the capture step is advisory (#330), so the shared `gh-screenshots` push race the global group once guarded (#268) is no longer fatal.

**To be explicit about the lever:** the **per-ref key** (already on `main`) is what prevents cross-PR cancellation — `cancel-in-progress` only governs runs *within* a group. On the old global group, `cancel-in-progress: true` would have cancelled another PR's *in-progress* run, which is why it was never a substitute for the per-ref fix.

This brings the config to the canonical concurrency idiom (`…-${{ github.ref }}` + `cancel-in-progress: true`).

Context: #329, #330, #336.

---
*Created by Claude Opus 4.8*