### PR TITLE
fix(ci): paginate screenshot comment search past 100 PR comments

### DIFF
--- a/scripts/post-screenshots-comment.d.mts
+++ b/scripts/post-screenshots-comment.d.mts
@@ -1,0 +1,22 @@
+export declare const MARKER: string;
+
+export declare function parseNextLink(
+  linkHeader: string | null | undefined,
+): string | undefined;
+
+export interface MarkerComment {
+  id: number;
+  body?: string;
+}
+
+export interface FindMarkerCommentOptions {
+  fetchFn?: (url: string, init?: RequestInit) => Promise<Response>;
+  repo: string;
+  pr: string;
+  token: string;
+  marker?: string;
+}
+
+export declare function findMarkerComment(
+  options: FindMarkerCommentOptions,
+): Promise<MarkerComment | undefined>;

--- a/scripts/post-screenshots-comment.mjs
+++ b/scripts/post-screenshots-comment.mjs
@@ -13,8 +13,9 @@
 // Requires env: GITHUB_REPOSITORY (owner/repo) and GITHUB_TOKEN.
 
 import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const MARKER = "<!-- storybook-screenshots -->";
+export const MARKER = "<!-- storybook-screenshots -->";
 
 function parseArgs(argv) {
   const args = { dir: "screenshots" };
@@ -25,6 +26,14 @@ function parseArgs(argv) {
     else if (arg.startsWith("--dir=")) args.dir = arg.slice(6);
   }
   return args;
+}
+
+// Extract the `rel="next"` URL from a GitHub `Link` response header, or
+// undefined when no next page exists (last page, or header absent).
+export function parseNextLink(linkHeader) {
+  if (!linkHeader) return undefined;
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+  return match ? match[1] : undefined;
 }
 
 async function gh(path, method = "GET", body) {
@@ -43,6 +52,36 @@ async function gh(path, method = "GET", body) {
     );
   }
   return res.json();
