### PR TITLE
ci(deploy): gate Vercel preview deploys to feat/fix PR titles

### DIFF
--- a/scripts/vercel-ignore-build.d.mts
+++ b/scripts/vercel-ignore-build.d.mts
@@ -1,0 +1,3 @@
+export declare function isDeployableTitle(
+  title: string | null | undefined,
+): boolean;

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
+// Vercel "Ignored Build Step" — gates preview deploys to conserve the daily
+// deploy quota. Wired up via the `ignoreCommand` field in vercel.json.
+//
+// Vercel runs this for every deploy after cloning the repo (before install) and
+// reads its exit code: exit 1 = proceed with the build, exit 0 = cancel it.
+//
+// Policy: production builds always proceed. Preview builds proceed only when the
+// associated pull request's title is a `feat:` or `fix:` Conventional Commit —
+// the change types that warrant a UAT preview. Everything else (docs, chore,
+// refactor, test, style, ci, build, perf, revert) is skipped, along with branch
+// pushes that have no open PR yet and draft `[WIP]` titles, which do not need a
+// preview to review.
+//
+// The PR title lives on GitHub, not in the git checkout, so it is fetched from
+// the public GitHub REST API. group-picks is a public repo, so the call needs
+// no token — this is why the title-based gate requires no API key (unlike the
+// label-based follow-up tracked separately). If the repo is ever made private,
+// this fetch will 404 and the build will fail open (proceed) per the error
+// handling below; a token would then be required.
+
+const BUILD = 1; // exit code → Vercel proceeds with the build
+const SKIP = 0; // exit code → Vercel cancels the build
+
+// Matches feat/fix Conventional Commit titles, with an optional scope and an
+// optional breaking-change `!`: feat:, fix:, feat(api):, fix(ui)!:, etc.
+const DEPLOYABLE_TITLE = /^(feat|fix)(\([^)]*\))?!?:/i;
+
+export function isDeployableTitle(title) {
+  return DEPLOYABLE_TITLE.test((title ?? "").trim());
+}
+
+async function fetchPullRequestTitle(owner, repo, prNumber) {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
+    { headers: { Accept: "application/vnd.github+json" } },
+  );
+  if (!response.ok) {
+    throw new Error(`GitHub API responded ${response.status}`);
+  }
+  const { title } = await response.json();
+  return title;
+}
+
+async function main() {
+  const env = process.env.VERCEL_ENV;
+  if (env === "production") {
+    console.log("✅ Production deploy — building.");
+    process.exit(BUILD);
+  }
+
+  const prNumber = process.env.VERCEL_GIT_PULL_REQUEST_ID;
+  if (!prNumber || prNumber === "0") {
+    console.log("⏭️  No associated pull request — skipping preview deploy.");
+    process.exit(SKIP);
+  }
+
+  const owner = process.env.VERCEL_GIT_REPO_OWNER;
+  const repo = process.env.VERCEL_GIT_REPO_SLUG;
+
+  try {
+    const title = await fetchPullRequestTitle(owner, repo, prNumber);
+    if (isDeployableTitle(title)) {
+      console.log(`✅ PR #${prNumber} "${title}" is feat/fix — building.`);
+      process.exit(BUILD);
+    }
+    console.log(
+      `⏭️  PR #${prNumber} "${title}" is not feat/fix — skipping preview deploy.`,
+    );
+    process.exit(SKIP);
+  } catch (error) {
+    // Fail open: a transient API failure should not silently drop a preview a
+    // reviewer is waiting on. Quota cost of an occasional over-build is the
+    // lesser evil versus a missing UAT preview.
+    console.warn(
+      `⚠️  Could not determine PR title (${error.message}) — building to be safe.`,
+    );
+    process.exit(BUILD);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/src/scripts/vercel-ignore-build.spec.ts
+++ b/src/scripts/vercel-ignore-build.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { isDeployableTitle } from "../../scripts/vercel-ignore-build.mjs";
+
+describe("isDeployableTitle: feat titles", () => {
+  it("returns true for a plain feat: title", () => {
+    expect(isDeployableTitle("feat: add user profile")).toBe(true);
+  });
+
+  it("returns true for a feat: title with a scope", () => {
+    expect(isDeployableTitle("feat(api): add endpoint")).toBe(true);
+  });
+
+  it("returns true for a feat!: title with the breaking-change marker", () => {
+    expect(isDeployableTitle("feat!: remove legacy auth")).toBe(true);
+  });
+
+  it("returns true for a feat(scope)!: title with scope and breaking-change marker", () => {
+    expect(isDeployableTitle("feat(api)!: remove v1 routes")).toBe(true);
+  });
+
+  it("returns true for a FEAT: title (case-insensitive)", () => {
+    expect(isDeployableTitle("FEAT: uppercase type")).toBe(true);
+  });
+});
+
+describe("isDeployableTitle: fix titles", () => {
+  it("returns true for a plain fix: title", () => {
+    expect(isDeployableTitle("fix: resolve login bug")).toBe(true);
+  });
+
+  it("returns true for a fix: title with a scope", () => {
+    expect(isDeployableTitle("fix(ui): correct button color")).toBe(true);
+  });
+
+  it("returns true for a fix!: title with the breaking-change marker", () => {
+    expect(isDeployableTitle("fix!: remove deprecated endpoint")).toBe(true);
+  });
+
+  it("returns true for a Fix: title (case-insensitive)", () => {
+    expect(isDeployableTitle("Fix: mixed-case type")).toBe(true);
+  });
+});
+
+describe("isDeployableTitle: non-deployable types", () => {
+  it("returns false for a chore: title", () => {
+    expect(isDeployableTitle("chore: update dependencies")).toBe(false);
+  });
+
+  it("returns false for a ci: title", () => {
+    expect(isDeployableTitle("ci: add lint job")).toBe(false);
+  });
+
+  it("returns false for a docs: title", () => {
+    expect(isDeployableTitle("docs: update README")).toBe(false);
+  });
+
+  it("returns false for a refactor: title", () => {
+    expect(isDeployableTitle("refactor: reorganize modules")).toBe(false);
+  });
+
+  it("returns false for a test: title", () => {
+    expect(isDeployableTitle("test: add unit tests")).toBe(false);
+  });
+
+  it("returns false for a style: title", () => {
+    expect(isDeployableTitle("style: format files")).toBe(false);
+  });
+
+  it("returns false for a perf: title", () => {
+    expect(isDeployableTitle("perf: optimize render")).toBe(false);
+  });
+
+  it("returns false for a revert: title", () => {
+    expect(isDeployableTitle("revert: undo last commit")).toBe(false);
+  });
+
+  it("returns false for a build: title", () => {
+    expect(isDeployableTitle("build: upgrade webpack")).toBe(false);
+  });
+});
+
+describe("isDeployableTitle: [WIP] prefix", () => {
+  it("returns false for a [WIP] feat: title", () => {
+    expect(isDeployableTitle("[WIP] feat: draft work")).toBe(false);
+  });
+
+  it("returns false for a [WIP] fix: title", () => {
+    expect(isDeployableTitle("[WIP] fix: draft fix")).toBe(false);
+  });
+});
+
+describe("isDeployableTitle: edge cases", () => {
+  it("returns false for an empty string", () => {
+    expect(isDeployableTitle("")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isDeployableTitle(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isDeployableTitle(undefined)).toBe(false);
+  });
+
+  it("trims leading and trailing whitespace before matching", () => {
+    expect(isDeployableTitle("  feat: padded title  ")).toBe(true);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "git config --global url.\"https://github.com/\".insteadOf \"git@github.com:\" && pnpm install --frozen-lockfile"
+  "installCommand": "git config --global url.\"https://github.com/\".insteadOf \"git@github.com:\" && pnpm install --frozen-lockfile",
+  "ignoreCommand": "node scripts/vercel-ignore-build.mjs"
 }


### PR DESCRIPTION
Gates Vercel **preview** deploys to PRs whose title is a `feat:` or `fix:` Conventional Commit, to stop non-UAT work (docs, chore, refactor, deps, ci, test, etc.) from consuming the daily preview-deploy quota. Production deploys from `main` are untouched.

## How

Adds a Vercel **Ignored Build Step** (`ignoreCommand` in `vercel.json`) backed by `scripts/vercel-ignore-build.mjs`. Vercel runs it for every deploy and reads its exit code (1 = build, 0 = cancel):

- **Production** (`VERCEL_ENV=production`) → always builds.
- **Preview with no associated PR** (pre-PR branch push) → skipped.
- **Preview with a PR** → fetches the PR title from the public GitHub REST API and builds only if it matches `^(feat|fix)(\(scope\))?!?:` (case-insensitive); otherwise skips. `[WIP]`-prefixed titles don't match, so draft work is skipped too — aligned with the goal of deploying only review/UAT-ready changes.

The title fetch needs **no API key**: group-picks is public, so an unauthenticated call returns the title. If the title can't be determined (transient API error), the step **fails open** and builds, so a hiccup never drops a preview a reviewer is waiting on.

## Why title, not branch

`new-worktree.py` names every branch `feat/…` regardless of the actual change type (e.g. this PR's own branch is `feat/…` but several open PRs are `refactor:`/`docs:`), so the branch ref is not a usable proxy — the real PR title is.

## Follow-up

A more precise **label-based** gate (deploy only when a PR is `ready for UAT`) is deferred to #351 — it needs a Vercel API token and an events-driven workflow, since labels are applied after the push rather than at build-trigger time.

## Testing

`isDeployableTitle` verified against feat/fix variants (scope, `!`, uppercase) and the real non-matching titles of currently-open PRs. `format` / `lint` / `tsc` / `test` all green.

---
*Created by Claude Opus 4.8*
