### PR TITLE
ci: add gating build-storybook job (production SB build currently ships green)

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -115,6 +115,25 @@ jobs:
           playwright: chromium
       - run: pnpm storybook-tests
 
+  storybook-build:
+    name: Storybook Build
+    needs: detect-changes
+    # Gate on the broad code_changed signal (like storybook-tests and build), NOT
+    # stories_changed: a non-story change (a .storybook/ preset, a preview
+    # decorator, an addon/MDX config, a global CSS import) can break
+    # `pnpm build-storybook` without touching a *.stories.* file, and would ship
+    # green if this only ran on story changes (#372). This is a gating check with
+    # no continue-on-error — distinct from the advisory storybook-screenshots job,
+    # which also builds Storybook but reports its build neutral. Static build, so
+    # no browser: the setup action is called without the `playwright` input.
+    if: needs.detect-changes.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: ./.github/actions/setup
+      - run: pnpm build-storybook
+
   storybook-screenshots:
     name: Storybook Screenshots
     needs: detect-changes


### PR DESCRIPTION
Adds a standalone gating **`Storybook Build`** job so a broken `pnpm build-storybook` can no longer ship green.

## Problem

`build-storybook` ran in exactly one place — inside the advisory `storybook-screenshots` job — which left two holes (surfaced in [rmartz/ai discussion #6](https://github.com/rmartz/ai/discussions/6) and matched against the synthesized `storybook-screenshot-ci` guidance):

1. **Masked** — the capture step is `continue-on-error: true`, so a deterministic build break reported neutral.
2. **Never-run** — the job is gated on `stories_changed` (only `*.stories.*` paths), so a `.storybook/` preset, preview decorator, addon, or global-CSS change that breaks the build with no `.stories.` file skipped the job entirely.

Neither sibling gating job covers it: `build` is `pnpm build` (Next.js — different bundler/entrypoint), and `storybook-tests` renders via the Vitest `addon-vitest` transform, not the production Storybook bundle.

## Change

A `storybook-build` job that runs `pnpm build-storybook` on the broad **`code_changed`** gate (where `storybook-tests` and `build` already sit), with **no** `continue-on-error`. It's a static build, so it calls the shared `setup` action **without** the `playwright` input — no browser install. The advisory screenshots pipeline is unchanged.

This buys **compile** coverage of the production bundle. Render coverage (a story that compiles + passes Vitest but throws only in the production bundle in real Chromium) stays advisory-only in the screenshots job — a deliberate proportionality choice, not a gap this PR needs to close; `@storybook/test-runner` is the tool if such breaks ever appear.

## Testing

`pnpm build-storybook` verified green on the current tree; `format` / `lint` / `tsc` / `test` all pass.

Closes #372

---
*Created by Claude Opus 4.8*