+}
+
+// Search every page of a PR's comments for the sticky marker, following the
+// `Link: rel="next"` header until exhausted (#342). Without this loop only the
+// first 100 comments were searched, so a marker beyond page 1 was missed and a
+// duplicate comment posted. `fetchFn` is injectable for testing.
+export async function findMarkerComment({
+  fetchFn = fetch,
+  repo,
+  pr,
+  token,
+  marker = MARKER,
+}) {
+  let url = `https://api.github.com/repos/${repo}/issues/${pr}/comments?per_page=100`;
+  while (url) {
+    const res = await fetchFn(url, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/vnd.github+json",
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`GitHub GET ${url} -> ${res.status} ${await res.text()}`);
+    }
+    const comments = await res.json();
+    const existing = comments.find((c) => c.body?.includes(marker));
+    if (existing) return existing;
+    url = parseNextLink(res.headers.get("link"));
+  }
+  return undefined;
 }
 
 function buildBody(repo, branch, sha, files) {
@@ -87,10 +126,11 @@ async function main() {
   }
 
   const body = buildBody(repo, args.branch, args.sha, files);
-  const comments = await gh(
-    `/repos/${repo}/issues/${args.pr}/comments?per_page=100`,
-  );
-  const existing = comments.find((c) => c.body?.includes(MARKER));
+  const existing = await findMarkerComment({
+    repo,
+    pr: args.pr,
+    token: process.env.GITHUB_TOKEN,
+  });
 
   if (existing) {
     await gh(`/repos/${repo}/issues/comments/${existing.id}`, "PATCH", {
@@ -103,7 +143,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/scripts/post-screenshots-comment.spec.ts
+++ b/src/scripts/post-screenshots-comment.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  findMarkerComment,
+  MARKER,
+  parseNextLink,
+} from "../../scripts/post-screenshots-comment.mjs";
+
+interface CommentPage {
+  comments: { id: number; body: string }[];
+  next?: string;
+}
+
+// Build a `fetch` stub whose responses are keyed by request URL, so the
+// pagination loop is driven purely by the `Link: <...>; rel="next"` headers
+// each real `Response` carries — no network access.
+function makeFetch(pages: Record<string, CommentPage>) {
+  return vi.fn((url: string) => {
+    const page = pages[url];
+    if (!page) {
+      throw new Error(`unexpected fetch url: ${url}`);
+    }
+    const headers = new Headers();
+    if (page.next) {
+      headers.set("link", `<${page.next}>; rel="next"`);
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(page.comments), { status: 200, headers }),
+    );
+  });
+}
+
+const PAGE_1 =
+  "https://api.github.com/repos/o/r/issues/7/comments?per_page=100";
+const PAGE_2 =
+  "https://api.github.com/repos/o/r/issues/7/comments?per_page=100&page=2";
+
+describe("parseNextLink: extract the rel=next URL", () => {
+  it("returns the next-page URL when a rel=next link is present", () => {
+    const header =
+      '<https://api.github.com/x?page=2>; rel="next", <https://api.github.com/x?page=9>; rel="last"';
+    expect(parseNextLink(header)).toBe("https://api.github.com/x?page=2");
+  });
+
+  it("returns undefined when there is no rel=next link", () => {
+    const header = '<https://api.github.com/x?page=9>; rel="last"';
+    expect(parseNextLink(header)).toBeUndefined();
+  });
+
+  it("returns undefined for a missing header", () => {
+    expect(parseNextLink(null)).toBeUndefined();
+  });
+});
+
+describe("findMarkerComment: paginate past the first page", () => {
+  it("finds a marker comment located on page 2", async () => {
+    const fetchFn = makeFetch({
+      [PAGE_1]: {
+        comments: [
+          { id: 1, body: "first" },
+          { id: 2, body: "second" },
+        ],
+        next: PAGE_2,
+      },
+      [PAGE_2]: {
+        comments: [
+          { id: 3, body: "third" },
+          { id: 42, body: `${MARKER}\n## screenshots` },
+        ],
+      },
+    });
+
+    const existing = await findMarkerComment({
+      fetchFn,
+      repo: "o/r",
+      pr: "7",
+      token: "t",
+    });
+
+    expect(existing?.id).toBe(42);
+    // Both pages must have been fetched to reach the page-2 marker.
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn).toHaveBeenNthCalledWith(1, PAGE_1, expect.anything());
+    expect(fetchFn).toHaveBeenNthCalledWith(2, PAGE_2, expect.anything());
+  });
+
+  it("returns undefined when no page contains the marker", async () => {
+    const fetchFn = makeFetch({
+      [PAGE_1]: { comments: [{ id: 1, body: "a" }], next: PAGE_2 },
+      [PAGE_2]: { comments: [{ id: 2, body: "b" }] },
+    });
+
+    const existing = await findMarkerComment({
+      fetchFn,
+      repo: "o/r",
+      pr: "7",
+      token: "t",
+    });
+
+    expect(existing).toBeUndefined();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Fixes the screenshot upsert missing an existing sticky comment when a PR has more than 100 comments, which caused a duplicate to be posted instead of an in-place update.

`findMarkerComment` now follows the GitHub `Link: rel="next"` header until exhausted, so every page of comments is searched. The searchable logic is extracted into module exports (with a companion `.d.mts`) and `main()` is guarded behind an `import.meta.url` check so it can be unit-tested without real HTTP. The spec injects a `fetchFn` returning real `Response` objects with synthetic `Link` headers.

## Acceptance Criteria
- [x] Pagination loop follows `Link: rel="next"` so all comments are searched, not just the first 100
- [x] Unit test proves the marker is found on page 2+, mocking paginated API responses (no real HTTP)

## Tests
5 tests added, all passing (`findMarkerComment` page-2 hit + miss, `parseNextLink` cases).

Closes #342

---
*Created by Claude Opus 4.8*