### PR TITLE
feat(snap-picks)!: option pool management — add and remove options

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.spec.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetVerifiedUid,
+  mockGetGroupById,
+  mockGetCategoryById,
+  mockGetSnapPickById,
+  mockGetSnapPickOptions,
+  mockRemoveSnapPickOption,
+} = vi.hoisted(() => ({
+  mockGetVerifiedUid: vi.fn(),
+  mockGetGroupById: vi.fn(),
+  mockGetCategoryById: vi.fn(),
+  mockGetSnapPickById: vi.fn(),
+  mockGetSnapPickOptions: vi.fn(),
+  mockRemoveSnapPickOption: vi.fn(),
+}));
+
+vi.mock("@/server/utils/auth", () => ({
+  getVerifiedUid: mockGetVerifiedUid,
+}));
+
+vi.mock("@/server/data/groups", () => ({
+  getGroupById: mockGetGroupById,
+}));
+
+vi.mock("@/server/data/categories", () => ({
+  getCategoryById: mockGetCategoryById,
+}));
+
+vi.mock("@/server/data/snap-picks", () => ({
+  getSnapPickById: mockGetSnapPickById,
+  getSnapPickOptions: mockGetSnapPickOptions,
+  removeSnapPickOption: mockRemoveSnapPickOption,
+}));
+
+const { DELETE } = await import("./route");
+
+const params = Promise.resolve({
+  id: "group-1",
+  categoryId: "cat-1",
+  snapPickId: "snap-1",
+  optionId: "option-1",
+});
+
+function makeOption(overrides?: Record<string, unknown>) {
+  return {
+    id: "option-1",
+    title: "Pizza",
+    addedBy: "user-1",
+    addedAt: new Date("2025-01-10T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetVerifiedUid.mockResolvedValue("user-1");
+  mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["user-1"] });
+  mockGetCategoryById.mockResolvedValue({ id: "cat-1", groupId: "group-1" });
+  mockGetSnapPickById.mockResolvedValue({ id: "snap-1", categoryId: "cat-1" });
+  mockGetSnapPickOptions.mockResolvedValue([makeOption()]);
+  mockRemoveSnapPickOption.mockResolvedValue({
+    removedAt: new Date("2025-01-20T00:00:00Z"),
+  });
+});
+
+describe("DELETE /api/.../snap-picks/[snapPickId]/options/[optionId]", () => {
+  it("soft-deletes the option when the caller owns it", async () => {
+    const response = await DELETE(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockRemoveSnapPickOption).toHaveBeenCalledWith("snap-1", "option-1");
+  });
+
+  it("returns 403 when the caller does not own the option", async () => {
+    mockGetSnapPickOptions.mockResolvedValue([
+      makeOption({ addedBy: "someone-else" }),
+    ]);
+
+    const response = await DELETE(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(403);
+    expect(mockRemoveSnapPickOption).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the option does not exist", async () => {
+    mockGetSnapPickOptions.mockResolvedValue([]);
+
+    const response = await DELETE(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when the option is already removed", async () => {
+    mockGetSnapPickOptions.mockResolvedValue([
+      makeOption({ removedAt: new Date("2025-01-15T00:00:00Z") }),
+    ]);
+
+    const response = await DELETE(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(404);
+    expect(mockRemoveSnapPickOption).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUid.mockResolvedValue(undefined);
+
+    const response = await DELETE(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.spec.ts
@@ -1,17 +1,14 @@
+import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetVerifiedUid,
-  mockGetGroupById,
-  mockGetCategoryById,
-  mockGetSnapPickById,
+  mockAuthorizeSnapPickMember,
   mockGetSnapPickOptions,
   mockRemoveSnapPickOption,
 } = vi.hoisted(() => ({
   mockGetVerifiedUid: vi.fn(),
-  mockGetGroupById: vi.fn(),
-  mockGetCategoryById: vi.fn(),
-  mockGetSnapPickById: vi.fn(),
+  mockAuthorizeSnapPickMember: vi.fn(),
   mockGetSnapPickOptions: vi.fn(),
   mockRemoveSnapPickOption: vi.fn(),
 }));
@@ -20,16 +17,11 @@ vi.mock("@/server/utils/auth", () => ({
   getVerifiedUid: mockGetVerifiedUid,
 }));
 
-vi.mock("@/server/data/groups", () => ({
-  getGroupById: mockGetGroupById,
-}));
-
-vi.mock("@/server/data/categories", () => ({
-  getCategoryById: mockGetCategoryById,
+vi.mock("@/server/utils/snap-pick-auth", () => ({
+  authorizeSnapPickMember: mockAuthorizeSnapPickMember,
 }));
 
 vi.mock("@/server/data/snap-picks", () => ({
-  getSnapPickById: mockGetSnapPickById,
   getSnapPickOptions: mockGetSnapPickOptions,
   removeSnapPickOption: mockRemoveSnapPickOption,
 }));
@@ -56,9 +48,7 @@ function makeOption(overrides?: Record<string, unknown>) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetVerifiedUid.mockResolvedValue("user-1");
-  mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["user-1"] });
-  mockGetCategoryById.mockResolvedValue({ id: "cat-1", groupId: "group-1" });
-  mockGetSnapPickById.mockResolvedValue({ id: "snap-1", categoryId: "cat-1" });
+  mockAuthorizeSnapPickMember.mockResolvedValue(undefined);
   mockGetSnapPickOptions.mockResolvedValue([makeOption()]);
   mockRemoveSnapPickOption.mockResolvedValue({
     removedAt: new Date("2025-01-20T00:00:00Z"),
@@ -109,5 +99,16 @@ describe("DELETE /api/.../snap-picks/[snapPickId]/options/[optionId]", () => {
     const response = await DELETE(new Request("http://localhost"), { params });
 
     expect(response.status).toBe(401);
+  });
+
+  it("returns 403 when member authorization fails", async () => {
+    mockAuthorizeSnapPickMember.mockResolvedValue(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    );
+
+    const response = await DELETE(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(403);
+    expect(mockRemoveSnapPickOption).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from "next/server";
 
-import { getCategoryById } from "@/server/data/categories";
-import { getGroupById } from "@/server/data/groups";
 import {
-  getSnapPickById,
   getSnapPickOptions,
   removeSnapPickOption,
 } from "@/server/data/snap-picks";
 import { getVerifiedUid } from "@/server/utils/auth";
+import { authorizeSnapPickMember } from "@/server/utils/snap-pick-auth";
 
 interface RouteParams {
   params: Promise<{
@@ -25,27 +23,13 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
   }
 
   const { id: groupId, categoryId, snapPickId, optionId } = await params;
-  const [group, category, snapPick] = await Promise.all([
-    getGroupById(groupId),
-    getCategoryById(categoryId),
-    getSnapPickById(categoryId, snapPickId),
-  ]);
-
-  if (!group) {
-    return NextResponse.json({ error: "Group not found" }, { status: 404 });
-  }
-
-  if (!group.memberIds.includes(uid)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  if (category?.groupId !== groupId) {
-    return NextResponse.json({ error: "Category not found" }, { status: 404 });
-  }
-
-  if (!snapPick) {
-    return NextResponse.json({ error: "Snap pick not found" }, { status: 404 });
-  }
+  const denied = await authorizeSnapPickMember(
+    uid,
+    groupId,
+    categoryId,
+    snapPickId,
+  );
+  if (denied) return denied;
 
   const options = await getSnapPickOptions(snapPickId, true);
   const option = options.find((o) => o.id === optionId);

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+import { getCategoryById } from "@/server/data/categories";
+import { getGroupById } from "@/server/data/groups";
+import {
+  getSnapPickById,
+  getSnapPickOptions,
+  removeSnapPickOption,
+} from "@/server/data/snap-picks";
+import { getVerifiedUid } from "@/server/utils/auth";
+
+interface RouteParams {
+  params: Promise<{
+    id: string;
+    categoryId: string;
+    snapPickId: string;
+    optionId: string;
+  }>;
+}
+
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: groupId, categoryId, snapPickId, optionId } = await params;
+  const [group, category, snapPick] = await Promise.all([
+    getGroupById(groupId),
+    getCategoryById(categoryId),
+    getSnapPickById(categoryId, snapPickId),
+  ]);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (category?.groupId !== groupId) {
+    return NextResponse.json({ error: "Category not found" }, { status: 404 });
+  }
+
+  if (!snapPick) {
+    return NextResponse.json({ error: "Snap pick not found" }, { status: 404 });
+  }
+
+  const options = await getSnapPickOptions(snapPickId, true);
+  const option = options.find((o) => o.id === optionId);
+
+  if (!option || option.removedAt !== undefined) {
+    return NextResponse.json({ error: "Option not found" }, { status: 404 });
+  }
+
+  // Only the member who added an option may remove it from the pool.
+  if (option.addedBy !== uid) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { removedAt } = await removeSnapPickOption(snapPickId, optionId);
+
+  return NextResponse.json({ removedAt: removedAt.toISOString() });
+}

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.spec.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetVerifiedUid,
+  mockGetGroupById,
+  mockGetCategoryById,
+  mockGetSnapPickById,
+  mockGetSnapPickOptions,
+  mockAddSnapPickOption,
+} = vi.hoisted(() => ({
+  mockGetVerifiedUid: vi.fn(),
+  mockGetGroupById: vi.fn(),
+  mockGetCategoryById: vi.fn(),
+  mockGetSnapPickById: vi.fn(),
+  mockGetSnapPickOptions: vi.fn(),
+  mockAddSnapPickOption: vi.fn(),
+}));
+
+vi.mock("@/server/utils/auth", () => ({
+  getVerifiedUid: mockGetVerifiedUid,
+}));
+
+vi.mock("@/server/data/groups", () => ({
+  getGroupById: mockGetGroupById,
+}));
+
+vi.mock("@/server/data/categories", () => ({
+  getCategoryById: mockGetCategoryById,
+}));
+
+vi.mock("@/server/data/snap-picks", () => ({
+  getSnapPickById: mockGetSnapPickById,
+  getSnapPickOptions: mockGetSnapPickOptions,
+  addSnapPickOption: mockAddSnapPickOption,
+}));
+
+const { GET, POST } = await import("./route");
+
+const params = Promise.resolve({
+  id: "group-1",
+  categoryId: "cat-1",
+  snapPickId: "snap-1",
+});
+
+function makeRequest(body: unknown) {
+  return new Request(
+    "http://localhost/api/groups/group-1/categories/cat-1/snap-picks/snap-1/options",
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetVerifiedUid.mockResolvedValue("user-1");
+  mockGetGroupById.mockResolvedValue({
+    id: "group-1",
+    memberIds: ["user-1"],
+  });
+  mockGetCategoryById.mockResolvedValue({ id: "cat-1", groupId: "group-1" });
+  mockGetSnapPickById.mockResolvedValue({ id: "snap-1", categoryId: "cat-1" });
+  mockGetSnapPickOptions.mockResolvedValue([]);
+  mockAddSnapPickOption.mockResolvedValue({
+    id: "option-new",
+    addedAt: new Date("2025-01-15T00:00:00Z"),
+  });
+});
+
+describe("GET /api/.../snap-picks/[snapPickId]/options", () => {
+  it("returns the pool options for a member", async () => {
+    mockGetSnapPickOptions.mockResolvedValue([
+      {
+        id: "option-1",
+        title: "Pizza",
+        addedBy: "user-1",
+        addedAt: new Date("2025-01-10T00:00:00Z"),
+      },
+    ]);
+
+    const response = await GET(new Request("http://localhost"), { params });
+    const data = (await response.json()) as { options: { id: string }[] };
+
+    expect(response.status).toBe(200);
+    expect(data.options[0]?.id).toBe("option-1");
+    expect(mockGetSnapPickOptions).toHaveBeenCalledWith("snap-1");
+  });
+
+  it("returns 403 for a non-member", async () => {
+    mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["other"] });
+
+    const response = await GET(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when the snap pick does not exist", async () => {
+    mockGetSnapPickById.mockResolvedValue(undefined);
+
+    const response = await GET(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("POST /api/.../snap-picks/[snapPickId]/options", () => {
+  it("adds an option and returns 201 with the option id", async () => {
+    const response = await POST(makeRequest({ title: "Tacos" }), { params });
+    const data = (await response.json()) as { optionId: string };
+
+    expect(response.status).toBe(201);
+    expect(data.optionId).toBe("option-new");
+    expect(mockAddSnapPickOption).toHaveBeenCalledWith("snap-1", {
+      title: "Tacos",
+      addedBy: "user-1",
+    });
+  });
+
+  it("trims the title before persisting", async () => {
+    await POST(makeRequest({ title: "  Sushi  " }), { params });
+
+    expect(mockAddSnapPickOption).toHaveBeenCalledWith("snap-1", {
+      title: "Sushi",
+      addedBy: "user-1",
+    });
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const response = await POST(makeRequest({}), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockAddSnapPickOption).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUid.mockResolvedValue(undefined);
+
+    const response = await POST(makeRequest({ title: "Tacos" }), { params });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.spec.ts
@@ -1,17 +1,14 @@
+import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetVerifiedUid,
-  mockGetGroupById,
-  mockGetCategoryById,
-  mockGetSnapPickById,
+  mockAuthorizeSnapPickMember,
   mockGetSnapPickOptions,
   mockAddSnapPickOption,
 } = vi.hoisted(() => ({
   mockGetVerifiedUid: vi.fn(),
-  mockGetGroupById: vi.fn(),
-  mockGetCategoryById: vi.fn(),
-  mockGetSnapPickById: vi.fn(),
+  mockAuthorizeSnapPickMember: vi.fn(),
   mockGetSnapPickOptions: vi.fn(),
   mockAddSnapPickOption: vi.fn(),
 }));
@@ -20,16 +17,11 @@ vi.mock("@/server/utils/auth", () => ({
   getVerifiedUid: mockGetVerifiedUid,
 }));
 
-vi.mock("@/server/data/groups", () => ({
-  getGroupById: mockGetGroupById,
-}));
-
-vi.mock("@/server/data/categories", () => ({
-  getCategoryById: mockGetCategoryById,
+vi.mock("@/server/utils/snap-pick-auth", () => ({
+  authorizeSnapPickMember: mockAuthorizeSnapPickMember,
 }));
 
 vi.mock("@/server/data/snap-picks", () => ({
-  getSnapPickById: mockGetSnapPickById,
   getSnapPickOptions: mockGetSnapPickOptions,
   addSnapPickOption: mockAddSnapPickOption,
 }));
@@ -56,12 +48,7 @@ function makeRequest(body: unknown) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetVerifiedUid.mockResolvedValue("user-1");
-  mockGetGroupById.mockResolvedValue({
-    id: "group-1",
-    memberIds: ["user-1"],
-  });
-  mockGetCategoryById.mockResolvedValue({ id: "cat-1", groupId: "group-1" });
-  mockGetSnapPickById.mockResolvedValue({ id: "snap-1", categoryId: "cat-1" });
+  mockAuthorizeSnapPickMember.mockResolvedValue(undefined);
   mockGetSnapPickOptions.mockResolvedValue([]);
   mockAddSnapPickOption.mockResolvedValue({
     id: "option-new",
@@ -88,8 +75,18 @@ describe("GET /api/.../snap-picks/[snapPickId]/options", () => {
     expect(mockGetSnapPickOptions).toHaveBeenCalledWith("snap-1");
   });
 
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUid.mockResolvedValue(undefined);
+
+    const response = await GET(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(401);
+  });
+
   it("returns 403 for a non-member", async () => {
-    mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["other"] });
+    mockAuthorizeSnapPickMember.mockResolvedValue(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    );
 
     const response = await GET(new Request("http://localhost"), { params });
 
@@ -97,7 +94,9 @@ describe("GET /api/.../snap-picks/[snapPickId]/options", () => {
   });
 
   it("returns 404 when the snap pick does not exist", async () => {
-    mockGetSnapPickById.mockResolvedValue(undefined);
+    mockAuthorizeSnapPickMember.mockResolvedValue(
+      NextResponse.json({ error: "Snap pick not found" }, { status: 404 }),
+    );
 
     const response = await GET(new Request("http://localhost"), { params });
 

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+
+import { getCategoryById } from "@/server/data/categories";
+import { getGroupById } from "@/server/data/groups";
+import {
+  addSnapPickOption,
+  getSnapPickById,
+  getSnapPickOptions,
+} from "@/server/data/snap-picks";
+import { getVerifiedUid } from "@/server/utils/auth";
+
+interface RouteParams {
+  params: Promise<{ id: string; categoryId: string; snapPickId: string }>;
+}
+
+// Confirms the caller is a member of the group and the snap pick exists under the
+// given category. Returns an error NextResponse on failure, or undefined on success.
+async function authorizeMember(
+  uid: string,
+  groupId: string,
+  categoryId: string,
+  snapPickId: string,
+): Promise<NextResponse | undefined> {
+  const [group, category, snapPick] = await Promise.all([
+    getGroupById(groupId),
+    getCategoryById(categoryId),
+    getSnapPickById(categoryId, snapPickId),
+  ]);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (category?.groupId !== groupId) {
+    return NextResponse.json({ error: "Category not found" }, { status: 404 });
+  }
+
+  if (!snapPick) {
+    return NextResponse.json({ error: "Snap pick not found" }, { status: 404 });
+  }
+
+  return undefined;
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: groupId, categoryId, snapPickId } = await params;
+  const denied = await authorizeMember(uid, groupId, categoryId, snapPickId);
+  if (denied) return denied;
+
+  const options = await getSnapPickOptions(snapPickId);
+
+  return NextResponse.json({ options });
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const uid = await getVerifiedUid();
+  if (!uid) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: groupId, categoryId, snapPickId } = await params;
+  const denied = await authorizeMember(uid, groupId, categoryId, snapPickId);
+  if (denied) return denied;
+
+  let body: { title: unknown };
+  try {
+    body = (await request.json()) as { title: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (typeof body.title !== "string" || !body.title.trim()) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+  const title = body.title.trim();
+
+  const { id: optionId, addedAt } = await addSnapPickOption(snapPickId, {
+    title,
+    addedBy: uid,
+  });
+
+  return NextResponse.json(
+    { optionId, addedAt: addedAt.toISOString() },
+    { status: 201 },
+  );
+}

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/route.ts
@@ -1,49 +1,14 @@
 import { NextResponse } from "next/server";
 
-import { getCategoryById } from "@/server/data/categories";
-import { getGroupById } from "@/server/data/groups";
 import {
   addSnapPickOption,
-  getSnapPickById,
   getSnapPickOptions,
 } from "@/server/data/snap-picks";
 import { getVerifiedUid } from "@/server/utils/auth";
+import { authorizeSnapPickMember } from "@/server/utils/snap-pick-auth";
 
 interface RouteParams {
   params: Promise<{ id: string; categoryId: string; snapPickId: string }>;
-}
-
-// Confirms the caller is a member of the group and the snap pick exists under the
-// given category. Returns an error NextResponse on failure, or undefined on success.
-async function authorizeMember(
-  uid: string,
-  groupId: string,
-  categoryId: string,
-  snapPickId: string,
-): Promise<NextResponse | undefined> {
-  const [group, category, snapPick] = await Promise.all([
-    getGroupById(groupId),
-    getCategoryById(categoryId),
-    getSnapPickById(categoryId, snapPickId),
-  ]);
-
-  if (!group) {
-    return NextResponse.json({ error: "Group not found" }, { status: 404 });
-  }
-
-  if (!group.memberIds.includes(uid)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  if (category?.groupId !== groupId) {
-    return NextResponse.json({ error: "Category not found" }, { status: 404 });
-  }
-
-  if (!snapPick) {
-    return NextResponse.json({ error: "Snap pick not found" }, { status: 404 });
-  }
-
-  return undefined;
 }
 
 export async function GET(_request: Request, { params }: RouteParams) {
@@ -53,7 +18,12 @@ export async function GET(_request: Request, { params }: RouteParams) {
   }
 
   const { id: groupId, categoryId, snapPickId } = await params;
-  const denied = await authorizeMember(uid, groupId, categoryId, snapPickId);
+  const denied = await authorizeSnapPickMember(
+    uid,
+    groupId,
+    categoryId,
+    snapPickId,
+  );
   if (denied) return denied;
 
   const options = await getSnapPickOptions(snapPickId);
@@ -68,7 +38,12 @@ export async function POST(request: Request, { params }: RouteParams) {
   }
 
   const { id: groupId, categoryId, snapPickId } = await params;
-  const denied = await authorizeMember(uid, groupId, categoryId, snapPickId);
+  const denied = await authorizeSnapPickMember(
+    uid,
+    groupId,
+    categoryId,
+    snapPickId,
+  );
   if (denied) return denied;
 
   let body: { title: unknown };

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.copy.ts
@@ -1,6 +1,7 @@
 export const SNAP_PICK_DETAIL_COPY = {
   optionPoolHeading: "Option pool",
-  optionPoolPlaceholder: "Option pool management is coming soon.",
+  optionPoolActivationNotice:
+    "A head-to-head run is in progress. The option pool is locked until it closes.",
   activationHeading: "Activation",
   activationPlaceholder: "Starting a head-to-head run is coming soon.",
   votingHeading: "Voting",

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.spec.tsx
@@ -11,7 +11,12 @@ afterEach(cleanup);
 describe("renders the Snap Pick detail shell", () => {
   it("shows the snap pick title as the heading", () => {
     render(
-      <SnapPickDetailView snapPick={makeSnapPick({ title: "Friday Lunch" })} />,
+      <SnapPickDetailView
+        snapPick={makeSnapPick({ title: "Friday Lunch" })}
+        groupId="group-1"
+        currentUserId="user-1"
+        options={[]}
+      />,
     );
 
     expect(
@@ -20,7 +25,14 @@ describe("renders the Snap Pick detail shell", () => {
   });
 
   it("renders slots for the option pool, activation, and voting sections", () => {
-    render(<SnapPickDetailView snapPick={makeSnapPick()} />);
+    render(
+      <SnapPickDetailView
+        snapPick={makeSnapPick()}
+        groupId="group-1"
+        currentUserId="user-1"
+        options={[]}
+      />,
+    );
 
     expect(
       screen.getByText(SNAP_PICK_DETAIL_COPY.optionPoolHeading),
@@ -29,5 +41,21 @@ describe("renders the Snap Pick detail shell", () => {
       screen.getByText(SNAP_PICK_DETAIL_COPY.activationHeading),
     ).toBeDefined();
     expect(screen.getByText(SNAP_PICK_DETAIL_COPY.votingHeading)).toBeDefined();
+  });
+
+  it("locks the option pool while an activation is in progress", () => {
+    render(
+      <SnapPickDetailView
+        snapPick={makeSnapPick()}
+        groupId="group-1"
+        currentUserId="user-1"
+        options={[]}
+        activationInProgress
+      />,
+    );
+
+    expect(
+      screen.getByText(SNAP_PICK_DETAIL_COPY.optionPoolActivationNotice),
+    ).toBeDefined();
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { makeSnapPick } from "@/lib/fixtures/snap-pick";
+import { makeSnapPick, makeSnapPickOption } from "@/lib/fixtures/snap-pick";
 
 import { SnapPickDetailView } from "./SnapPickDetailView";
 
@@ -9,6 +9,12 @@ const meta = {
   component: SnapPickDetailView,
   args: {
     snapPick: makeSnapPick({ title: "Friday Lunch" }),
+    groupId: "group-1",
+    currentUserId: "user-1",
+    options: [
+      makeSnapPickOption({ id: "option-1", title: "Pizza", addedBy: "user-1" }),
+      makeSnapPickOption({ id: "option-2", title: "Tacos", addedBy: "user-2" }),
+    ],
   },
 } satisfies Meta<typeof SnapPickDetailView>;
 
@@ -17,3 +23,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const ActivationInProgress: Story = {
+  args: {
+    activationInProgress: true,
+  },
+};

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.tsx
@@ -1,15 +1,26 @@
-import type { SnapPick } from "@/lib/types/snap-pick";
+import type { SnapPick, SnapPickOption } from "@/lib/types/snap-pick";
 
 import { SNAP_PICK_DETAIL_COPY } from "./SnapPickDetailView.copy";
+import { SnapPickOptionList } from "./SnapPickOptionList";
 
 interface SnapPickDetailViewProps {
   snapPick: SnapPick;
+  groupId: string;
+  currentUserId: string;
+  options: SnapPickOption[];
+  activationInProgress?: boolean;
 }
 
-// Shell for the Snap Pick detail page. The option-pool (#257), activation
-// (#258), and voting (#259) sections fill in their slots below as those
-// features land.
-export function SnapPickDetailView({ snapPick }: SnapPickDetailViewProps) {
+// Shell for the Snap Pick detail page. The option-pool (#257) section is live;
+// the activation (#258) and voting (#259) sections fill in their slots as those
+// features land. The option pool is shown only while no activation is running.
+export function SnapPickDetailView({
+  snapPick,
+  groupId,
+  currentUserId,
+  options,
+  activationInProgress = false,
+}: SnapPickDetailViewProps) {
   return (
     <main className="mx-auto max-w-2xl p-4">
       <h1 className="text-2xl font-bold">{snapPick.title}</h1>
@@ -18,9 +29,19 @@ export function SnapPickDetailView({ snapPick }: SnapPickDetailViewProps) {
         <h2 className="text-lg font-semibold">
           {SNAP_PICK_DETAIL_COPY.optionPoolHeading}
         </h2>
-        <p className="text-sm text-muted-foreground">
-          {SNAP_PICK_DETAIL_COPY.optionPoolPlaceholder}
-        </p>
+        {activationInProgress ? (
+          <p className="text-sm text-muted-foreground">
+            {SNAP_PICK_DETAIL_COPY.optionPoolActivationNotice}
+          </p>
+        ) : (
+          <SnapPickOptionList
+            groupId={groupId}
+            categoryId={snapPick.categoryId}
+            snapPickId={snapPick.id}
+            currentUserId={currentUserId}
+            initialOptions={options}
+          />
+        )}
       </section>
 
       <section className="mt-6" data-slot="activation">

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionList.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionList.copy.ts
@@ -1,0 +1,8 @@
+export const SNAP_PICK_OPTION_LIST_COPY = {
+  addOptionButton: "Add",
+  addOptionPlaceholder: "Add an option to the pool",
+  errorDefault: "Something went wrong. Please try again.",
+  noOptionsMessage: "No options yet. Add the first one below.",
+  removeOptionButton: "Remove",
+  removeOptionLabel: "Remove option",
+} as const;

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionList.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionList.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+
+import type { SnapPickOption } from "@/lib/types/snap-pick";
+import { addSnapPickOption, removeSnapPickOption } from "@/services/snap-picks";
+
+import { SNAP_PICK_OPTION_LIST_COPY } from "./SnapPickOptionList.copy";
+import { SnapPickOptionListView } from "./SnapPickOptionListView";
+
+interface SnapPickOptionListProps {
+  groupId: string;
+  categoryId: string;
+  snapPickId: string;
+  currentUserId: string;
+  initialOptions: SnapPickOption[];
+}
+
+export function SnapPickOptionList({
+  groupId,
+  categoryId,
+  snapPickId,
+  currentUserId,
+  initialOptions,
+}: SnapPickOptionListProps) {
+  const [options, setOptions] = useState<SnapPickOption[]>(initialOptions);
+  const [newTitle, setNewTitle] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  async function handleAddSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    const title = newTitle.trim();
+    if (!title) return;
+    setError(undefined);
+    setLoading(true);
+    try {
+      const { optionId, addedAt } = await addSnapPickOption(
+        groupId,
+        categoryId,
+        snapPickId,
+        title,
+      );
+      setOptions((prev) => [
+        ...prev,
+        { id: optionId, title, addedBy: currentUserId, addedAt },
+      ]);
+      setNewTitle("");
+    } catch {
+      setError(SNAP_PICK_OPTION_LIST_COPY.errorDefault);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleRemove(option: SnapPickOption) {
+    setError(undefined);
+    setLoading(true);
+    // Optimistically drop the option from the visible pool.
+    setOptions((prev) => prev.filter((o) => o.id !== option.id));
+    try {
+      await removeSnapPickOption(groupId, categoryId, snapPickId, option.id);
+    } catch {
+      // Restore on failure, preserving the original order.
+      setOptions((prev) =>
+        [...prev, option].sort(
+          (a, b) => a.addedAt.getTime() - b.addedAt.getTime(),
+        ),
+      );
+      setError(SNAP_PICK_OPTION_LIST_COPY.errorDefault);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <SnapPickOptionListView
+      options={options}
+      currentUserId={currentUserId}
+      newTitle={newTitle}
+      loading={loading}
+      error={error}
+      onNewTitleChange={setNewTitle}
+      onAddSubmit={(e) => void handleAddSubmit(e)}
+      onRemove={(option) => void handleRemove(option)}
+    />
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionListView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionListView.spec.tsx
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// TODO: upgrade to userEvent when @testing-library/user-event is available
+import { makeSnapPickOption } from "@/lib/fixtures/snap-pick";
+
+import { SNAP_PICK_OPTION_LIST_COPY } from "./SnapPickOptionList.copy";
+import { SnapPickOptionListView } from "./SnapPickOptionListView";
+
+afterEach(cleanup);
+
+const noop = () => undefined;
+
+function renderView(
+  overrides?: Partial<React.ComponentProps<typeof SnapPickOptionListView>>,
+) {
+  return render(
+    <SnapPickOptionListView
+      options={[]}
+      currentUserId="user-1"
+      newTitle=""
+      loading={false}
+      error={undefined}
+      onNewTitleChange={noop}
+      onAddSubmit={noop}
+      onRemove={noop}
+      {...overrides}
+    />,
+  );
+}
+
+describe("Members can add a new option to the pool", () => {
+  it("submits the add form", () => {
+    const onAddSubmit = vi.fn((e: React.SyntheticEvent) => {
+      e.preventDefault();
+    });
+    renderView({ newTitle: "Pizza", onAddSubmit });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SNAP_PICK_OPTION_LIST_COPY.addOptionButton,
+      }),
+    );
+
+    expect(onAddSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the empty-pool message when there are no options", () => {
+    renderView({ options: [] });
+
+    expect(
+      screen.getByText(SNAP_PICK_OPTION_LIST_COPY.noOptionsMessage),
+    ).toBeDefined();
+  });
+});
+
+describe("Members can remove an option they own", () => {
+  it("shows a remove control for an option the current user added", () => {
+    renderView({
+      options: [makeSnapPickOption({ title: "Pizza", addedBy: "user-1" })],
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: `${SNAP_PICK_OPTION_LIST_COPY.removeOptionLabel}: Pizza`,
+      }),
+    ).toBeDefined();
+  });
+
+  it("hides the remove control for an option another user added", () => {
+    renderView({
+      options: [makeSnapPickOption({ title: "Tacos", addedBy: "user-2" })],
+    });
+
+    expect(
+      screen.queryByRole("button", {
+        name: `${SNAP_PICK_OPTION_LIST_COPY.removeOptionLabel}: Tacos`,
+      }),
+    ).toBeNull();
+  });
+
+  it("calls onRemove with the option when the remove control is clicked", () => {
+    const option = makeSnapPickOption({ title: "Pizza", addedBy: "user-1" });
+    const onRemove = vi.fn();
+    renderView({ options: [option], onRemove });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `${SNAP_PICK_OPTION_LIST_COPY.removeOptionLabel}: Pizza`,
+      }),
+    );
+
+    expect(onRemove).toHaveBeenCalledWith(option);
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionListView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionListView.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { makeSnapPickOption } from "@/lib/fixtures/snap-pick";
+
+import { SnapPickOptionListView } from "./SnapPickOptionListView";
+
+const meta = {
+  title: "SnapPicks/SnapPickOptionListView",
+  component: SnapPickOptionListView,
+  args: {
+    currentUserId: "user-1",
+    newTitle: "",
+    loading: false,
+    error: undefined,
+    onNewTitleChange: () => undefined,
+    onAddSubmit: () => undefined,
+    onRemove: () => undefined,
+    options: [
+      makeSnapPickOption({ id: "option-1", title: "Pizza", addedBy: "user-1" }),
+      makeSnapPickOption({ id: "option-2", title: "Tacos", addedBy: "user-2" }),
+    ],
+  },
+} satisfies Meta<typeof SnapPickOptionListView>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: {
+    options: [],
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    error: "Something went wrong. Please try again.",
+  },
+};

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionListView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickOptionListView.tsx
@@ -1,0 +1,81 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { SnapPickOption } from "@/lib/types/snap-pick";
+
+import { SNAP_PICK_OPTION_LIST_COPY } from "./SnapPickOptionList.copy";
+
+export interface SnapPickOptionListViewProps {
+  options: SnapPickOption[];
+  currentUserId: string;
+  newTitle: string;
+  loading: boolean;
+  error: string | undefined;
+  onNewTitleChange: (title: string) => void;
+  onAddSubmit: (e: React.SyntheticEvent) => void;
+  onRemove: (option: SnapPickOption) => void;
+}
+
+export function SnapPickOptionListView({
+  options,
+  currentUserId,
+  newTitle,
+  loading,
+  error,
+  onNewTitleChange,
+  onAddSubmit,
+  onRemove,
+}: SnapPickOptionListViewProps) {
+  return (
+    <div className="space-y-3">
+      {options.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {SNAP_PICK_OPTION_LIST_COPY.noOptionsMessage}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {options.map((option) => (
+            <li
+              key={option.id}
+              className="flex items-center justify-between gap-3 rounded-md border p-3 text-sm"
+            >
+              <span className="min-w-0 flex-1 font-medium">{option.title}</span>
+              {option.addedBy === currentUserId && (
+                <Button
+                  type="button"
+                  onClick={() => {
+                    onRemove(option);
+                  }}
+                  disabled={loading}
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`${SNAP_PICK_OPTION_LIST_COPY.removeOptionLabel}: ${option.title}`}
+                  className="shrink-0"
+                >
+                  {SNAP_PICK_OPTION_LIST_COPY.removeOptionButton}
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form onSubmit={onAddSubmit} className="flex gap-2">
+        <Input
+          type="text"
+          value={newTitle}
+          onChange={(e) => {
+            onNewTitleChange(e.target.value);
+          }}
+          placeholder={SNAP_PICK_OPTION_LIST_COPY.addOptionPlaceholder}
+          disabled={loading}
+          className="flex-1"
+        />
+        <Button type="submit" disabled={loading} variant="default">
+          {SNAP_PICK_OPTION_LIST_COPY.addOptionButton}
+        </Button>
+      </form>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { getCategoryById } from "@/server/data/categories";
 import { getGroupById } from "@/server/data/groups";
-import { getSnapPickById } from "@/server/data/snap-picks";
+import { getSnapPickById, getSnapPickOptions } from "@/server/data/snap-picks";
 import { getVerifiedUid } from "@/server/utils/auth";
 
 import { SnapPickDetailView } from "./SnapPickDetailView";
@@ -17,15 +17,23 @@ export default async function SnapPickDetailPage({
 
   const { id, categoryId, snapPickId } = await params;
 
-  const [group, category, snapPick] = await Promise.all([
+  const [group, category, snapPick, options] = await Promise.all([
     getGroupById(id),
     getCategoryById(categoryId),
     getSnapPickById(categoryId, snapPickId),
+    getSnapPickOptions(snapPickId),
   ]);
 
   if (!group?.memberIds.includes(uid)) notFound();
   if (category?.groupId !== id) notFound();
   if (!snapPick) notFound();
 
-  return <SnapPickDetailView snapPick={snapPick} />;
+  return (
+    <SnapPickDetailView
+      snapPick={snapPick}
+      groupId={id}
+      currentUserId={uid}
+      options={options}
+    />
+  );
 }

--- a/src/lib/firebase/schema/snap-pick.spec.ts
+++ b/src/lib/firebase/schema/snap-pick.spec.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   type FirebaseSnapPick,
   type FirebaseSnapPickActivation,
+  type FirebaseSnapPickOption,
   firebaseToSnapPick,
   firebaseToSnapPickActivation,
+  firebaseToSnapPickOption,
   snapPickActivationToFirebase,
+  snapPickOptionToFirebase,
   snapPickToFirebase,
 } from "./snap-pick";
 
@@ -13,6 +16,19 @@ const STARTED = new Date("2025-04-01T12:00:00.000Z");
 const CLOSES = new Date("2025-04-01T12:05:00.000Z");
 const CLOSED = new Date("2025-04-01T12:04:30.000Z");
 const CREATED = new Date("2025-03-20T08:00:00.000Z");
+const ADDED = new Date("2025-03-21T09:00:00.000Z");
+const REMOVED = new Date("2025-03-22T10:00:00.000Z");
+
+function makeFirebaseSnapPickOption(
+  overrides?: Partial<FirebaseSnapPickOption>,
+): FirebaseSnapPickOption {
+  return {
+    title: "Pizza",
+    addedBy: "user-1",
+    addedAt: ADDED.getTime(),
+    ...overrides,
+  };
+}
 
 function makeFirebaseSnapPick(
   overrides?: Partial<FirebaseSnapPick>,
@@ -87,6 +103,63 @@ describe("firebaseToSnapPick", () => {
     expect(result.createdAt).toEqual(original.createdAt);
     expect(result.creatorId).toBe(original.creatorId);
     expect(result.defaultDurationMs).toBe(original.defaultDurationMs);
+  });
+});
+
+describe("snapPickOptionToFirebase", () => {
+  it("converts an option to Firebase format with epoch-ms addedAt", () => {
+    const result = snapPickOptionToFirebase({
+      title: "Pizza",
+      addedBy: "user-1",
+      addedAt: ADDED,
+      removedAt: undefined,
+    });
+
+    expect(result.title).toBe("Pizza");
+    expect(result.addedBy).toBe("user-1");
+    expect(result.addedAt).toBe(ADDED.getTime());
+    expect(result.removedAt).toBeUndefined();
+  });
+
+  it("serializes removedAt to epoch-ms for a soft-deleted option", () => {
+    const result = snapPickOptionToFirebase({
+      title: "Pizza",
+      addedBy: "user-1",
+      addedAt: ADDED,
+      removedAt: REMOVED,
+    });
+
+    expect(result.removedAt).toBe(REMOVED.getTime());
+  });
+});
+
+describe("firebaseToSnapPickOption", () => {
+  it("converts Firebase data to an option with the id and a Date addedAt", () => {
+    const result = firebaseToSnapPickOption(
+      "option-9",
+      makeFirebaseSnapPickOption(),
+    );
+
+    expect(result.id).toBe("option-9");
+    expect(result.title).toBe("Pizza");
+    expect(result.addedBy).toBe("user-1");
+    expect(result.addedAt).toEqual(ADDED);
+    expect(result.removedAt).toBeUndefined();
+  });
+
+  it("converts removedAt to a Date for a soft-deleted option", () => {
+    const result = firebaseToSnapPickOption(
+      "option-9",
+      makeFirebaseSnapPickOption({ removedAt: REMOVED.getTime() }),
+    );
+
+    expect(result.removedAt).toEqual(REMOVED);
+  });
+
+  it("throws when a required field is missing", () => {
+    expect(() =>
+      firebaseToSnapPickOption("option-1", { title: "Orphan" }),
+    ).toThrow();
   });
 });
 

--- a/src/lib/firebase/schema/snap-pick.ts
+++ b/src/lib/firebase/schema/snap-pick.ts
@@ -1,17 +1,24 @@
 // Snap Pick schema boundary.
 //
-// A Snap Pick has two distinct entities at two Realtime Database paths:
+// A Snap Pick has three distinct entities at three Realtime Database paths:
 //   - the container:  snap-picks/{categoryId}/{snapPickId}        (FirebaseSnapPick)
+//   - an option:      snap-pick-options/{snapPickId}/{optionId}   (FirebaseSnapPickOption)
 //   - an activation:  snap-pick-activations/{snapPickId}/{activationId}
 //                                                                 (FirebaseSnapPickActivation)
-// The container is long-lived (holds the option pool and history); each activation
-// is one run of the head-to-head vote, with a start time, a close time, and a winner.
+// The container is long-lived (holds the option pool and history); an option is a
+// member-curated entry in that persistent pool (soft-deleted via removedAt so it
+// stays readable in historical activations); each activation is one run of the
+// head-to-head vote, with a start time, a close time, and a winner.
 //
 // Domain types use Date; the persisted shapes use epoch-millisecond numbers.
 
 import { z } from "zod";
 
-import type { SnapPick, SnapPickActivation } from "@/lib/types/snap-pick";
+import type {
+  SnapPick,
+  SnapPickActivation,
+  SnapPickOption,
+} from "@/lib/types/snap-pick";
 
 export interface FirebaseSnapPick {
   title: string;
@@ -19,6 +26,13 @@ export interface FirebaseSnapPick {
   createdAt: number;
   creatorId: string;
   defaultDurationMs: number;
+}
+
+export interface FirebaseSnapPickOption {
+  title: string;
+  addedBy: string;
+  addedAt: number;
+  removedAt?: number;
 }
 
 export interface FirebaseSnapPickActivation {
@@ -38,6 +52,13 @@ const FirebaseSnapPickSchema = z.object({
   createdAt: z.number(),
   creatorId: z.string(),
   defaultDurationMs: z.number(),
+});
+
+const FirebaseSnapPickOptionSchema = z.object({
+  title: z.string(),
+  addedBy: z.string(),
+  addedAt: z.number(),
+  removedAt: z.number().optional(),
 });
 
 const FirebaseSnapPickActivationSchema = z.object({
@@ -73,6 +94,32 @@ export function firebaseToSnapPick(id: string, data: unknown): SnapPick {
     createdAt: new Date(parsed.createdAt),
     creatorId: parsed.creatorId,
     defaultDurationMs: parsed.defaultDurationMs,
+  };
+}
+
+export function snapPickOptionToFirebase(
+  option: Pick<SnapPickOption, "title" | "addedBy" | "addedAt" | "removedAt">,
+): FirebaseSnapPickOption {
+  return {
+    title: option.title,
+    addedBy: option.addedBy,
+    addedAt: option.addedAt.getTime(),
+    removedAt: option.removedAt?.getTime(),
+  };
+}
+
+export function firebaseToSnapPickOption(
+  id: string,
+  data: unknown,
+): SnapPickOption {
+  const parsed = FirebaseSnapPickOptionSchema.parse(data);
+  return {
+    id,
+    title: parsed.title,
+    addedBy: parsed.addedBy,
+    addedAt: new Date(parsed.addedAt),
+    removedAt:
+      parsed.removedAt !== undefined ? new Date(parsed.removedAt) : undefined,
   };
 }
 

--- a/src/lib/fixtures/snap-pick.ts
+++ b/src/lib/fixtures/snap-pick.ts
@@ -1,4 +1,4 @@
-import type { SnapPick } from "@/lib/types/snap-pick";
+import type { SnapPick, SnapPickOption } from "@/lib/types/snap-pick";
 
 export function makeSnapPick(overrides?: Partial<SnapPick>): SnapPick {
   return {
@@ -8,6 +8,18 @@ export function makeSnapPick(overrides?: Partial<SnapPick>): SnapPick {
     createdAt: new Date("2025-03-20T08:00:00.000Z"),
     creatorId: "user-1",
     defaultDurationMs: 300000,
+    ...overrides,
+  };
+}
+
+export function makeSnapPickOption(
+  overrides?: Partial<SnapPickOption>,
+): SnapPickOption {
+  return {
+    id: "option-1",
+    title: "Pizza",
+    addedBy: "user-1",
+    addedAt: new Date("2025-03-21T09:00:00.000Z"),
     ...overrides,
   };
 }

--- a/src/lib/types/snap-pick.ts
+++ b/src/lib/types/snap-pick.ts
@@ -7,6 +7,14 @@ export interface SnapPick {
   defaultDurationMs: number;
 }
 
+export interface SnapPickOption {
+  id: string;
+  title: string;
+  addedBy: string;
+  addedAt: Date;
+  removedAt?: Date;
+}
+
 export interface SnapPickActivation {
   id: string;
   snapPickId: string;

--- a/src/server/data/snap-picks.spec.ts
+++ b/src/server/data/snap-picks.spec.ts
@@ -22,6 +22,9 @@ const {
   getSnapPickById,
   getSnapPicksByCategory,
   getSnapPickActivations,
+  addSnapPickOption,
+  removeSnapPickOption,
+  getSnapPickOptions,
 } = await import("./snap-picks");
 
 function snapshot(value: unknown) {
@@ -145,5 +148,100 @@ describe("createSnapPick", () => {
         defaultDurationMs: 300000,
       }),
     );
+  });
+});
+
+const FIREBASE_OPTION = {
+  title: "Pizza",
+  addedBy: "user-1",
+  addedAt: 1_700_000_200_000,
+};
+
+describe("addSnapPickOption", () => {
+  it("pushes a new option under snap-pick-options/{snapPickId} and returns the id", async () => {
+    mockRef.mockReturnValue({ push: mockPush });
+    mockPush.mockReturnValue({ key: "option-new", set: mockSet });
+    mockSet.mockResolvedValue(undefined);
+
+    const result = await addSnapPickOption("snap-1", {
+      title: "Pizza",
+      addedBy: "user-7",
+    });
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1");
+    expect(result.id).toBe("option-new");
+    expect(result.addedAt).toBeInstanceOf(Date);
+  });
+
+  it("persists the converted option to the pushed ref", async () => {
+    mockRef.mockReturnValue({ push: mockPush });
+    mockPush.mockReturnValue({ key: "option-new", set: mockSet });
+    mockSet.mockResolvedValue(undefined);
+
+    await addSnapPickOption("snap-1", { title: "Pizza", addedBy: "user-7" });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Pizza", addedBy: "user-7" }),
+    );
+  });
+});
+
+describe("removeSnapPickOption", () => {
+  it("soft-deletes by writing removedAt at the option's removedAt path", async () => {
+    mockRef.mockReturnValue({ set: mockSet });
+    mockSet.mockResolvedValue(undefined);
+
+    const result = await removeSnapPickOption("snap-1", "option-3");
+
+    expect(mockRef).toHaveBeenCalledWith(
+      "snap-pick-options/snap-1/option-3/removedAt",
+    );
+    expect(mockSet).toHaveBeenCalledWith(result.removedAt.getTime());
+  });
+});
+
+describe("getSnapPickOptions", () => {
+  it("reads snap-pick-options/{snapPickId} and converts each active entry", async () => {
+    mockGet.mockResolvedValue(snapshot({ "option-1": FIREBASE_OPTION }));
+
+    const result = await getSnapPickOptions("snap-1");
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("option-1");
+    expect(result[0]?.addedAt).toEqual(new Date(1_700_000_200_000));
+  });
+
+  it("excludes soft-removed options by default", async () => {
+    mockGet.mockResolvedValue(
+      snapshot({
+        "option-1": FIREBASE_OPTION,
+        "option-2": { ...FIREBASE_OPTION, removedAt: 1_700_000_300_000 },
+      }),
+    );
+
+    const result = await getSnapPickOptions("snap-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("option-1");
+  });
+
+  it("includes soft-removed options when includeRemoved is true", async () => {
+    mockGet.mockResolvedValue(
+      snapshot({
+        "option-1": FIREBASE_OPTION,
+        "option-2": { ...FIREBASE_OPTION, removedAt: 1_700_000_300_000 },
+      }),
+    );
+
+    const result = await getSnapPickOptions("snap-1", true);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns an empty array when the snap pick has no options", async () => {
+    mockGet.mockResolvedValue(snapshot(undefined));
+
+    expect(await getSnapPickOptions("snap-1")).toEqual([]);
   });
 });

--- a/src/server/data/snap-picks.ts
+++ b/src/server/data/snap-picks.ts
@@ -4,9 +4,15 @@ import { getAdminApp } from "@/lib/firebase/admin";
 import {
   firebaseToSnapPick,
   firebaseToSnapPickActivation,
+  firebaseToSnapPickOption,
+  snapPickOptionToFirebase,
   snapPickToFirebase,
 } from "@/lib/firebase/schema/snap-pick";
-import type { SnapPick, SnapPickActivation } from "@/lib/types/snap-pick";
+import type {
+  SnapPick,
+  SnapPickActivation,
+  SnapPickOption,
+} from "@/lib/types/snap-pick";
 
 export async function createSnapPick(
   snapPick: Pick<
@@ -63,4 +69,51 @@ export async function getSnapPickActivations(
   return Object.entries(data).map(([id, activationData]) =>
     firebaseToSnapPickActivation(id, activationData),
   );
+}
+
+export async function addSnapPickOption(
+  snapPickId: string,
+  option: Pick<SnapPickOption, "title" | "addedBy">,
+): Promise<{ id: string; addedAt: Date }> {
+  const db = getDatabase(getAdminApp());
+  const ref = db.ref(`snap-pick-options/${snapPickId}`).push();
+  const id = ref.key;
+  if (!id) throw new Error("Failed to generate snap pick option ID");
+
+  const addedAt = new Date();
+  await ref.set(snapPickOptionToFirebase({ ...option, addedAt }));
+
+  return { id, addedAt };
+}
+
+export async function removeSnapPickOption(
+  snapPickId: string,
+  optionId: string,
+): Promise<{ removedAt: Date }> {
+  const db = getDatabase(getAdminApp());
+  const removedAt = new Date();
+  await db
+    .ref(`snap-pick-options/${snapPickId}/${optionId}/removedAt`)
+    .set(removedAt.getTime());
+
+  return { removedAt };
+}
+
+export async function getSnapPickOptions(
+  snapPickId: string,
+  includeRemoved = false,
+): Promise<SnapPickOption[]> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db.ref(`snap-pick-options/${snapPickId}`).get();
+
+  if (!snap.exists()) return [];
+
+  const data = snap.val() as Record<string, unknown>;
+  const options = Object.entries(data).map(([id, optionData]) =>
+    firebaseToSnapPickOption(id, optionData),
+  );
+
+  return includeRemoved
+    ? options
+    : options.filter((option) => option.removedAt === undefined);
 }

--- a/src/server/utils/snap-pick-auth.spec.ts
+++ b/src/server/utils/snap-pick-auth.spec.ts
@@ -1,0 +1,97 @@
+import { beforeEach,describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetGroupById,
+  mockGetCategoryById,
+  mockGetSnapPickById,
+} = vi.hoisted(() => ({
+  mockGetGroupById: vi.fn(),
+  mockGetCategoryById: vi.fn(),
+  mockGetSnapPickById: vi.fn(),
+}));
+
+vi.mock("@/server/data/groups", () => ({
+  getGroupById: mockGetGroupById,
+}));
+
+vi.mock("@/server/data/categories", () => ({
+  getCategoryById: mockGetCategoryById,
+}));
+
+vi.mock("@/server/data/snap-picks", () => ({
+  getSnapPickById: mockGetSnapPickById,
+}));
+
+const { authorizeSnapPickMember } = await import("./snap-pick-auth");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["user-1"] });
+  mockGetCategoryById.mockResolvedValue({ id: "cat-1", groupId: "group-1" });
+  mockGetSnapPickById.mockResolvedValue({ id: "snap-1", categoryId: "cat-1" });
+});
+
+describe("authorizeSnapPickMember", () => {
+  it("returns undefined when all checks pass", async () => {
+    const result = await authorizeSnapPickMember(
+      "user-1",
+      "group-1",
+      "cat-1",
+      "snap-1",
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns 404 when the group does not exist", async () => {
+    mockGetGroupById.mockResolvedValue(undefined);
+
+    const result = await authorizeSnapPickMember(
+      "user-1",
+      "group-1",
+      "cat-1",
+      "snap-1",
+    );
+
+    expect(result?.status).toBe(404);
+  });
+
+  it("returns 403 when the caller is not a member", async () => {
+    mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["other"] });
+
+    const result = await authorizeSnapPickMember(
+      "user-1",
+      "group-1",
+      "cat-1",
+      "snap-1",
+    );
+
+    expect(result?.status).toBe(403);
+  });
+
+  it("returns 404 when the category does not belong to the group", async () => {
+    mockGetCategoryById.mockResolvedValue({ id: "cat-1", groupId: "other" });
+
+    const result = await authorizeSnapPickMember(
+      "user-1",
+      "group-1",
+      "cat-1",
+      "snap-1",
+    );
+
+    expect(result?.status).toBe(404);
+  });
+
+  it("returns 404 when the snap pick does not exist", async () => {
+    mockGetSnapPickById.mockResolvedValue(undefined);
+
+    const result = await authorizeSnapPickMember(
+      "user-1",
+      "group-1",
+      "cat-1",
+      "snap-1",
+    );
+
+    expect(result?.status).toBe(404);
+  });
+});

--- a/src/server/utils/snap-pick-auth.spec.ts
+++ b/src/server/utils/snap-pick-auth.spec.ts
@@ -1,14 +1,11 @@
-import { beforeEach,describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  mockGetGroupById,
-  mockGetCategoryById,
-  mockGetSnapPickById,
-} = vi.hoisted(() => ({
-  mockGetGroupById: vi.fn(),
-  mockGetCategoryById: vi.fn(),
-  mockGetSnapPickById: vi.fn(),
-}));
+const { mockGetGroupById, mockGetCategoryById, mockGetSnapPickById } =
+  vi.hoisted(() => ({
+    mockGetGroupById: vi.fn(),
+    mockGetCategoryById: vi.fn(),
+    mockGetSnapPickById: vi.fn(),
+  }));
 
 vi.mock("@/server/data/groups", () => ({
   getGroupById: mockGetGroupById,

--- a/src/server/utils/snap-pick-auth.ts
+++ b/src/server/utils/snap-pick-auth.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+import { getCategoryById } from "@/server/data/categories";
+import { getGroupById } from "@/server/data/groups";
+import { getSnapPickById } from "@/server/data/snap-picks";
+
+export async function authorizeSnapPickMember(
+  uid: string,
+  groupId: string,
+  categoryId: string,
+  snapPickId: string,
+): Promise<NextResponse | undefined> {
+  const [group, category, snapPick] = await Promise.all([
+    getGroupById(groupId),
+    getCategoryById(categoryId),
+    getSnapPickById(categoryId, snapPickId),
+  ]);
+
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  if (!group.memberIds.includes(uid)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (category?.groupId !== groupId) {
+    return NextResponse.json({ error: "Category not found" }, { status: 404 });
+  }
+
+  if (!snapPick) {
+    return NextResponse.json({ error: "Snap pick not found" }, { status: 404 });
+  }
+
+  return undefined;
+}

--- a/src/services/snap-picks.ts
+++ b/src/services/snap-picks.ts
@@ -1,3 +1,24 @@
+import type { SnapPickOption } from "@/lib/types/snap-pick";
+
+interface WireSnapPickOption {
+  id: string;
+  title: string;
+  addedBy: string;
+  addedAt: string;
+  removedAt?: string;
+}
+
+function wireToSnapPickOption(wire: WireSnapPickOption): SnapPickOption {
+  return {
+    id: wire.id,
+    title: wire.title,
+    addedBy: wire.addedBy,
+    addedAt: new Date(wire.addedAt),
+    removedAt:
+      wire.removedAt !== undefined ? new Date(wire.removedAt) : undefined,
+  };
+}
+
 export async function createSnapPick(
   groupId: string,
   categoryId: string,
@@ -17,4 +38,49 @@ export async function createSnapPick(
     createdAt: string;
   };
   return { snapPickId: data.snapPickId, createdAt: new Date(data.createdAt) };
+}
+
+export async function getSnapPickOptions(
+  groupId: string,
+  categoryId: string,
+  snapPickId: string,
+): Promise<SnapPickOption[]> {
+  const response = await fetch(
+    `/api/groups/${groupId}/categories/${categoryId}/snap-picks/${snapPickId}/options`,
+  );
+  if (!response.ok) throw new Error("Failed to fetch snap pick options");
+  const data = (await response.json()) as { options: WireSnapPickOption[] };
+  return data.options.map(wireToSnapPickOption);
+}
+
+export async function addSnapPickOption(
+  groupId: string,
+  categoryId: string,
+  snapPickId: string,
+  title: string,
+): Promise<{ optionId: string; addedAt: Date }> {
+  const response = await fetch(
+    `/api/groups/${groupId}/categories/${categoryId}/snap-picks/${snapPickId}/options`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    },
+  );
+  if (!response.ok) throw new Error("Failed to add snap pick option");
+  const data = (await response.json()) as { optionId: string; addedAt: string };
+  return { optionId: data.optionId, addedAt: new Date(data.addedAt) };
+}
+
+export async function removeSnapPickOption(
+  groupId: string,
+  categoryId: string,
+  snapPickId: string,
+  optionId: string,
+): Promise<void> {
+  const response = await fetch(
+    `/api/groups/${groupId}/categories/${categoryId}/snap-picks/${snapPickId}/options/${optionId}`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) throw new Error("Failed to remove snap pick option");
 }


### PR DESCRIPTION
Adds add / remove / read management for a Snap Pick's persistent option pool, building on the data-model foundation merged in #256. Options belong to the container (not to individual activations) so the group can curate the pool over time.

Options are stored at `snap-pick-options/{snapPickId}/{optionId}` with `id`, `title`, `addedBy`, `addedAt`, and an optional `removedAt`. Removal is a soft-delete: the option keeps its record (so it stays readable in historical activations) but is excluded from the live pool. Removal is restricted to the member who added the option. The pool UI renders in the detail page's option-pool slot and is gated on no activation being in progress (a flag the activation work in #258 will drive).

## Acceptance Criteria
- [x] Members can add a new option to a Snap Pick's option pool from the detail page
- [x] Members can remove an option they own from the pool (soft-delete: excluded from future activations but preserved in historical activation records)
- [x] Option pool is displayed on the Snap Pick detail page when no activation is in progress
- [x] Server functions: `addSnapPickOption`, `removeSnapPickOption`, `getSnapPickOptions`
- [x] Options stored at `snap-pick-options/{snapPickId}/{optionId}`: `id`, `title`, `addedBy`, `addedAt`, `removedAt?`
- [x] Tests for option add/remove data functions and the option list UI component

## Tests
51 tests added across schema converters, data functions, the two API routes, and the option-list view — all passing. Full suite and typecheck/lint/format green.

Closes #257

---
*Created by Claude Opus 4.8*