### PR TITLE
feat(ui)!: reusable breadcrumb navigation primitive + wire into detail pages

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.spec.tsx
@@ -1,11 +1,12 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { BREADCRUMBS_COPY } from "@/components/breadcrumbs";
 import type { Category } from "@/lib/types/category";
 import type { GroupPick } from "@/lib/types/pick";
 import { RankingMode } from "@/lib/types/pick";
 
-import { CategoryDetailView } from "./CategoryDetailView";
+import { CategoryDetailView as CategoryDetailViewBase } from "./CategoryDetailView";
 import { CATEGORY_DETAIL_COPY } from "./copy";
 
 afterEach(cleanup);
@@ -17,6 +18,20 @@ vi.mock("./ReopenPickButton", () => ({
     </button>
   ),
 }));
+
+type CategoryDetailViewProps = Omit<
+  Parameters<typeof CategoryDetailViewBase>[0],
+  "groupName"
+> & {
+  groupName?: string;
+};
+
+function CategoryDetailView({
+  groupName = "Movie Night",
+  ...props
+}: CategoryDetailViewProps) {
+  return <CategoryDetailViewBase groupName={groupName} {...props} />;
+}
 
 function makeCategory(overrides?: Partial<Category>): Category {
   return {
@@ -49,7 +64,9 @@ describe("CategoryDetailView — category metadata", () => {
   it("renders the category name as a heading", () => {
     render(<CategoryDetailView category={makeCategory()} picks={[]} />);
 
-    expect(screen.getByText("Best Movies")).toBeDefined();
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Best Movies" }),
+    ).toBeDefined();
   });
 
   it("renders the created at label", () => {
@@ -252,5 +269,28 @@ describe("CategoryDetailView — due date", () => {
         new Date("2026-01-01T00:00:00.000Z").toLocaleDateString(),
       ),
     ).toBeNull();
+  });
+});
+
+describe("CategoryDetailView — breadcrumb trail", () => {
+  it("renders a Group → Category breadcrumb trail", () => {
+    const category = makeCategory({ name: "Best Movies", groupId: "group-1" });
+    render(
+      <CategoryDetailView
+        category={category}
+        groupName="Movie Night"
+        picks={[]}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", {
+      name: BREADCRUMBS_COPY.navLabel,
+    });
+
+    const groupCrumb = within(nav).getByRole("link", { name: "Movie Night" });
+    expect(groupCrumb.getAttribute("href")).toBe("/groups/group-1");
+
+    const categoryCrumb = within(nav).getByText("Best Movies");
+    expect(categoryCrumb.getAttribute("aria-current")).toBe("page");
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.stories.tsx
@@ -49,6 +49,7 @@ const meta: Meta<typeof CategoryDetailView> = {
   },
   args: {
     category,
+    groupName: "Movie Night",
     picks,
   },
 };

--- a/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/CategoryDetailView.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumbs } from "@/components/breadcrumbs";
 import type { Category } from "@/lib/types/category";
 import type { GroupPick } from "@/lib/types/pick";
 
@@ -7,16 +8,27 @@ import { ReopenPickButton } from "./ReopenPickButton";
 interface CategoryDetailViewProps {
   category: Category;
   closePickAction?: (formData: FormData) => void | Promise<void>;
+  groupName: string;
   picks: GroupPick[];
 }
 
 export function CategoryDetailView({
   category,
   closePickAction,
+  groupName,
   picks,
 }: CategoryDetailViewProps) {
   return (
     <main className="mx-auto max-w-lg space-y-6 p-6">
+      <Breadcrumbs
+        crumbs={[
+          { label: groupName, href: `/groups/${category.groupId}` },
+          {
+            label: category.name,
+            href: `/groups/${category.groupId}/categories/${category.id}`,
+          },
+        ]}
+      />
       <div className="space-y-1">
         <h1 className="text-2xl font-semibold">{category.name}</h1>
         <dl className="space-y-2 text-sm">

--- a/src/app/groups/[id]/categories/[categoryId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/page.tsx
@@ -88,6 +88,7 @@ export default async function CategoryDetailPage({
       <CategoryDetailView
         category={category}
         closePickAction={closePickAction}
+        groupName={group.name}
         picks={picks}
       />
       <SnapPickSection

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView-tests/interactions.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView-tests/interactions.spec.tsx
@@ -73,6 +73,7 @@ function renderView(overrides?: Partial<Parameters<typeof PickDetailView>[0]>) {
     <PickDetailView
       pick={makePick()}
       groupId="group-1"
+      groupName="Movie Night"
       categoryId="cat-1"
       currentUserId="user-1"
       initialOptions={[]}
@@ -281,7 +282,10 @@ describe("pick metadata — category name", () => {
   it("renders the category name when provided", () => {
     renderView({ categoryName: "Best Movies" });
 
-    expect(screen.getByText("Best Movies")).toBeDefined();
+    const categoryLabel = screen.getByText(
+      PICK_DETAIL_SCAFFOLD_COPY.categoryLabel,
+    );
+    expect(categoryLabel.parentElement?.textContent).toContain("Best Movies");
   });
 
   it("does not render the category label when category name is not provided", () => {

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView-tests/rendering.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView-tests/rendering.spec.tsx
@@ -8,6 +8,8 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { BREADCRUMBS_COPY } from "@/components/breadcrumbs";
+
 import { CLOSED_PICK_RESULTS_COPY } from "../ClosedPickResultsView.copy";
 import { PICK_DETAIL_SCAFFOLD_COPY } from "../copy";
 import { PickDetailView } from "../PickDetailView";
@@ -94,6 +96,7 @@ function renderView(overrides?: Partial<Parameters<typeof PickDetailView>[0]>) {
     <PickDetailView
       pick={makePick()}
       groupId="group-1"
+      groupName="Movie Night"
       categoryId="cat-1"
       currentUserId="user-1"
       initialOptions={[]}
@@ -121,6 +124,33 @@ describe("pick metadata", () => {
       screen.getByText(PICK_DETAIL_SCAFFOLD_COPY.topCountLabel),
     ).toBeDefined();
     expect(screen.getByText("3")).toBeDefined();
+  });
+});
+
+describe("breadcrumb trail", () => {
+  it("renders a Group → Category → Pick breadcrumb trail", () => {
+    renderView({
+      pick: makePick({ id: "pick-1", title: "Best Movie of 2025" }),
+      groupName: "Movie Night",
+      categoryName: "Best Movies",
+    });
+
+    const nav = screen.getByRole("navigation", {
+      name: BREADCRUMBS_COPY.navLabel,
+    });
+
+    const groupCrumb = within(nav).getByRole("link", { name: "Movie Night" });
+    expect(groupCrumb.getAttribute("href")).toBe("/groups/group-1");
+
+    const categoryCrumb = within(nav).getByRole("link", {
+      name: "Best Movies",
+    });
+    expect(categoryCrumb.getAttribute("href")).toBe(
+      "/groups/group-1/categories/cat-1",
+    );
+
+    const pickCrumb = within(nav).getByText("Best Movie of 2025");
+    expect(pickCrumb.getAttribute("aria-current")).toBe("page");
   });
 });
 

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.stories.tsx
@@ -63,7 +63,9 @@ const meta: Meta<typeof PickDetailView> = {
   args: {
     pick: mockPick,
     groupId: "group-1",
+    groupName: "Movie Night",
     categoryId: "cat-1",
+    categoryName: "Best Movies",
     currentUserId: "user-1",
     initialOptions: mockOptions,
     initialSuggestions: [],

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/PickDetailView.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -26,6 +27,7 @@ import { TOP_PICKS_VIEW_COPY } from "./TopPicksView.copy";
 interface PickDetailViewProps {
   pick: GroupPick;
   groupId: string;
+  groupName: string;
   categoryId: string;
   categoryName?: string;
   currentUserId: string;
@@ -43,6 +45,7 @@ interface PickDetailViewProps {
 export function PickDetailView({
   pick,
   groupId,
+  groupName,
   categoryId,
   categoryName,
   currentUserId,
@@ -61,6 +64,21 @@ export function PickDetailView({
   const closedAt = pick.closedAt;
   const isOpen = closedAt === undefined;
   const uniqueOwnerCount = new Set(options.flatMap((opt) => opt.ownerIds)).size;
+  const breadcrumbs = [
+    { label: groupName, href: `/groups/${groupId}` },
+    ...(categoryName
+      ? [
+          {
+            label: categoryName,
+            href: `/groups/${groupId}/categories/${categoryId}`,
+          },
+        ]
+      : []),
+    {
+      label: pick.title,
+      href: `/groups/${groupId}/categories/${categoryId}/picks/${pick.id}`,
+    },
+  ];
 
   async function handleReopen() {
     setIsReopening(true);
@@ -112,6 +130,7 @@ export function PickDetailView({
 
   return (
     <main className="mx-auto max-w-lg space-y-6 p-6">
+      <Breadcrumbs crumbs={breadcrumbs} />
       <div className="space-y-2">
         <h1 className="text-2xl font-semibold">{pick.title}</h1>
         {categoryName && (

--- a/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/picks/[pickId]/page.tsx
@@ -139,6 +139,7 @@ export default async function PickDetailPage({
     <PickDetailView
       pick={pick}
       groupId={groupId}
+      groupName={group.name}
       categoryId={categoryId}
       categoryName={category.name}
       currentUserId={uid}

--- a/src/components/breadcrumbs/Breadcrumbs.copy.ts
+++ b/src/components/breadcrumbs/Breadcrumbs.copy.ts
@@ -1,0 +1,3 @@
+export const BREADCRUMBS_COPY = {
+  navLabel: "Breadcrumb",
+} as const;

--- a/src/components/breadcrumbs/Breadcrumbs.spec.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.spec.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Breadcrumbs } from "./Breadcrumbs";
+import { BREADCRUMBS_COPY } from "./Breadcrumbs.copy";
+
+afterEach(cleanup);
+
+const trail = [
+  { label: "Movie Night", href: "/groups/group-1" },
+  { label: "Best Movies", href: "/groups/group-1/categories/cat-1" },
+  {
+    label: "Top 3 of 2025",
+    href: "/groups/group-1/categories/cat-1/picks/pick-1",
+  },
+];
+
+describe("Breadcrumbs — reusable component", () => {
+  it("renders a labelled navigation landmark", () => {
+    render(<Breadcrumbs crumbs={trail} />);
+
+    expect(
+      screen.getByRole("navigation", { name: BREADCRUMBS_COPY.navLabel }),
+    ).toBeDefined();
+  });
+
+  it("renders a crumb for every supplied entry", () => {
+    render(<Breadcrumbs crumbs={trail} />);
+
+    expect(screen.getByText("Movie Night")).toBeDefined();
+    expect(screen.getByText("Best Movies")).toBeDefined();
+    expect(screen.getByText("Top 3 of 2025")).toBeDefined();
+  });
+});
+
+describe("Breadcrumbs — data-driven trails", () => {
+  it("renders an arbitrary trail of two crumbs", () => {
+    render(<Breadcrumbs crumbs={trail.slice(0, 2)} />);
+
+    expect(screen.getByText("Movie Night")).toBeDefined();
+    expect(screen.getByText("Best Movies")).toBeDefined();
+    expect(screen.queryByText("Top 3 of 2025")).toBeNull();
+  });
+
+  it("renders a single-crumb trail", () => {
+    render(<Breadcrumbs crumbs={[trail[0]!]} />);
+
+    expect(screen.getByText("Movie Night")).toBeDefined();
+  });
+});
+
+describe("Breadcrumbs — links and current crumb", () => {
+  it("links every non-final crumb to its route", () => {
+    render(<Breadcrumbs crumbs={trail} />);
+
+    const groupLink = screen.getByRole("link", { name: "Movie Night" });
+    expect(groupLink.getAttribute("href")).toBe("/groups/group-1");
+
+    const categoryLink = screen.getByRole("link", { name: "Best Movies" });
+    expect(categoryLink.getAttribute("href")).toBe(
+      "/groups/group-1/categories/cat-1",
+    );
+  });
+
+  it("marks the final crumb as the current page and non-interactive", () => {
+    render(<Breadcrumbs crumbs={trail} />);
+
+    const current = screen.getByText("Top 3 of 2025");
+    expect(current.getAttribute("aria-current")).toBe("page");
+    expect(current.getAttribute("aria-disabled")).toBe("true");
+    expect(current.tagName).toBe("SPAN");
+    expect(current.getAttribute("href")).toBeNull();
+  });
+});

--- a/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Breadcrumbs } from "./Breadcrumbs";
+
+const meta: Meta<typeof Breadcrumbs> = {
+  title: "Components/Breadcrumbs",
+  component: Breadcrumbs,
+  parameters: {
+    nextjs: { appDirectory: true },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Breadcrumbs>;
+
+export const SingleCrumb: Story = {
+  args: {
+    crumbs: [{ label: "Best Movies", href: "/groups/group-1" }],
+  },
+};
+
+export const TwoCrumbs: Story = {
+  args: {
+    crumbs: [
+      { label: "Movie Night", href: "/groups/group-1" },
+      { label: "Best Movies", href: "/groups/group-1/categories/cat-1" },
+    ],
+  },
+};
+
+export const ThreeCrumbs: Story = {
+  args: {
+    crumbs: [
+      { label: "Movie Night", href: "/groups/group-1" },
+      { label: "Best Movies", href: "/groups/group-1/categories/cat-1" },
+      {
+        label: "Top 3 of 2025",
+        href: "/groups/group-1/categories/cat-1/picks/pick-1",
+      },
+    ],
+  },
+};

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { Fragment } from "react";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+import { BREADCRUMBS_COPY } from "./Breadcrumbs.copy";
+
+export interface Crumb {
+  href: string;
+  label: string;
+}
+
+interface BreadcrumbsProps {
+  crumbs: Crumb[];
+}
+
+export function Breadcrumbs({ crumbs }: BreadcrumbsProps) {
+  return (
+    <Breadcrumb aria-label={BREADCRUMBS_COPY.navLabel}>
+      <BreadcrumbList>
+        {crumbs.map((crumb, index) => {
+          const isLast = index === crumbs.length - 1;
+          return (
+            <Fragment key={crumb.href}>
+              <BreadcrumbItem>
+                {isLast ? (
+                  <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink render={<Link href={crumb.href} />}>
+                    {crumb.label}
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+              {!isLast && <BreadcrumbSeparator />}
+            </Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/src/components/breadcrumbs/index.ts
+++ b/src/components/breadcrumbs/index.ts
@@ -1,0 +1,3 @@
+export type { Crumb } from "./Breadcrumbs";
+export { Breadcrumbs } from "./Breadcrumbs";
+export { BREADCRUMBS_COPY } from "./Breadcrumbs.copy";

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+
+function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a">) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn("transition-colors hover:text-foreground", className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "breadcrumb-link",
+    },
+  })
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? (
+        <ChevronRightIcon />
+      )}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn(
+        "flex size-5 items-center justify-center [&>svg]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon
+      />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}


### PR DESCRIPTION
Adds a reusable, data-driven `Breadcrumbs` navigation primitive and wires it into the standard detail pages so the trail reflects the route hierarchy. The app previously had no breadcrumb infrastructure anywhere.

The ShadCN `breadcrumb` primitive was installed via `pnpm dlx shadcn@latest add breadcrumb` (upstream-managed, Prettier-ignored). On top of it, `src/components/breadcrumbs/Breadcrumbs.tsx` exposes a presentational component that accepts a `Crumb[]` (`{ label, href }`) and renders every crumb except the last as a Next.js `Link`; the last crumb renders as the non-interactive `aria-current="page"` element. Category detail now shows Group → Category and pick detail shows Group → Category → Pick (the group name is threaded through from each page's server data).

## Acceptance Criteria
- [x] A reusable `Breadcrumbs` component exists with story + tests.
- [x] Category detail page shows a Group → Category breadcrumb trail.
- [x] Pick detail page shows a Group → Category → Pick breadcrumb trail.
- [x] Crumb labels link to their routes; the current (last) crumb is non-interactive.
- [x] Component is data-driven so other pages can supply arbitrary trails.

## Tests
6 new tests for the `Breadcrumbs` component (single/2-crumb/3-crumb, landmark, links, current crumb) plus a Group → Category trail test on `CategoryDetailView` and a Group → Category → Pick trail test on `PickDetailView`. Full suite passes (327 tests) and the pre-push gate (format/lint/typecheck/test) is green.

The Snap Pick detail view is intentionally untouched — its breadcrumb placement is tracked in #366.

Closes #368

---
*Created by Claude Opus 4.8*
