### PR TITLE
chore: rename package to group-picks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "firebase-nextjs-template",
+  "name": "group-picks",
   "version": "0.1.0",
-  "description": "Template repository for Next.js projects built on Firebase",
+  "description": "Collaborative group decision-making — picks, rankings, and recurring Snap Picks for groups",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
The repo was scaffolded from the Firebase/Next.js template and its `package.json` `name` / `description` were never updated — they still read `firebase-nextjs-template` / "Template repository for Next.js projects built on Firebase".

## Change

- `name`: `firebase-nextjs-template` → `group-picks`
- `description`: template boilerplate → "Collaborative group decision-making — picks, rankings, and recurring Snap Picks for groups"

Scoped to `package.json` — a tree scan confirmed the template name appears nowhere else in tracked files, and `pnpm-lock.yaml` carries no root name field, so `--frozen-lockfile` is unaffected (verified: lockfile unchanged, `format`/`lint`/`tsc`/`test` all green).

---
*Created by Claude Opus 4.8*
