### PR TITLE
ci: make Storybook screenshot capture fail fast, not time out

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -152,7 +152,16 @@ jobs:
       group: storybook-screenshots-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
-    # Backstop cap; the capture step has its own shorter, bounded timeout.
+    # Job-level continue-on-error keeps this advisory job non-blocking while
+    # letting the capture step report a real `failure` (→ routed to fix-review)
+    # instead of being swallowed to neutral. A bad/hung story is usually
+    # agent-fixable, so it should surface as a failure, not a job timeout →
+    # cancellation (which requires human escalation). The capture script fails
+    # fast (its own wall-clock deadline, below) so the timeout path is a last
+    # resort, not the only way the job goes non-green.
+    continue-on-error: true
+    # Backstop cap; the capture script's deadline and the step timeout both fire
+    # first, as failures rather than a job cancellation.
     timeout-minutes: 8
     permissions:
       contents: write
@@ -172,11 +181,13 @@ jobs:
       - name: List changed files
         run: |
           git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.sha }}" > changed-files.txt
-      # Advisory acceptance aid, never a gate: continue-on-error + a bounded
-      # timeout mean a hang or capture failure reports neutral and cannot block
-      # merge (#339). Capture reuses the Chromium installed by the setup action.
+      # No step-level continue-on-error here (unlike the setup step): a non-zero
+      # exit from the capture script must surface as a `failure` so it routes to
+      # fix-review. The job-level continue-on-error above keeps that failure
+      # non-blocking (advisory, never a merge gate — #339). The step timeout is a
+      # backstop; the script's own wall-clock deadline exits non-zero first.
+      # Capture reuses the Chromium installed by the setup action.
       - name: Capture and publish screenshots
-        continue-on-error: true
         timeout-minutes: 6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/capture-screenshots.d.mts
+++ b/scripts/capture-screenshots.d.mts
@@ -24,3 +24,7 @@ export declare function filterStoriesByChangedFiles(
 ): StoryEntry[];
 
 export declare function parseChangedFiles(contents: string): string[];
+
+export declare function resolveDeadlineMs(env: {
+  CAPTURE_DEADLINE_MS?: string;
+}): number;

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -109,6 +109,44 @@ function selectStories(staticDir, changedFilesPath) {
   return filterStoriesByChangedFiles(stories, changedFiles);
 }
 
