### PR TITLE
feat(snap-picks): surface Snap Picks in category and group navigation

### DIFF
--- a/src/app/groups/[id]/ActiveSnapPickList.copy.ts
+++ b/src/app/groups/[id]/ActiveSnapPickList.copy.ts
@@ -1,0 +1,7 @@
+export const ACTIVE_SNAP_PICK_LIST_COPY = {
+  heading: "Snap Picks in progress",
+  voteNowButton: "Vote now",
+  closingSoonLabel: "Closing soon",
+  timeRemaining: (remaining: string) => `Closes in ${remaining}`,
+  closingNow: "Closing now",
+} as const;

--- a/src/app/groups/[id]/ActiveSnapPickList.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickList.tsx
@@ -58,6 +58,8 @@ export function ActiveSnapPickList({
       title: snapPick.title,
       categoryName: categoryById[snapPick.categoryId]?.name,
       timeRemainingLabel: formatTimeRemaining(activation.closesAt, now),
+      isClosingSoon:
+        activation.closesAt.getTime() - now.getTime() <= 60 * 60 * 1000,
       href: `/groups/${groupId}/categories/${snapPick.categoryId}/snap-picks/${snapPick.id}`,
     }),
   );

--- a/src/app/groups/[id]/ActiveSnapPickList.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickList.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { Category } from "@/lib/types/category";
+import type { SnapPick, SnapPickActivation } from "@/lib/types/snap-pick";
+
+import { ACTIVE_SNAP_PICK_LIST_COPY } from "./ActiveSnapPickList.copy";
+import {
+  type ActiveSnapPickListItem,
+  ActiveSnapPickListView,
+} from "./ActiveSnapPickListView";
+
+export interface ActiveSnapPickActivationItem {
+  snapPick: SnapPick;
+  activation: SnapPickActivation;
+}
+
+interface ActiveSnapPickListProps {
+  groupId: string;
+  activations: ActiveSnapPickActivationItem[];
+  categories: Category[];
+}
+
+function formatTimeRemaining(closesAt: Date, now: Date): string {
+  const remainingMs = closesAt.getTime() - now.getTime();
+  if (remainingMs <= 0) return ACTIVE_SNAP_PICK_LIST_COPY.closingNow;
+
+  const totalMinutes = Math.floor(remainingMs / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const label =
+    hours > 0 ? `${String(hours)}h ${String(minutes)}m` : `${String(minutes)}m`;
+  return ACTIVE_SNAP_PICK_LIST_COPY.timeRemaining(label);
+}
+
+export function ActiveSnapPickList({
+  groupId,
+  activations,
+  categories,
+}: ActiveSnapPickListProps) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNow(new Date());
+    }, 60_000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  const categoryById = Object.fromEntries(categories.map((c) => [c.id, c]));
+
+  const items: ActiveSnapPickListItem[] = activations.map(
+    ({ snapPick, activation }) => ({
+      activationId: activation.id,
+      title: snapPick.title,
+      categoryName: categoryById[snapPick.categoryId]?.name,
+      timeRemainingLabel: formatTimeRemaining(activation.closesAt, now),
+      href: `/groups/${groupId}/categories/${snapPick.categoryId}/snap-picks/${snapPick.id}`,
+    }),
+  );
+
+  return <ActiveSnapPickListView items={items} />;
+}

--- a/src/app/groups/[id]/ActiveSnapPickListView.spec.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickListView.spec.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ACTIVE_SNAP_PICK_LIST_COPY } from "./ActiveSnapPickList.copy";
+import {
+  type ActiveSnapPickListItem,
+  ActiveSnapPickListView,
+} from "./ActiveSnapPickListView";
+
+afterEach(cleanup);
+
+const item: ActiveSnapPickListItem = {
+  activationId: "activation-1",
+  title: "Where should we eat tonight?",
+  categoryName: "Dinner",
+  timeRemainingLabel: "Closes in 2h 15m",
+  href: "/groups/group-1/categories/cat-1/snap-picks/snap-1",
+};
+
+describe("ActiveSnapPickListView", () => {
+  it("renders the section heading", () => {
+    render(<ActiveSnapPickListView items={[item]} />);
+
+    expect(screen.getByText(ACTIVE_SNAP_PICK_LIST_COPY.heading)).toBeDefined();
+  });
+
+  it("renders a Vote now link to the snap pick detail route", () => {
+    render(<ActiveSnapPickListView items={[item]} />);
+
+    expect(
+      screen
+        .getByRole("link", { name: ACTIVE_SNAP_PICK_LIST_COPY.voteNowButton })
+        .getAttribute("href"),
+    ).toBe("/groups/group-1/categories/cat-1/snap-picks/snap-1");
+  });
+
+  it("shows the category name alongside the time remaining", () => {
+    render(<ActiveSnapPickListView items={[item]} />);
+
+    expect(screen.getByText("Dinner · Closes in 2h 15m")).toBeDefined();
+  });
+
+  it("shows only the time remaining when there is no category name", () => {
+    render(
+      <ActiveSnapPickListView items={[{ ...item, categoryName: undefined }]} />,
+    );
+
+    expect(screen.getByText("Closes in 2h 15m")).toBeDefined();
+  });
+});

