### PR TITLE
feat(deploy)!: gate Vercel previews on the ready for UAT label

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -39,7 +40,7 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup
@@ -52,7 +53,12 @@ jobs:
       - name: Deploy prebuilt preview
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt --json --token="$VERCEL_TOKEN" | jq -r '.url')
+          url=$(vercel deploy --prebuilt --json --token="$VERCEL_TOKEN" \
+            | jq -r 'select(.url != null) | .url' | tail -1)
+          if [ -z "$url" ]; then
+            echo "Error: failed to extract deployment URL from vercel output" >&2
+            exit 1
+          fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Preview deployed to: $url"
       - name: Post or update sticky PR comment

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,77 @@
+name: Preview Deploy
+
+# Label-driven Vercel preview deploy (#351). A preview exists to enable UAT, so
+# we deploy one only when a PR is marked `ready for UAT` — not on every push.
+# Triggered when the label is added, and re-deployed when new commits land on an
+# already-labelled PR. The deploy URL is posted as a sticky PR comment.
+#
+# Requires repo secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID.
+#
+# This is the sole preview path: native Git-integration previews are disabled in
+# scripts/vercel-ignore-build.mjs (production-only), so a preview is created only
+# via this label-driven workflow.
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-deploy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Deploy preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Same-repo PRs only (forks can't read secrets), carrying `ready for UAT`,
+    # not held by `do not merge`, and not a draft.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'ready for UAT') &&
+      !contains(github.event.pull_request.labels.*.name, 'do not merge')
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/setup
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel@54.19.0
+      - name: Pull Vercel preview environment
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+      - name: Build
+        run: vercel build --token="$VERCEL_TOKEN"
+      - name: Deploy prebuilt preview
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --json --token="$VERCEL_TOKEN" | jq -r '.url')
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Preview deployed to: $url"
+      - name: Post or update sticky PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          URL: ${{ steps.deploy.outputs.url }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          marker="<!-- vercel-preview-bot -->"
+          body="$marker
+          🔺 **Vercel preview** (\`ready for UAT\`) for commit \`${SHA:0:7}\`:
+
+          $URL"
+          existing=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id // empty")
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" >/dev/null
+          fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,7 +215,7 @@ Flat config (`eslint.config.js`) with:
 
 ### Vercel
 
-- Automatic preview deployments on every PR
+- Label-gated preview deployments: a preview is built only when a PR carries the `ready for UAT` label (`.github/workflows/preview-deploy.yml`); native preview builds are cancelled by `scripts/vercel-ignore-build.mjs`
 - Production deployment on merge to main
 - Root directory: project root (no subdirectory)
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ project-root/
 
 1. Import your repository in the [Vercel dashboard](https://vercel.com/new)
 2. Add all environment variables from `.env.example`
-3. Deploy — Vercel handles preview deployments on PRs and production deployments on merge to `main`
+3. Deploy — Vercel handles production deployments on merge to `main`. Preview deployments are **label-gated**: a preview is built (by `.github/workflows/preview-deploy.yml`) only when a PR is marked `ready for UAT`, not on every push (see `scripts/vercel-ignore-build.mjs`, which cancels native preview builds)
 
 ### GitHub Actions
 

--- a/scripts/vercel-ignore-build.d.mts
+++ b/scripts/vercel-ignore-build.d.mts
@@ -1,3 +1,1 @@
-export declare function isDeployableTitle(
-  title: string | null | undefined,
-): boolean;
+export declare function shouldBuild(env: { VERCEL_ENV?: string }): boolean;

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -1,84 +1,34 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
 
-// Vercel "Ignored Build Step" — gates preview deploys to conserve the daily
-// deploy quota. Wired up via the `ignoreCommand` field in vercel.json.
+// Vercel "Ignored Build Step" — wired up via the `ignoreCommand` field in
+// vercel.json. Vercel runs this for every deploy and reads its exit code:
+// exit 1 = proceed with the build, exit 0 = cancel it.
 //
-// Vercel runs this for every deploy after cloning the repo (before install) and
-// reads its exit code: exit 1 = proceed with the build, exit 0 = cancel it.
-//
-// Policy: production builds always proceed. Preview builds proceed only when the
-// associated pull request's title is a `feat:` or `fix:` Conventional Commit —
-// the change types that warrant a UAT preview. Everything else (docs, chore,
-// refactor, test, style, ci, build, perf, revert) is skipped, along with branch
-// pushes that have no open PR yet and draft `[WIP]` titles, which do not need a
-// preview to review.
-//
-// The PR title lives on GitHub, not in the git checkout, so it is fetched from
-// the public GitHub REST API. group-picks is a public repo, so the call needs
-// no token — this is why the title-based gate requires no API key (unlike the
-// label-based follow-up tracked separately). If the repo is ever made private,
-// this fetch will 404 and the build will fail open (proceed) per the error
-// handling below; a token would then be required.
+// Policy: PRODUCTION deploys proceed; every non-production (preview) build is
+// cancelled. Native Git-integration previews are therefore disabled entirely —
+// a preview is created instead, on demand, by the label-driven
+// `.github/workflows/preview-deploy.yml`, which runs `vercel deploy` only when a
+// PR carries the `ready for UAT` label (#351). That makes the label workflow the
+// sole preview path, so a preview exists exactly when a human is ready to test
+// it — not on every push.
 
 const BUILD = 1; // exit code → Vercel proceeds with the build
 const SKIP = 0; // exit code → Vercel cancels the build
 
-// Matches feat/fix Conventional Commit titles, with an optional scope and an
-// optional breaking-change `!`: feat:, fix:, feat(api):, fix(ui)!:, etc.
-const DEPLOYABLE_TITLE = /^(feat|fix)(\([^)]*\))?!?:/i;
-
-export function isDeployableTitle(title) {
-  return DEPLOYABLE_TITLE.test((title ?? "").trim());
+export function shouldBuild(env) {
+  return env?.VERCEL_ENV === "production";
 }
 
-async function fetchPullRequestTitle(owner, repo, prNumber) {
-  const response = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
-    { headers: { Accept: "application/vnd.github+json" } },
-  );
-  if (!response.ok) {
-    throw new Error(`GitHub API responded ${response.status}`);
-  }
-  const { title } = await response.json();
-  return title;
-}
-
-async function main() {
-  const env = process.env.VERCEL_ENV;
-  if (env === "production") {
+function main() {
+  if (shouldBuild(process.env)) {
     console.log("✅ Production deploy — building.");
     process.exit(BUILD);
   }
-
-  const prNumber = process.env.VERCEL_GIT_PULL_REQUEST_ID;
-  if (!prNumber || prNumber === "0") {
-    console.log("⏭️  No associated pull request — skipping preview deploy.");
-    process.exit(SKIP);
-  }
-
-  const owner = process.env.VERCEL_GIT_REPO_OWNER;
-  const repo = process.env.VERCEL_GIT_REPO_SLUG;
-
-  try {
-    const title = await fetchPullRequestTitle(owner, repo, prNumber);
-    if (isDeployableTitle(title)) {
-      console.log(`✅ PR #${prNumber} "${title}" is feat/fix — building.`);
-      process.exit(BUILD);
-    }
-    console.log(
-      `⏭️  PR #${prNumber} "${title}" is not feat/fix — skipping preview deploy.`,
-    );
-    process.exit(SKIP);
-  } catch (error) {
-    // Fail open: a transient API failure should not silently drop a preview a
-    // reviewer is waiting on. Quota cost of an occasional over-build is the
-    // lesser evil versus a missing UAT preview.
-    console.warn(
-      `⚠️  Could not determine PR title (${error.message}) — building to be safe.`,
-    );
-    process.exit(BUILD);
-  }
+  console.log(
+    "⏭️  Non-production build cancelled — previews are created on demand by the `ready for UAT` label workflow (preview-deploy.yml).",
+  );
+  process.exit(SKIP);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/scripts/vercel-ignore-build.spec.ts
+++ b/src/scripts/vercel-ignore-build.spec.ts
@@ -1,109 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { isDeployableTitle } from "../../scripts/vercel-ignore-build.mjs";
+import { shouldBuild } from "../../scripts/vercel-ignore-build.mjs";
 
