### PR TITLE
chore(deps): group version-locked dependency families in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,49 @@ updates:
     # bumps match no group and are raised as individual PRs, since they are the
     # most likely to need a code change and warrant isolated review.
     groups:
+      # Version-locked families — packages whose versions move together, so an
+      # update to one is broken without the rest (a `react` bump without
+      # `react-dom`, one `@storybook/*` without the others). Grouped with
+      # *unrestricted* update-types (major AND minor AND patch) so the whole
+      # family always bumps atomically in one PR. Listed first, and ordered so
+      # first-match precedence resolves the overlaps: storybook before eslint
+      # (catches `eslint-plugin-storybook`) and before vite (catches
+      # `@storybook/*-vite*`); prettier's `prettier-plugin-*` still catches
+      # `prettier-plugin-tailwindcss` (the tailwind patterns don't match it).
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+          - "eslint-plugin-storybook"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vitest"
+          - "@vitest/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/js"
+          - "typescript-eslint"
+          - "eslint-plugin-react-hooks"
+          - "eslint-plugin-simple-import-sort"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
       # Prettier (and its plugins) is special-cased: a minor bump can change
       # formatting output and force code changes, so isolate major + minor bumps
       # into their own PR for focused review. A trivial patch bump is not in this
       # group's update-types, so it falls through to dev-dependencies and stays
-      # grouped with other low-risk bumps. Listed first to win group-assignment
-      # precedence (a dependency joins the first group whose patterns match).
+      # grouped with other low-risk bumps. After the version-locked families
+      # above so those win precedence, but before the catch-alls below.
       prettier:
         patterns:
           - "prettier"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,21 +16,32 @@ updates:
     # bumps match no group and are raised as individual PRs, since they are the
     # most likely to need a code change and warrant isolated review.
     groups:
-      # Version-locked families — packages whose versions move together, so an
-      # update to one is broken without the rest (a `react` bump without
-      # `react-dom`, one `@storybook/*` without the others). Grouped with
-      # *unrestricted* update-types (major AND minor AND patch) so the whole
-      # family always bumps atomically in one PR. Listed first, and ordered so
-      # first-match precedence resolves the overlaps: storybook before eslint
-      # (catches `eslint-plugin-storybook`) and before vite (catches
+      # Version-locked families — packages whose versions move together, so a
+      # major to one is broken without the rest (a `react` major without
+      # `react-dom`, one `@storybook/*` without the others). Listed first, and
+      # ordered so first-match precedence resolves the overlaps: storybook before
+      # eslint (catches `eslint-plugin-storybook`) and before vite (catches
       # `@storybook/*-vite*`); prettier's `prettier-plugin-*` still catches
       # `prettier-plugin-tailwindcss` (the tailwind patterns don't match it).
+      #
+      # Same-scope families (all dev, or all prod) restrict to `major`: their
+      # minor/patch bumps already move in lockstep inside the dev-dependencies /
+      # production-dependencies catch-alls below, so a major is the only bump the
+      # catch-alls exclude — i.e. the only case that would fragment the family
+      # into standalone PRs. Restricting to `major` keeps majors atomic while
+      # letting minor/patch rejoin the big weekly batch (fewer PRs). Only react
+      # *crosses* dev↔prod, so it keeps all update-types (see its note).
       storybook:
         patterns:
           - "storybook"
           - "@storybook/*"
           - "eslint-plugin-storybook"
+        update-types:
+          - "major"
       react:
+        # Unrestricted (major + minor + patch): react spans prod (`react`,
+        # `react-dom`) and dev (`@types/react*`), so its minor/patch would
+        # otherwise scatter across the two catch-alls instead of staying atomic.
         patterns:
           - "react"
           - "react-dom"
@@ -42,6 +53,8 @@ updates:
           - "@vitejs/*"
           - "vitest"
           - "@vitest/*"
+        update-types:
+          - "major"
       eslint:
         patterns:
           - "eslint"
@@ -49,10 +62,14 @@ updates:
           - "typescript-eslint"
           - "eslint-plugin-react-hooks"
           - "eslint-plugin-simple-import-sort"
+        update-types:
+          - "major"
       tailwind:
         patterns:
           - "tailwindcss"
           - "@tailwindcss/*"
+        update-types:
+          - "major"
       # Prettier (and its plugins) is special-cased: a minor bump can change
       # formatting output and force code changes, so isolate major + minor bumps
       # into their own PR for focused review. A trivial patch bump is not in this

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,18 @@ updates:
         update-types:
           - "major"
           - "minor"