--- a/src/app/groups/[id]/ActiveSnapPickListView.spec.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickListView.spec.tsx
@@ -14,6 +14,7 @@ const item: ActiveSnapPickListItem = {
   title: "Where should we eat tonight?",
   categoryName: "Dinner",
   timeRemainingLabel: "Closes in 2h 15m",
+  isClosingSoon: false,
   href: "/groups/group-1/categories/cat-1/snap-picks/snap-1",
 };
 
@@ -46,5 +47,25 @@ describe("ActiveSnapPickListView", () => {
     );
 
     expect(screen.getByText("Closes in 2h 15m")).toBeDefined();
+  });
+
+  it("shows the closing soon badge when isClosingSoon is true", () => {
+    render(
+      <ActiveSnapPickListView items={[{ ...item, isClosingSoon: true }]} />,
+    );
+
+    expect(
+      screen.getByText(ACTIVE_SNAP_PICK_LIST_COPY.closingSoonLabel),
+    ).toBeDefined();
+  });
+
+  it("does not show the closing soon badge when isClosingSoon is false", () => {
+    render(
+      <ActiveSnapPickListView items={[{ ...item, isClosingSoon: false }]} />,
+    );
+
+    expect(
+      screen.queryByText(ACTIVE_SNAP_PICK_LIST_COPY.closingSoonLabel),
+    ).toBeNull();
   });
 });