-describe("isDeployableTitle: feat titles", () => {
-  it("returns true for a plain feat: title", () => {
-    expect(isDeployableTitle("feat: add user profile")).toBe(true);
+describe("shouldBuild: production only", () => {
+  it("builds a production deploy", () => {
+    expect(shouldBuild({ VERCEL_ENV: "production" })).toBe(true);
   });
 
-  it("returns true for a feat: title with a scope", () => {
-    expect(isDeployableTitle("feat(api): add endpoint")).toBe(true);
+  it("cancels a preview deploy (previews come from the label workflow)", () => {
+    expect(shouldBuild({ VERCEL_ENV: "preview" })).toBe(false);
   });
 
-  it("returns true for a feat!: title with the breaking-change marker", () => {
-    expect(isDeployableTitle("feat!: remove legacy auth")).toBe(true);
+  it("cancels a development deploy", () => {
+    expect(shouldBuild({ VERCEL_ENV: "development" })).toBe(false);
   });
 
-  it("returns true for a feat(scope)!: title with scope and breaking-change marker", () => {
-    expect(isDeployableTitle("feat(api)!: remove v1 routes")).toBe(true);
-  });
-
-  it("returns true for a FEAT: title (case-insensitive)", () => {
-    expect(isDeployableTitle("FEAT: uppercase type")).toBe(true);
-  });
-});
-
-describe("isDeployableTitle: fix titles", () => {
-  it("returns true for a plain fix: title", () => {
-    expect(isDeployableTitle("fix: resolve login bug")).toBe(true);
-  });
-
-  it("returns true for a fix: title with a scope", () => {
-    expect(isDeployableTitle("fix(ui): correct button color")).toBe(true);
-  });
-
-  it("returns true for a fix!: title with the breaking-change marker", () => {
-    expect(isDeployableTitle("fix!: remove deprecated endpoint")).toBe(true);
-  });
-
-  it("returns true for a Fix: title (case-insensitive)", () => {
-    expect(isDeployableTitle("Fix: mixed-case type")).toBe(true);
-  });
-});
-
-describe("isDeployableTitle: non-deployable types", () => {
-  it("returns false for a chore: title", () => {
-    expect(isDeployableTitle("chore: update dependencies")).toBe(false);
-  });
-
-  it("returns false for a ci: title", () => {
-    expect(isDeployableTitle("ci: add lint job")).toBe(false);
-  });
-
-  it("returns false for a docs: title", () => {
-    expect(isDeployableTitle("docs: update README")).toBe(false);
-  });
-
-  it("returns false for a refactor: title", () => {
-    expect(isDeployableTitle("refactor: reorganize modules")).toBe(false);
-  });
-
-  it("returns false for a test: title", () => {
-    expect(isDeployableTitle("test: add unit tests")).toBe(false);
-  });
-
-  it("returns false for a style: title", () => {
-    expect(isDeployableTitle("style: format files")).toBe(false);
-  });
-
-  it("returns false for a perf: title", () => {
-    expect(isDeployableTitle("perf: optimize render")).toBe(false);
-  });
-
-  it("returns false for a revert: title", () => {
-    expect(isDeployableTitle("revert: undo last commit")).toBe(false);
-  });
-
-  it("returns false for a build: title", () => {
-    expect(isDeployableTitle("build: upgrade webpack")).toBe(false);
-  });
-});
-
-describe("isDeployableTitle: [WIP] prefix", () => {
-  it("returns false for a [WIP] feat: title", () => {
-    expect(isDeployableTitle("[WIP] feat: draft work")).toBe(false);
-  });
-
-  it("returns false for a [WIP] fix: title", () => {
-    expect(isDeployableTitle("[WIP] fix: draft fix")).toBe(false);
-  });
-});
-
-describe("isDeployableTitle: edge cases", () => {
-  it("returns false for an empty string", () => {
-    expect(isDeployableTitle("")).toBe(false);
-  });
-
-  it("returns false for null", () => {
-    expect(isDeployableTitle(null)).toBe(false);
-  });
-
-  it("returns false for undefined", () => {
-    expect(isDeployableTitle(undefined)).toBe(false);
-  });
-
-  it("trims leading and trailing whitespace before matching", () => {
-    expect(isDeployableTitle("  feat: padded title  ")).toBe(true);
+  it("cancels when VERCEL_ENV is absent", () => {
+    expect(shouldBuild({})).toBe(false);
   });
 });


### PR DESCRIPTION
Replaces the title-based preview gate with a **label-driven** one: a preview is built only when a PR is marked **`ready for UAT`**, not on every `feat:`/`fix:` push. A preview exists to enable UAT, so this deploys one exactly when a human is ready to test it — cutting preview-deploy quota further. Mirrors the `preview-deploy.yml` pattern already running in sibling repos (personal-budget, hidden-role-game).

**Ready to work end-to-end:** the required repo secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) are already configured on this repo, so this is live on merge — no manual setup left.

## What changed

- **`scripts/vercel-ignore-build.mjs`** — now **production-only**: it cancels every non-production build, disabling native Git-integration previews entirely (so the label workflow is the *sole* preview path). This drops the PR-title fetch and its public-repo dependency; the exported helper becomes `shouldBuild(env)`.
- **`.github/workflows/preview-deploy.yml`** (new) — on `pull_request` `labeled` / `synchronize` / `reopened`, gated to a **same-repo, non-draft** PR carrying **`ready for UAT`** and not `do not merge`, it runs `vercel pull` → `vercel build` → `vercel deploy --prebuilt` and posts the preview URL as a sticky PR comment. `concurrency` cancels superseded runs per PR.
- Updated the ignore script's spec + typing shim (`isDeployableTitle` → `shouldBuild`) and the README / ARCHITECTURE deploy notes.

## Acceptance criteria

- [x] Previews are produced only for PRs carrying `ready for UAT`, on the PR's current HEAD (`if:` guard + `head.sha` checkout).
- [x] Adding the label to an already-pushed PR triggers a preview without a new push (`labeled` event).
- [x] Removing the label does not refresh the preview (no deploy fires without the label; native previews are off).
- [x] Production deploys from `main` are unaffected (ignore step stays production-only).
- [x] `VERCEL_TOKEN` is a secret, never committed.
- [x] The title-based Ignored Build Step is reconciled — replaced by the production-only gate so the two paths don't conflict.

## Verification

Exit-code smoke: `VERCEL_ENV=production` → exit 1 (build), `preview` → exit 0 (cancel). `format` / `lint` / `tsc` / `test` all green (`shouldBuild` unit tests added).

Closes #351

---
*Created by Claude Opus 4.8*