+// Wall-clock budget for the whole capture, kept below the job's timeout-minutes
+// so an overrun exits non-zero (a FAILURE routed to fix-review) rather than
+// letting the job hit its timeout and be CANCELLED (which requires human
+// escalation). Overridable via CAPTURE_DEADLINE_MS for local testing.
+const DEFAULT_DEADLINE_MS = 240_000;
+// Per-story budgets: navigate to first paint (not networkidle, which can hang on
+// a page that keeps requesting), then give the story a short window to mount. A
+// story that crashes on render leaves #storybook-root empty and fails within
+// RENDER_TIMEOUT_MS instead of dragging the whole run toward the job timeout.
+const NAV_TIMEOUT_MS = 15_000;
+const RENDER_TIMEOUT_MS = 4_000;
+const CONCURRENCY = 4;
+
+// Resolve the wall-clock deadline from the environment, falling back to the
+// default when unset or not a positive number.
+export function resolveDeadlineMs(env) {
+  const parsed = Number(env?.CAPTURE_DEADLINE_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DEADLINE_MS;
+}
+
+async function captureStory(context, port, outDir, story) {
+  const url = `http://127.0.0.1:${port}/iframe.html?id=${story.id}&viewMode=story`;
+  const page = await context.newPage();
+  try {
+    await page.goto(url, {
+      waitUntil: "domcontentloaded",
+      timeout: NAV_TIMEOUT_MS,
+    });
+    await page
+      .locator("#storybook-root > *")
+      .first()
+      .waitFor({ state: "attached", timeout: RENDER_TIMEOUT_MS });
+    await page.screenshot({ path: join(outDir, `${story.id}.png`) });
+  } finally {
+    await page.close();
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const stories = selectStories(args.staticDir, args.changedFiles);
@@ -119,31 +157,41 @@ async function main() {
   }
   mkdirSync(args.out, { recursive: true });
 
+  const deadlineMs = resolveDeadlineMs(process.env);
+  const startedAt = Date.now();
   const { server, port } = await startStaticServer(args.staticDir);
   const browser = await chromium.launch();
-  const page = await browser.newPage({
+  const context = await browser.newContext({
     viewport: { width: 1280, height: 800 },
   });
 
+  const queue = [...stories];
+  const failed = [];
   let captured = 0;
-  try {
-    for (const story of stories) {
-      const url = `http://127.0.0.1:${port}/iframe.html?id=${story.id}&viewMode=story`;
-      // One flaky story must not abort the whole (advisory) capture.
+  let deadlineHit = false;
+
+  async function worker() {
+    while (queue.length > 0) {
+      if (Date.now() - startedAt > deadlineMs) {
+        deadlineHit = true;
+        return;
+      }
+      const story = queue.shift();
       try {
-        await page.goto(url, { waitUntil: "networkidle", timeout: 20_000 });
-        // Wait for the story root to actually render content.
-        await page
-          .locator("#storybook-root > *")
-          .first()
-          .waitFor({ state: "attached", timeout: 15_000 });
-        await page.screenshot({ path: join(args.out, `${story.id}.png`) });
+        await captureStory(context, port, args.out, story);
         captured += 1;
         console.log(`captured ${story.id}`);
       } catch (err) {
-        console.warn(`skipped ${story.id}: ${err.message}`);
+        failed.push(story.id);
+        console.warn(`FAILED ${story.id}: ${err.message}`);
       }
     }
+  }
+
+  try {
+    await Promise.all(
+      Array.from({ length: Math.min(CONCURRENCY, stories.length) }, worker),
+    );
   } finally {
     await browser.close();
     server.close();
@@ -152,6 +200,23 @@ async function main() {
   console.log(
     `Captured ${captured}/${stories.length} screenshot(s) to ${args.out}/`,
   );
+
+  // Exit non-zero on a deadline overrun or any render failure, so the problem is
+  // surfaced as a job FAILURE (→ fix-review) rather than silently skipped or left
+  // to time out and be cancelled. The job is advisory (job-level
+  // continue-on-error), so this failure is non-blocking for the run.
+  if (deadlineHit) {
+    console.error(
+      `Capture exceeded its ${deadlineMs}ms deadline with ${queue.length} unrendered — failing fast instead of timing out.`,
+    );
+    process.exit(1);
+  }
+  if (failed.length > 0) {
+    console.error(
+      `${failed.length} stor${failed.length === 1 ? "y" : "ies"} failed to render: ${failed.join(", ")}`,
+    );
+    process.exit(1);
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/scripts/capture-screenshots.spec.ts
+++ b/src/scripts/capture-screenshots.spec.ts
@@ -4,6 +4,7 @@ import {
   filterStoriesByChangedFiles,
   parseArgs,
   parseChangedFiles,
+  resolveDeadlineMs,
   storiesFromIndex,
   type StorybookIndex,
   type StoryEntry,
@@ -113,5 +114,21 @@ describe("filterStoriesByChangedFiles: match stories to changed files", () => {
         "src/components/Other.stories.tsx",
       ]),
     ).toEqual([]);
+  });
+});
+
+describe("resolveDeadlineMs: wall-clock budget from the environment", () => {
+  it("uses the default when CAPTURE_DEADLINE_MS is unset", () => {
+    expect(resolveDeadlineMs({})).toBe(240_000);
+  });
+
+  it("reads a positive numeric override", () => {
+    expect(resolveDeadlineMs({ CAPTURE_DEADLINE_MS: "5000" })).toBe(5000);
+  });
+
+  it("falls back to the default for non-positive or non-numeric values", () => {
+    expect(resolveDeadlineMs({ CAPTURE_DEADLINE_MS: "0" })).toBe(240_000);
+    expect(resolveDeadlineMs({ CAPTURE_DEADLINE_MS: "-1" })).toBe(240_000);
+    expect(resolveDeadlineMs({ CAPTURE_DEADLINE_MS: "abc" })).toBe(240_000);
   });
 });


### PR DESCRIPTION
Makes the advisory **Storybook Screenshots** job **fail fast** instead of running to `timeout-minutes` and being **cancelled** — so a capture problem is routed to fix-review (a `failure`) rather than escalated to a human (a `cancellation`). Mirrors [rmartz/personal-budget#358](https://github.com/rmartz/personal-budget/pull/358) for group-picks' structure.

## The problem

The job could only ever go non-green by hitting its timeout, because:

1. `scripts/capture-screenshots.mjs` **caught every per-story error and skipped it** — the script always exited `0`, so a story failing to render never failed the run.
2. The capture step's `continue-on-error: true` **swallowed the exit code** anyway, and each story used slow waits (`networkidle` + 15s), so once stories hung the run drifted toward the job timeout.

A bad/hung story therefore surfaced as a **cancellation** (human escalation), never a **failure** (agent-fixable → fix-review).

## The fix

- **`scripts/capture-screenshots.mjs`** now fails fast: stories render **concurrently** (pool of 4); each gets a short budget (`domcontentloaded` + a 4s mount wait instead of `networkidle` + 15s); an overall **wall-clock deadline** (default 4 min, overridable via `CAPTURE_DEADLINE_MS`, kept below the job's `timeout-minutes`) exits non-zero; and **any render failure** exits non-zero. Successfully-rendered stories still write their PNGs.
- **`ci-actions.yml`**: removed the capture step's `continue-on-error` so a non-zero exit surfaces as a job **`failure`** (→ fix-review); added **job-level** `continue-on-error` so that failure stays **non-blocking** for the run. The **setup step keeps** its own `continue-on-error`, so a transient browser-install flake stays **neutral** (infra, not agent-fixable) rather than routing to fix-review — group-picks' step-level granularity is preserved here deliberately.

## Verified locally

Against a real `build-storybook` output: a normal one-story capture renders 5/5 and exits `0` with PNGs; `CAPTURE_DEADLINE_MS=1` exits `1` immediately with a clear message. `format` / `lint` / `tsc` / `test` all pass (3 new `resolveDeadlineMs` unit tests added).

## Note

On a render failure the capture step aborts (`set -e`) before publishing, so the screenshot comment isn't posted that run — the failure is the signal; once the story is fixed and re-run, screenshots publish normally. This PR changes the **fail-vs-cancel behavior**, not any underlying story-render bug.

---
*Created by Claude Opus 4.8*