--- a/src/app/groups/[id]/ActiveSnapPickListView.stories.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickListView.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { ActiveSnapPickListView } from "./ActiveSnapPickListView";
+
+const meta: Meta<typeof ActiveSnapPickListView> = {
+  title: "Groups/ActiveSnapPickListView",
+  component: ActiveSnapPickListView,
+  args: {
+    items: [
+      {
+        activationId: "activation-1",
+        title: "Where should we eat tonight?",
+        categoryName: "Dinner",
+        timeRemainingLabel: "Closes in 2h 15m",
+        href: "/groups/group-1/categories/cat-1/snap-picks/snap-1",
+      },
+      {
+        activationId: "activation-2",
+        title: "Which movie?",
+        categoryName: "Movie night",
+        timeRemainingLabel: "Closes in 40m",
+        href: "/groups/group-1/categories/cat-2/snap-picks/snap-2",
+      },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActiveSnapPickListView>;
+
+export const Default: Story = {};
+
+export const WithoutCategoryName: Story = {
+  args: {
+    items: [
+      {
+        activationId: "activation-3",
+        title: "Weekend hike?",
+        categoryName: undefined,
+        timeRemainingLabel: "Closes in 5h 3m",
+        href: "/groups/group-1/categories/cat-3/snap-picks/snap-3",
+      },
+    ],
+  },
+};

--- a/src/app/groups/[id]/ActiveSnapPickListView.stories.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickListView.stories.tsx
@@ -12,6 +12,7 @@ const meta: Meta<typeof ActiveSnapPickListView> = {
         title: "Where should we eat tonight?",
         categoryName: "Dinner",
         timeRemainingLabel: "Closes in 2h 15m",
+        isClosingSoon: false,
         href: "/groups/group-1/categories/cat-1/snap-picks/snap-1",
       },
       {
@@ -19,6 +20,7 @@ const meta: Meta<typeof ActiveSnapPickListView> = {
         title: "Which movie?",
         categoryName: "Movie night",
         timeRemainingLabel: "Closes in 40m",
+        isClosingSoon: true,
         href: "/groups/group-1/categories/cat-2/snap-picks/snap-2",
       },
     ],
@@ -30,6 +32,21 @@ type Story = StoryObj<typeof ActiveSnapPickListView>;
 
 export const Default: Story = {};
 
+export const ClosingSoon: Story = {
+  args: {
+    items: [
+      {
+        activationId: "activation-4",
+        title: "Pick a restaurant for tonight",
+        categoryName: "Dinner",
+        timeRemainingLabel: "Closes in 15m",
+        isClosingSoon: true,
+        href: "/groups/group-1/categories/cat-4/snap-picks/snap-4",
+      },
+    ],
+  },
+};
+
 export const WithoutCategoryName: Story = {
   args: {
     items: [
@@ -38,6 +55,7 @@ export const WithoutCategoryName: Story = {
         title: "Weekend hike?",
         categoryName: undefined,
         timeRemainingLabel: "Closes in 5h 3m",
+        isClosingSoon: false,
         href: "/groups/group-1/categories/cat-3/snap-picks/snap-3",
       },
     ],

--- a/src/app/groups/[id]/ActiveSnapPickListView.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickListView.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
+
+import { ACTIVE_SNAP_PICK_LIST_COPY } from "./ActiveSnapPickList.copy";
+
+export interface ActiveSnapPickListItem {
+  activationId: string;
+  title: string;
+  categoryName: string | undefined;
+  timeRemainingLabel: string;
+  href: string;
+}
+
+interface ActiveSnapPickListViewProps {
+  items: ActiveSnapPickListItem[];
+}
+
+export function ActiveSnapPickListView({ items }: ActiveSnapPickListViewProps) {
+  return (
+    <section className="space-y-2">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {ACTIVE_SNAP_PICK_LIST_COPY.heading}
+      </p>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li
+            key={item.activationId}
+            className="flex items-center justify-between gap-2 rounded-md border p-3"
+          >
+            <div className="min-w-0 space-y-0.5">
+              <p className="truncate font-medium">{item.title}</p>
+              <p className="text-xs text-muted-foreground">
+                {item.categoryName
+                  ? `${item.categoryName} · ${item.timeRemainingLabel}`
+                  : item.timeRemainingLabel}
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Badge variant="default">
+                {ACTIVE_SNAP_PICK_LIST_COPY.closingSoonLabel}
+              </Badge>
+              <Link href={item.href} className={buttonVariants({ size: "sm" })}>
+                {ACTIVE_SNAP_PICK_LIST_COPY.voteNowButton}
+              </Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/groups/[id]/ActiveSnapPickListView.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickListView.tsx
@@ -10,6 +10,7 @@ export interface ActiveSnapPickListItem {
   title: string;
   categoryName: string | undefined;
   timeRemainingLabel: string;
+  isClosingSoon: boolean;
   href: string;
 }
 
@@ -38,9 +39,11 @@ export function ActiveSnapPickListView({ items }: ActiveSnapPickListViewProps) {
               </p>
             </div>
             <div className="flex shrink-0 items-center gap-2">
-              <Badge variant="default">
-                {ACTIVE_SNAP_PICK_LIST_COPY.closingSoonLabel}
-              </Badge>
+              {item.isClosingSoon && (
+                <Badge variant="default">
+                  {ACTIVE_SNAP_PICK_LIST_COPY.closingSoonLabel}
+                </Badge>
+              )}
               <Link href={item.href} className={buttonVariants({ size: "sm" })}>
                 {ACTIVE_SNAP_PICK_LIST_COPY.voteNowButton}
               </Link>

--- a/src/app/groups/[id]/GroupDetailClient.tsx
+++ b/src/app/groups/[id]/GroupDetailClient.tsx
@@ -17,6 +17,7 @@ import {
   updateGroupSettings,
 } from "@/services/groups";
 
+import type { ActiveSnapPickActivationItem } from "./ActiveSnapPickList";
 import { GROUP_DETAIL_COPY } from "./copy";
 import { GroupDetailView } from "./GroupDetailView";
 import type { MemberName } from "./MemberRow";
@@ -29,6 +30,7 @@ interface GroupDetailClientProps {
   initialInviteMode: InviteMode;
   memberNames: MemberName[];
   picksByCategory: Record<string, GroupPick[]>;
+  activeSnapPicks: ActiveSnapPickActivationItem[];
 }
 
 export function GroupDetailClient({
@@ -39,6 +41,7 @@ export function GroupDetailClient({
   initialInviteMode,
   memberNames,
   picksByCategory,
+  activeSnapPicks,
 }: GroupDetailClientProps) {
   const router = useRouter();
   const [isLeaving, setIsLeaving] = useState(false);
@@ -154,6 +157,7 @@ export function GroupDetailClient({
       initialInviteMode={initialInviteMode}
       memberNames={memberNames}
       picksByCategory={picksByCategory}
+      activeSnapPicks={activeSnapPicks}
       onTogglePicksRestricted={() => {
         void handleTogglePicksRestricted();
       }}

--- a/src/app/groups/[id]/GroupDetailView.spec.tsx
+++ b/src/app/groups/[id]/GroupDetailView.spec.tsx
@@ -58,6 +58,7 @@ function renderView(
       onLeave={vi.fn()}
       memberNames={memberNames}
       picksByCategory={{}}
+      activeSnapPicks={[]}
       initialInviteMode={InviteMode.Group}
       onMakeAdmin={vi.fn()}
       onRevokeAdmin={vi.fn()}

--- a/src/app/groups/[id]/GroupDetailView.stories.tsx
+++ b/src/app/groups/[id]/GroupDetailView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
+import { makeSnapPick, makeSnapPickActivation } from "@/lib/fixtures/snap-pick";
 import type { Category } from "@/lib/types/category";
 import type { Group } from "@/lib/types/group";
 import { InviteMode } from "@/lib/types/invite";
@@ -90,6 +91,7 @@ const meta: Meta<typeof GroupDetailView> = {
     onLeave: noop,
     memberNames: mockMemberNames,
     picksByCategory: {},
+    activeSnapPicks: [],
     initialInviteMode: InviteMode.Group,
   },
 };
@@ -106,6 +108,26 @@ export const WithPicks: Story = {
       "cat-1": [mockFridayFlick, mockDateNightFilm],
       "cat-2": [mockBeachWeekRead],
     },
+  },
+};
+
+export const WithActiveSnapPicks: Story = {
+  args: {
+    categories: mockCategories,
+    activeSnapPicks: [
+      {
+        snapPick: makeSnapPick({
+          id: "snap-1",
+          title: "Where should we eat tonight?",
+          categoryId: "cat-1",
+        }),
+        activation: makeSnapPickActivation({
+          id: "activation-1",
+          snapPickId: "snap-1",
+          closesAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+        }),
+      },
+    ],
   },
 };
 

--- a/src/app/groups/[id]/GroupDetailView.tsx
+++ b/src/app/groups/[id]/GroupDetailView.tsx
@@ -11,6 +11,8 @@ import type { Group } from "@/lib/types/group";
 import { InviteMode } from "@/lib/types/invite";
 import type { GroupPick } from "@/lib/types/pick";
 
+import type { ActiveSnapPickActivationItem } from "./ActiveSnapPickList";
+import { ActiveSnapPickList } from "./ActiveSnapPickList";
 import { CategoryList } from "./categories/CategoryList";
 import { GROUP_DETAIL_COPY } from "./copy";
 import { DeleteGroupButtonView } from "./DeleteGroupButtonView";
@@ -33,6 +35,7 @@ interface GroupDetailViewProps {
   initialInviteMode: InviteMode;
   memberNames: MemberName[];
   picksByCategory: Record<string, GroupPick[]>;
+  activeSnapPicks: ActiveSnapPickActivationItem[];
   onMakeAdmin?: (uid: string) => void;
   onRevokeAdmin?: (uid: string) => void;
   onTogglePicksRestricted: () => void;
@@ -108,6 +111,7 @@ export function GroupDetailView({
   initialInviteMode,
   memberNames,
   picksByCategory,
+  activeSnapPicks,
   onMakeAdmin,
   onRevokeAdmin,
   onTogglePicksRestricted,
@@ -208,7 +212,14 @@ export function GroupDetailView({
         </TabsList>
 
         <TabsContent value="picks" className="mt-4 space-y-6">
-          {allPicks.length === 0 ? (
+          {activeSnapPicks.length > 0 && (
+            <ActiveSnapPickList
+              groupId={group.id}
+              activations={activeSnapPicks}
+              categories={categories}
+            />
+          )}
+          {allPicks.length === 0 && activeSnapPicks.length === 0 ? (
             <p className="text-sm text-muted-foreground">
               {GROUP_DETAIL_COPY.noPicksMessage}
             </p>

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickForm.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickForm.copy.ts
@@ -1,0 +1,14 @@
+export const CREATE_SNAP_PICK_COPY = {
+  title: "Create a Snap Pick",
+  subtitle:
+    "Snap Picks start with just a name. You add options and run votes from the Snap Pick page.",
+  nameLabel: "Snap Pick name",
+  namePlaceholder: "e.g. What's for dinner?",
+  submitButton: "Create Snap Pick",
+  submittingButton: "Creating…",
+  cancelButton: "Cancel",
+  errors: {
+    nameRequired: "Snap Pick name cannot be blank.",
+    default: "Could not create the Snap Pick. Please try again.",
+  },
+} as const;

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickForm.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickForm.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { createSnapPick } from "@/services/snap-picks";
+
+import { CREATE_SNAP_PICK_COPY } from "./CreateSnapPickForm.copy";
+import { CreateSnapPickFormView } from "./CreateSnapPickFormView";
+
+interface CreateSnapPickFormProps {
+  groupId: string;
+  categoryId: string;
+}
+
+export function CreateSnapPickForm({
+  groupId,
+  categoryId,
+}: CreateSnapPickFormProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  async function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError(CREATE_SNAP_PICK_COPY.errors.nameRequired);
+      return;
+    }
+    setError(undefined);
+    setLoading(true);
+    try {
+      const { snapPickId } = await createSnapPick(
+        groupId,
+        categoryId,
+        title.trim(),
+      );
+      router.push(
+        `/groups/${groupId}/categories/${categoryId}/snap-picks/${snapPickId}`,
+      );
+    } catch {
+      setError(CREATE_SNAP_PICK_COPY.errors.default);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <CreateSnapPickFormView
+      title={title}
+      onTitleChange={setTitle}
+      onSubmit={(e) => void handleSubmit(e)}
+      onCancel={() => {
+        router.back();
+      }}
+      loading={loading}
+      error={error}
+    />
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickFormView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickFormView.spec.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CREATE_SNAP_PICK_COPY } from "./CreateSnapPickForm.copy";
+import { CreateSnapPickFormView } from "./CreateSnapPickFormView";
+
+afterEach(cleanup);
+
+const noop = vi.fn();
+
+describe("CreateSnapPickFormView", () => {
+  it("renders the Snap Pick create heading", () => {
+    render(
+      <CreateSnapPickFormView
+        title=""
+        onTitleChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+        loading={false}
+        error={undefined}
+      />,
+    );
+
+    expect(screen.getByText(CREATE_SNAP_PICK_COPY.title)).toBeDefined();
+  });
+
+  it("disables the submit button when the title is blank", () => {
+    render(
+      <CreateSnapPickFormView
+        title=""
+        onTitleChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+        loading={false}
+        error={undefined}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: CREATE_SNAP_PICK_COPY.submitButton })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  // TODO: upgrade to userEvent when @testing-library/user-event is available
+  it("invokes onSubmit when the form is submitted", () => {
+    const onSubmit = vi.fn((e: React.SyntheticEvent) => {
+      e.preventDefault();
+    });
+    const { container } = render(
+      <CreateSnapPickFormView
+        title="Dinner"
+        onTitleChange={noop}
+        onSubmit={onSubmit}
+        onCancel={noop}
+        loading={false}
+        error={undefined}
+      />,
+    );
+
+    const form = container.querySelector("form");
+    if (form) fireEvent.submit(form);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("shows the error message when provided", () => {
+    render(
+      <CreateSnapPickFormView
+        title="Dinner"
+        onTitleChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+        loading={false}
+        error={CREATE_SNAP_PICK_COPY.errors.default}
+      />,
+    );
+
+    expect(
+      screen.getByText(CREATE_SNAP_PICK_COPY.errors.default),
+    ).toBeDefined();
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickFormView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickFormView.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { CreateSnapPickFormView } from "./CreateSnapPickFormView";
+
+const noop = () => undefined;
+
+const meta: Meta<typeof CreateSnapPickFormView> = {
+  title: "Picks/CreateSnapPickFormView",
+  component: CreateSnapPickFormView,
+  args: {
+    title: "",
+    onTitleChange: noop,
+    onSubmit: noop,
+    onCancel: noop,
+    loading: false,
+    error: undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CreateSnapPickFormView>;
+
+export const Default: Story = {};
+
+export const WithTitle: Story = {
+  args: {
+    title: "What's for dinner?",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: "What's for dinner?",
+    loading: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    error: "Could not create the Snap Pick. Please try again.",
+  },
+};

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickFormView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/CreateSnapPickFormView.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { CREATE_SNAP_PICK_COPY } from "./CreateSnapPickForm.copy";
+
+interface CreateSnapPickFormViewProps {
+  title: string;
+  onTitleChange: (title: string) => void;
+  onSubmit: (e: React.SyntheticEvent) => void;
+  onCancel: () => void;
+  loading: boolean;
+  error: string | undefined;
+}
+
+export function CreateSnapPickFormView({
+  title,
+  onTitleChange,
+  onSubmit,
+  onCancel,
+  loading,
+  error,
+}: CreateSnapPickFormViewProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold">{CREATE_SNAP_PICK_COPY.title}</h2>
+        <p className="text-sm text-muted-foreground">
+          {CREATE_SNAP_PICK_COPY.subtitle}
+        </p>
+      </div>
+
+      <form
+        aria-label={CREATE_SNAP_PICK_COPY.title}
+        onSubmit={onSubmit}
+        className="space-y-4"
+      >
+        <div className="space-y-1">
+          <Label htmlFor="snap-pick-title">
+            {CREATE_SNAP_PICK_COPY.nameLabel}
+          </Label>
+          <Input
+            id="snap-pick-title"
+            type="text"
+            value={title}
+            onChange={(e) => {
+              onTitleChange(e.target.value);
+            }}
+            placeholder={CREATE_SNAP_PICK_COPY.namePlaceholder}
+            disabled={loading}
+            required
+          />
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <div className="flex gap-2">
+          <Button type="submit" disabled={loading || !title.trim()}>
+            {loading
+              ? CREATE_SNAP_PICK_COPY.submittingButton
+              : CREATE_SNAP_PICK_COPY.submitButton}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={loading}
+          >
+            {CREATE_SNAP_PICK_COPY.cancelButton}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSelectorView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSelectorView.spec.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NewPickTypeSelectorView } from "./NewPickTypeSelectorView";
+import { NEW_PICK_TYPE_SWITCHER_COPY } from "./NewPickTypeSwitcher.copy";
+
+afterEach(cleanup);
+
+describe("NewPickTypeSelectorView", () => {
+  it("offers both a Standard pick and a Snap Pick option", () => {
+    render(
+      <NewPickTypeSelectorView
+        pickType="standard"
+        onPickTypeChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(NEW_PICK_TYPE_SWITCHER_COPY.standard.label),
+    ).toBeDefined();
+    expect(
+      screen.getByText(NEW_PICK_TYPE_SWITCHER_COPY.snap.label),
+    ).toBeDefined();
+  });
+
+  it("marks the standard radio as checked when standard is selected", () => {
+    render(
+      <NewPickTypeSelectorView
+        pickType="standard"
+        onPickTypeChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("radio", {
+        name: NEW_PICK_TYPE_SWITCHER_COPY.standard.label,
+        checked: true,
+      }),
+    ).toBeDefined();
+  });
+
+  // TODO: upgrade to userEvent when @testing-library/user-event is available
+  it("invokes onPickTypeChange with 'snap' when the Snap Pick option is chosen", () => {
+    const onPickTypeChange = vi.fn();
+    render(
+      <NewPickTypeSelectorView
+        pickType="standard"
+        onPickTypeChange={onPickTypeChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("radio", {
+        name: NEW_PICK_TYPE_SWITCHER_COPY.snap.label,
+      }),
+    );
+
+    expect(onPickTypeChange).toHaveBeenCalledWith("snap");
+  });
+});

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSelectorView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSelectorView.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { NewPickTypeSelectorView } from "./NewPickTypeSelectorView";
+
+const noop = () => undefined;
+
+const meta: Meta<typeof NewPickTypeSelectorView> = {
+  title: "Picks/NewPickTypeSelectorView",
+  component: NewPickTypeSelectorView,
+  args: {
+    pickType: "standard",
+    onPickTypeChange: noop,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NewPickTypeSelectorView>;
+
+export const StandardSelected: Story = {};
+
+export const SnapSelected: Story = {
+  args: {
+    pickType: "snap",
+  },
+};

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSelectorView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSelectorView.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { NEW_PICK_TYPE_SWITCHER_COPY } from "./NewPickTypeSwitcher.copy";
+import type { NewPickType } from "./pick-type";
+
+interface NewPickTypeSelectorViewProps {
+  pickType: NewPickType;
+  onPickTypeChange: (pickType: NewPickType) => void;
+}
+
+export function NewPickTypeSelectorView({
+  pickType,
+  onPickTypeChange,
+}: NewPickTypeSelectorViewProps) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium">
+        {NEW_PICK_TYPE_SWITCHER_COPY.legend}
+      </legend>
+      <div className="grid grid-cols-2 gap-2">
+        <label className="flex cursor-pointer flex-col gap-1 rounded-md border p-3 text-sm has-checked:border-primary has-checked:bg-accent">
+          <span className="flex items-center gap-2 font-medium">
+            <input
+              type="radio"
+              name="pick-type"
+              value="standard"
+              aria-label={NEW_PICK_TYPE_SWITCHER_COPY.standard.label}
+              checked={pickType === "standard"}
+              onChange={() => {
+                onPickTypeChange("standard");
+              }}
+            />
+            {NEW_PICK_TYPE_SWITCHER_COPY.standard.label}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {NEW_PICK_TYPE_SWITCHER_COPY.standard.description}
+          </span>
+        </label>
+        <label className="flex cursor-pointer flex-col gap-1 rounded-md border p-3 text-sm has-checked:border-primary has-checked:bg-accent">
+          <span className="flex items-center gap-2 font-medium">
+            <input
+              type="radio"
+              name="pick-type"
+              value="snap"
+              aria-label={NEW_PICK_TYPE_SWITCHER_COPY.snap.label}
+              checked={pickType === "snap"}
+              onChange={() => {
+                onPickTypeChange("snap");
+              }}
+            />
+            {NEW_PICK_TYPE_SWITCHER_COPY.snap.label}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {NEW_PICK_TYPE_SWITCHER_COPY.snap.description}
+          </span>
+        </label>
+      </div>
+    </fieldset>
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSwitcher.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSwitcher.copy.ts
@@ -1,0 +1,12 @@
+export const NEW_PICK_TYPE_SWITCHER_COPY = {
+  legend: "Pick type",
+  standard: {
+    label: "Standard pick",
+    description: "Members rank a fixed set of options you define up front.",
+  },
+  snap: {
+    label: "Snap Pick",
+    description:
+      "A recurring quick decision. Add just a title now; the option pool grows over time.",
+  },
+} as const;

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSwitcher.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/NewPickTypeSwitcher.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import { CreatePickForm } from "./CreatePickForm";
+import { CreateSnapPickForm } from "./CreateSnapPickForm";
+import { NewPickTypeSelectorView } from "./NewPickTypeSelectorView";
+import type { NewPickType } from "./pick-type";
+
+interface NewPickTypeSwitcherProps {
+  groupId: string;
+  categoryId: string;
+  hasPriorPicks: boolean;
+}
+
+export function NewPickTypeSwitcher({
+  groupId,
+  categoryId,
+  hasPriorPicks,
+}: NewPickTypeSwitcherProps) {
+  const [pickType, setPickType] = useState<NewPickType>("standard");
+
+  return (
+    <div className="space-y-6">
+      <NewPickTypeSelectorView
+        pickType={pickType}
+        onPickTypeChange={setPickType}
+      />
+      {pickType === "standard" ? (
+        <CreatePickForm
+          groupId={groupId}
+          categoryId={categoryId}
+          hasPriorPicks={hasPriorPicks}
+        />
+      ) : (
+        <CreateSnapPickForm groupId={groupId} categoryId={categoryId} />
+      )}
+    </div>
+  );
+}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/page.tsx
@@ -5,7 +5,7 @@ import { getGroupById } from "@/server/data/groups";
 import { hasPicks } from "@/server/data/picks";
 import { getVerifiedUid } from "@/server/utils/auth";
 
-import { CreatePickForm } from "./CreatePickForm";
+import { NewPickTypeSwitcher } from "./NewPickTypeSwitcher";
 
 export default async function CreatePickPage({
   params,
@@ -29,7 +29,7 @@ export default async function CreatePickPage({
 
   return (
     <main className="mx-auto max-w-lg p-6">
-      <CreatePickForm
+      <NewPickTypeSwitcher
         groupId={groupId}
         categoryId={categoryId}
         hasPriorPicks={hasPriorPicks}

--- a/src/app/groups/[id]/categories/[categoryId]/picks/new/pick-type.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/new/pick-type.ts
@@ -1,0 +1,2 @@
+export const NEW_PICK_TYPES = ["standard", "snap"] as const;
+export type NewPickType = (typeof NEW_PICK_TYPES)[number];

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -6,6 +6,7 @@ import { markGroupSeen } from "@/server/data/groupActivity";
 import { getGroupById, getMemberDisplayNames } from "@/server/data/groups";
 import { getGroupInviteByToken } from "@/server/data/invites";
 import { getPicksByCategoryIds } from "@/server/data/picks";
+import { getActiveSnapPickActivationsByCategories } from "@/server/data/snap-picks";
 import { getVerifiedUid } from "@/server/utils/auth";
 
 import { GroupDetailClient } from "./GroupDetailClient";
@@ -27,14 +28,22 @@ export default async function GroupDetailPage({
 
   const categoriesPromise = getCategoriesByGroupId(id);
 
-  const [invite, categories, memberNames, picksByCategory] = await Promise.all([
-    getGroupInviteByToken(group.inviteToken),
-    categoriesPromise,
-    getMemberDisplayNames(group.memberIds),
-    categoriesPromise.then((resolvedCategories) =>
-      getPicksByCategoryIds(resolvedCategories.map((category) => category.id)),
-    ),
-  ]);
+  const [invite, categories, memberNames, picksByCategory, activeSnapPicks] =
+    await Promise.all([
+      getGroupInviteByToken(group.inviteToken),
+      categoriesPromise,
+      getMemberDisplayNames(group.memberIds),
+      categoriesPromise.then((resolvedCategories) =>
+        getPicksByCategoryIds(
+          resolvedCategories.map((category) => category.id),
+        ),
+      ),
+      categoriesPromise.then((resolvedCategories) =>
+        getActiveSnapPickActivationsByCategories(
+          resolvedCategories.map((category) => category.id),
+        ),
+      ),
+    ]);
 
   return (
     <GroupDetailClient
@@ -45,6 +54,7 @@ export default async function GroupDetailPage({
       initialInviteMode={invite?.mode ?? InviteMode.Group}
       memberNames={memberNames}
       picksByCategory={picksByCategory}
+      activeSnapPicks={activeSnapPicks}
     />
   );
 }

--- a/src/lib/fixtures/snap-pick.ts
+++ b/src/lib/fixtures/snap-pick.ts
@@ -1,4 +1,8 @@
-import type { SnapPick, SnapPickOption } from "@/lib/types/snap-pick";
+import type {
+  SnapPick,
+  SnapPickActivation,
+  SnapPickOption,
+} from "@/lib/types/snap-pick";
 
 export function makeSnapPick(overrides?: Partial<SnapPick>): SnapPick {
   return {
@@ -20,6 +24,19 @@ export function makeSnapPickOption(
     title: "Pizza",
     addedBy: "user-1",
     addedAt: new Date("2025-03-21T09:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+export function makeSnapPickActivation(
+  overrides?: Partial<SnapPickActivation>,
+): SnapPickActivation {
+  return {
+    id: "activation-1",
+    snapPickId: "snap-1",
+    startedAt: new Date("2025-03-22T10:00:00.000Z"),
+    closesAt: new Date("2025-03-22T23:59:00.000Z"),
+    startedBy: "user-1",
     ...overrides,
   };
 }

--- a/src/server/data/snap-picks.spec.ts
+++ b/src/server/data/snap-picks.spec.ts
@@ -22,6 +22,7 @@ const {
   getSnapPickById,
   getSnapPicksByCategory,
   getSnapPickActivations,
+  getActiveSnapPickActivationsByCategories,
   addSnapPickOption,
   removeSnapPickOption,
   getSnapPickOptions,
@@ -243,5 +244,64 @@ describe("getSnapPickOptions", () => {
     mockGet.mockResolvedValue(snapshot(undefined));
 
     expect(await getSnapPickOptions("snap-1")).toEqual([]);
+  });
+});
+
+describe("getActiveSnapPickActivationsByCategories", () => {
+  // Routes each mocked db.ref(path).get() to a value keyed by path, so a single
+  // call can resolve both the container read and its activations read.
+  function routeByPath(valuesByPath: Record<string, unknown>) {
+    mockRef.mockImplementation((path: string) => ({
+      get: () => Promise.resolve(snapshot(valuesByPath[path])),
+    }));
+  }
+
+  const now = new Date(1_700_000_500_000);
+
+  it("returns only activations that are still open at the given time", async () => {
+    routeByPath({
+      "snap-picks/cat-1": { "snap-1": FIREBASE_SNAP_PICK },
+      "snap-pick-activations/snap-1": {
+        open: {
+          snapPickId: "snap-1",
+          startedAt: 1_700_000_100_000,
+          closesAt: 1_700_000_600_000,
+          startedBy: "user-2",
+        },
+        expired: {
+          snapPickId: "snap-1",
+          startedAt: 1_699_999_000_000,
+          closesAt: 1_700_000_400_000,
+          startedBy: "user-2",
+        },
+        closed: {
+          snapPickId: "snap-1",
+          startedAt: 1_700_000_100_000,
+          closesAt: 1_700_000_600_000,
+          closedAt: 1_700_000_450_000,
+          winnerId: "option-1",
+          startedBy: "user-2",
+        },
+      },
+    });
+
+    const result = await getActiveSnapPickActivationsByCategories(
+      ["cat-1"],
+      now,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.activation.id).toBe("open");
+    expect(result[0]?.snapPick.id).toBe("snap-1");
+  });
+
+  it("returns an empty array when no categories have active activations", async () => {
+    routeByPath({
+      "snap-picks/cat-1": undefined,
+    });
+
+    expect(
+      await getActiveSnapPickActivationsByCategories(["cat-1"], now),
+    ).toEqual([]);
   });
 });

--- a/src/server/data/snap-picks.ts
+++ b/src/server/data/snap-picks.ts
@@ -71,6 +71,45 @@ export async function getSnapPickActivations(
   );
 }
 
+// A Snap Pick together with one of its currently-running activations. Surfaced
+// on the group activity view so members can jump straight into an open vote.
+export interface ActiveSnapPickActivation {
+  snapPick: SnapPick;
+  activation: SnapPickActivation;
+}
+
+// An activation is "active" when it has not been explicitly closed and its
+// scheduled close time is still in the future.
+function isActivationActive(
+  activation: SnapPickActivation,
+  now: Date,
+): boolean {
+  return (
+    activation.closedAt === undefined &&
+    activation.closesAt.getTime() > now.getTime()
+  );
+}
+
+export async function getActiveSnapPickActivationsByCategories(
+  categoryIds: string[],
+  now: Date = new Date(),
+): Promise<ActiveSnapPickActivation[]> {
+  const snapPickArrays = await Promise.all(
+    categoryIds.map((categoryId) => getSnapPicksByCategory(categoryId)),
+  );
+  const snapPicks = snapPickArrays.flat();
+
+  const activationArrays = await Promise.all(
+    snapPicks.map((snapPick) => getSnapPickActivations(snapPick.id)),
+  );
+
+  return snapPicks.flatMap((snapPick, i) =>
+    (activationArrays[i] ?? [])
+      .filter((activation) => isActivationActive(activation, now))
+      .map((activation) => ({ snapPick, activation })),
+  );
+}
+
 export async function addSnapPickOption(
   snapPickId: string,
   option: Pick<SnapPickOption, "title" | "addedBy">,


### PR DESCRIPTION
## Purpose

Part of the Snap Picks epic (#255). Surfaces Snap Picks alongside normal picks in the category and group navigation, building on the merged Snap Pick container + option pool (#257 via #356).

Closes #262.

## What changed

- **New-pick flow (Standard vs Snap Pick):** the `picks/new` page now shows a pick-type chooser. "Standard pick" keeps the existing `CreatePickForm`; "Snap Pick" shows a title-only creation form that routes to the Snap Pick detail page after creation.
- **Group activity cards:** the group Picks tab now surfaces currently-active Snap Pick activations as cards with a "Vote now" CTA and live time-remaining, each linking to the Snap Pick detail route.
- **Data layer:** adds `getActiveSnapPickActivationsByCategories`, which reads the open (not-closed, not-past-`closesAt`) activations across a group's categories, wired into the group page's parallel fetch.
- **Category page:** already lists Snap Picks in a distinct section via the merged `SnapPickSection` (#257) — no change needed there.

## Technical considerations

- Follows the presentational `View` + hook-wrapper split, co-located `.copy.ts` files, Storybook stories, and Vitest specs throughout.
- Time-remaining is computed client-side (updates on a 1-minute interval) so the pure `ActiveSnapPickListView` stays trivially testable.
- Specs use `fireEvent` (with a `// TODO: upgrade to userEvent` note) since `@testing-library/user-event` is not yet available.

## Out of scope / known gap

- Acceptance-criterion "navigation breadcrumbs updated to include the Snap Pick container title" is **not** addressed: no breadcrumb infrastructure exists anywhere in the app yet (normal picks have none either), and the Snap Pick detail view is owned by the open activation/voting stack (#357/#362), which this PR intentionally does not touch to avoid conflicts. Breadcrumbs are best introduced as their own change once the detail view stabilizes.

---
*Created by Claude Opus 4.8*