+      # TypeScript (the language) is a more significant change than an ordinary
+      # dependency bump — a major or minor can shift type-checking behaviour
+      # repo-wide — so isolate its major + minor into their own PR for
+      # visibility. A patch falls through to dev-dependencies with the low-risk
+      # batch. `typescript` is an exact match, so it never catches
+      # `typescript-eslint` (that stays in the eslint family).
+      typescript:
+        patterns:
+          - "typescript"
+        update-types:
+          - "major"
+          - "minor"
       dev-dependencies:
         dependency-type: development
         update-types:


### PR DESCRIPTION
Groups **version-locked dependency families** in Dependabot so a family's interdependent packages bump **atomically** rather than fragmenting into individual PRs that a human has to reconcile (a `react` major without `react-dom`, one `@storybook/*` without the rest). Mirrors [rmartz/firebase-nextjs-template#159](https://github.com/rmartz/firebase-nextjs-template/pull/159), adapted to this repo — and tuned to keep the weekly PR count low.

## Version-locked family groups

Five families, **listed first** (to win first-match precedence), spanning prod + dev:

| Group | Packages | update-types |
|---|---|---|
| **storybook** | `storybook`, `@storybook/*`, `eslint-plugin-storybook` | **major** only |
| **react** | `react`, `react-dom`, `@types/react`, `@types/react-dom` | **all** (major/minor/patch) |
| **vite** | `vite`, `@vitejs/plugin-react`, `vitest`, `@vitest/*` | **major** only |
| **eslint** | `eslint`, `@eslint/js`, `typescript-eslint`, `eslint-plugin-{react-hooks,simple-import-sort}` | **major** only |
| **tailwind** | `tailwindcss`, `@tailwindcss/postcss` | **major** only |

**Why the update-types split — keeping PR volume down**

- **Same-scope families (all dev): `major` only.** storybook / vite / eslint / tailwind live entirely in devDependencies, so their **minor/patch** bumps already move in lockstep inside the `dev-dependencies` catch-all. A **major** is the only bump the catch-all excludes — the only case that would fragment the family — so restricting these groups to `major` keeps majors atomic while letting minor/patch **rejoin the big weekly dev-deps batch** (no separate storybook/eslint/vite/tailwind PR for routine minor bumps).
- **Cross-scope family (react): all types.** `react`/`react-dom` are prod, `@types/react*` are dev, so react's minor/patch would otherwise **scatter across the two catch-alls**. It keeps unrestricted update-types to stay atomic on every bump.

## Single-package visibility splits (major + minor → own PR)

| Group | Package | Rationale |
|---|---|---|
| **prettier** | `prettier`, `prettier-plugin-*` | a minor can change formatting output and force code changes |
| **typescript** | `typescript` | the language itself — a major/minor can shift type-checking behaviour repo-wide, so make it a visible standalone PR |

Both split **major + minor** into their own PR; a **patch** falls through to `dev-dependencies` with the low-risk batch. `typescript` is an exact match, so it never catches `typescript-eslint` (which stays in the eslint family).

## Unchanged

- **Non-family majors** (`firebase`, `firebase-admin`, `next`, `@sentry/nextjs`, `husky`, `playwright`, …) still raise **individual** PRs. `firebase`/`firebase-admin` version independently, so they're intentionally *not* grouped; `tailwind-merge`/`tw-animate-css` aren't tailwind-core and stay in the catch-alls.
- Everything else batches by `dev-dependencies` / `production-dependencies`.

## Verification

Simulated Dependabot's first-match assignment for **every** dependency across major/minor/patch:
- Same-scope families route **major → family group**, **minor/patch → `dev-dependencies`**; **react** stays atomic on all three bumps.
- `typescript` → typescript group on major/minor, `dev-dependencies` on patch; `typescript-eslint` unaffected (eslint on major, batch on minor/patch).
- All major-precedence edges resolve (`eslint-plugin-storybook`→storybook, `@storybook/addon-vitest`/`nextjs-vite`→storybook, `@vitest/browser-playwright`→vite, `prettier-plugin-tailwindcss`→prettier).

YAML parses; `pre-push-verify` green. `.github/dependabot.yml`-only — no `uses:`, so no CI-gate or action-pin impact.

---
*Created by Claude Opus 4.8*
