### PR TITLE
refactor(snap-picks): use authorizeSnapPickMember in the activate route

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activate/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activate/route.spec.ts
@@ -1,17 +1,14 @@
+import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetVerifiedUid,
-  mockGetGroupById,
-  mockGetCategoryById,
-  mockGetSnapPickById,
+  mockAuthorizeSnapPickMember,
   mockGetOpenActivation,
   mockCreateSnapPickActivation,
 } = vi.hoisted(() => ({
   mockGetVerifiedUid: vi.fn(),
-  mockGetGroupById: vi.fn(),
-  mockGetCategoryById: vi.fn(),
-  mockGetSnapPickById: vi.fn(),
+  mockAuthorizeSnapPickMember: vi.fn(),
   mockGetOpenActivation: vi.fn(),
   mockCreateSnapPickActivation: vi.fn(),
 }));
@@ -20,16 +17,8 @@ vi.mock("@/server/utils/auth", () => ({
   getVerifiedUid: mockGetVerifiedUid,
 }));
 
-vi.mock("@/server/data/groups", () => ({
-  getGroupById: mockGetGroupById,
-}));
-
-vi.mock("@/server/data/categories", () => ({
-  getCategoryById: mockGetCategoryById,
-}));
-
-vi.mock("@/server/data/snap-picks", () => ({
-  getSnapPickById: mockGetSnapPickById,
+vi.mock("@/server/utils/snap-pick-auth", () => ({
+  authorizeSnapPickMember: mockAuthorizeSnapPickMember,
 }));
 
 vi.mock("@/server/data/snap-pick-activations", () => ({
@@ -59,9 +48,7 @@ function makeRequest(body: unknown) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetVerifiedUid.mockResolvedValue("user-1");
-  mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["user-1"] });
-  mockGetCategoryById.mockResolvedValue({ id: "cat-1", groupId: "group-1" });
-  mockGetSnapPickById.mockResolvedValue({ id: "snap-1", categoryId: "cat-1" });
+  mockAuthorizeSnapPickMember.mockResolvedValue(undefined);
   mockGetOpenActivation.mockResolvedValue(undefined);
   mockCreateSnapPickActivation.mockResolvedValue({ id: "act-new" });
 });
@@ -131,7 +118,9 @@ describe("PUT /api/.../snap-picks/[snapPickId]/activate", () => {
   });
 
   it("returns 403 for a non-member", async () => {
-    mockGetGroupById.mockResolvedValue({ id: "group-1", memberIds: ["other"] });
+    mockAuthorizeSnapPickMember.mockResolvedValue(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    );
 
     const response = await PUT(
       makeRequest({ duration: { kind: "preset", preset: "1-hour" } }),
@@ -139,6 +128,7 @@ describe("PUT /api/.../snap-picks/[snapPickId]/activate", () => {
     );
 
     expect(response.status).toBe(403);
+    expect(mockCreateSnapPickActivation).not.toHaveBeenCalled();
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activate/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activate/route.ts
@@ -5,14 +5,12 @@ import {
   isDurationPreset,
   type SnapPickDurationChoice,
 } from "@/lib/snap-pick-activation";
-import { getCategoryById } from "@/server/data/categories";
-import { getGroupById } from "@/server/data/groups";
 import {
   createSnapPickActivation,
   getOpenActivation,
 } from "@/server/data/snap-pick-activations";
-import { getSnapPickById } from "@/server/data/snap-picks";
 import { getVerifiedUid } from "@/server/utils/auth";
+import { authorizeSnapPickMember } from "@/server/utils/snap-pick-auth";
 
 interface RouteParams {
   params: Promise<{ id: string; categoryId: string; snapPickId: string }>;
@@ -50,24 +48,13 @@ export async function PUT(request: Request, { params }: RouteParams) {
   }
 
   const { id: groupId, categoryId, snapPickId } = await params;
-  const [group, category, snapPick] = await Promise.all([
-    getGroupById(groupId),
-    getCategoryById(categoryId),
-    getSnapPickById(categoryId, snapPickId),
-  ]);
-
-  if (!group) {
-    return NextResponse.json({ error: "Group not found" }, { status: 404 });
-  }
-  if (!group.memberIds.includes(uid)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-  if (category?.groupId !== groupId) {
-    return NextResponse.json({ error: "Category not found" }, { status: 404 });
-  }
-  if (!snapPick) {
-    return NextResponse.json({ error: "Snap pick not found" }, { status: 404 });
-  }
+  const denied = await authorizeSnapPickMember(
+    uid,
+    groupId,
+    categoryId,
+    snapPickId,
+  );
+  if (denied) return denied;
 
   let body: { duration: unknown };
   try {


### PR DESCRIPTION
## Purpose

The snap-pick **activate** route re-implemented the same 4-step authorization chain (group exists → member → category belongs to group → snap pick exists) that `authorizeSnapPickMember` already centralizes and the sibling routes use. This refactor removes that duplication so the auth logic has a single source of truth.

## Changes

- Replace the inline auth block in `activate/route.ts` with a call to `authorizeSnapPickMember`, matching the `options` and `vote` sibling routes (`const denied = await authorizeSnapPickMember(...); if (denied) return denied;`).
- Drop the now-unused `getGroupById` / `getCategoryById` / `getSnapPickById` imports.
- Update the route spec to mock `authorizeSnapPickMember` directly (as the sibling specs do) instead of the underlying data functions; the 403 case now stubs the helper's denial response.

**Reuse decision:** reuse-as-is — the existing `authorizeSnapPickMember` helper already covers the full need. Behavior is identical (same 401/403/404/409/201 outcomes).

Closes #358

---
*Created by Claude Opus 4.8*
