### PR TITLE
ci: cache Playwright Chromium in the shared setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,9 +39,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: playwright-${{ runner.os }}-${{ inputs.playwright }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          playwright-${{ runner.os }}-
+          playwright-${{ runner.os }}-${{ inputs.playwright }}-
     - name: Install Playwright browser
       if: inputs.playwright != ''
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,12 @@ inputs:
     description: "Use --frozen-lockfile for pnpm install"
     required: false
     default: "true"
+  playwright:
+    description: >-
+      If set (e.g. "chromium"), install that Playwright browser with a shared,
+      cached browser binary. Leave empty for jobs that don't need a browser.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -21,3 +27,44 @@ runs:
       shell: bash
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    # Share the Playwright browser download across the parallel browser jobs
+    # (storybook-tests, storybook-screenshots). Each runs on its own runner, so
+    # the repo-global Actions cache is the sharing mechanism — the same way
+    # setup-node's `cache: pnpm` already shares the pnpm store. Keyed on the
+    # lockfile so a Playwright bump busts it; the restore-key still restores the
+    # most recent browsers so a non-Playwright lockfile change is a near-noop.
+    - name: Cache Playwright browsers
+      if: inputs.playwright != ''
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-${{ runner.os }}-
+    - name: Install Playwright browser
+      if: inputs.playwright != ''
+      shell: bash
+      env:
+        BROWSER: ${{ inputs.playwright }}
+        EXACT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
+      run: |
+        # On an exact cache hit the browser binary is already restored, so only
+        # (re)install the OS system libraries — those live outside the cached
+        # path and aren't cacheable. Otherwise do the full download. Retry 3x:
+        # `--with-deps` runs apt-get, which fails hard on a transient runner apt
+        # repo signing/403 hiccup (#283).
+        if [ "$EXACT_CACHE_HIT" = "true" ]; then
+          install=(playwright install-deps "$BROWSER")
+        else
+          install=(playwright install --with-deps "$BROWSER")
+        fi
+        for attempt in 1 2 3; do
+          if pnpm exec "${install[@]}"; then
+            exit 0
+          fi
+          echo "Playwright install attempt $attempt failed; retrying in 15s..." >&2
+          sleep 15
+        done
+        echo "Playwright install failed after 3 attempts." >&2
+        exit 1

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -143,7 +143,11 @@ jobs:
         with:
           fetch-depth: 0
       # Playwright Chromium is installed (and cached) by the shared setup action.
+      # continue-on-error preserves advisory semantics: a transient apt/Playwright
+      # failure here should not block merge, matching the old behaviour where the
+      # install ran inside the continue-on-error capture step (#283).
       - uses: ./.github/actions/setup
+        continue-on-error: true
         with:
           playwright: chromium
       - name: List changed files

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -109,20 +109,10 @@ jobs:
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v7.0.0
+      # Playwright Chromium is installed (and cached) by the shared setup action.
       - uses: ./.github/actions/setup
-      # Retry: `--with-deps` runs `apt-get update`, which fails hard if any
-      # preinstalled runner apt repo has a transient signing/403 hiccup (#283).
-      - name: Install Playwright Chromium
-        run: |
-          for attempt in 1 2 3; do
-            if pnpm exec playwright install --with-deps chromium; then
-              exit 0
-            fi
-            echo "Playwright install attempt $attempt failed; retrying in 15s..." >&2
-            sleep 15
-          done
-          echo "Playwright install failed after 3 attempts." >&2
-          exit 1
+        with:
+          playwright: chromium
       - run: pnpm storybook-tests
 
   storybook-screenshots:
@@ -152,14 +142,16 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+      # Playwright Chromium is installed (and cached) by the shared setup action.
       - uses: ./.github/actions/setup
+        with:
+          playwright: chromium
       - name: List changed files
         run: |
           git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.sha }}" > changed-files.txt
       # Advisory acceptance aid, never a gate: continue-on-error + a bounded
       # timeout mean a hang or capture failure reports neutral and cannot block
-      # merge (#339). Capture reuses the Chromium installed here — no separate
-      # pinned install owned by a third-party action (the old #329 hang).
+      # merge (#339). Capture reuses the Chromium installed by the setup action.
       - name: Capture and publish screenshots
         continue-on-error: true
         timeout-minutes: 6
@@ -167,11 +159,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            pnpm exec playwright install --with-deps chromium && break
-            echo "playwright install attempt $attempt failed; retrying in 15s..." >&2
-            sleep 15
-          done
           pnpm build-storybook
           node scripts/capture-screenshots.mjs \
             --static-dir=storybook-static \


### PR DESCRIPTION
Stops the `Storybook Tests` and `Storybook Screenshots` jobs from each doing an independent ~130MB Chromium download every run.

## Problem

The two jobs run on separate, parallel runners and each ran its own `pnpm exec playwright install --with-deps chromium` — so Chromium was downloaded twice per PR whenever both fired. The setup composite already skips the browser during `pnpm install` (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`), deferring to those two duplicated install steps.

## Change

Fold the install into the shared `./.github/actions/setup` composite behind an optional `playwright` input (default empty), so both Storybook jobs just opt in with `with: { playwright: chromium }` and drop their bespoke install steps:

- **Caches `~/.cache/ms-playwright`** via `actions/cache`, keyed `playwright-${{ runner.os }}-${{ inputs.playwright }}-${{ hashFiles('pnpm-lock.yaml') }}` with a `playwright-${{ runner.os }}-${{ inputs.playwright }}-` restore-key. The browser name is included in the key so a `chromium` cache never causes a false hit for a `firefox` request (or vice versa). Since the jobs run on separate runners, the repo-global Actions cache is the sharing mechanism — exactly how `setup-node`'s `cache: pnpm` already shares the pnpm store.
- On an **exact** cache hit runs `playwright install-deps chromium` (OS libs only, no download); otherwise the full `playwright install --with-deps chromium`.
- Centralizes the 3×/15s apt retry (#283) in one place, removing the duplicated loops.
- **`storybook-screenshots` setup step has `continue-on-error: true`** to preserve the job's advisory semantics: a transient apt/Playwright install failure should not block merge, matching the old behaviour where the install ran inside the `continue-on-error` capture step.

Non-browser jobs (lint / format / tsc / build / tests) omit the input, so they never touch Playwright.

## Cache-key behavior

`hashFiles('pnpm-lock.yaml')` busts the exact key whenever the lockfile changes (including a Playwright bump). The restore-key means a busted exact key still restores the most recent browsers, so `playwright install` re-downloads **only** when the browser revision actually changed — otherwise it's a near-noop that just ensures OS deps.

## Caveats

- `--with-deps` (apt system libs) isn't cacheable, so `install-deps` still runs each time — it's the fast half; the Chromium download is what caching removes.
- The two jobs run in parallel, so a fully cold cache still downloads once (a race to populate); every later run hits the warm cache. A serial "prime" job would eliminate even that but isn't worth the added latency.

This is a caching/DRY refactor — no job added or removed, no `if:`/timeout/permission change, and the gating (`storybook-tests`) vs advisory (`storybook-screenshots`, `continue-on-error`) separation is untouched.

---
*Created by Claude Opus 4.8*
