### PR TITLE
refactor(snap-picks)!: consolidate duplicate ActiveSnapPickActivation interface

### DIFF
--- a/src/app/groups/[id]/ActiveSnapPickList.spec.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickList.spec.tsx
@@ -2,24 +2,22 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { makeSnapPick, makeSnapPickActivation } from "@/lib/fixtures/snap-pick";
+import type { ActiveSnapPickActivation } from "@/lib/types/snap-pick";
 
-import {
-  type ActiveSnapPickActivationItem,
-  ActiveSnapPickList,
-} from "./ActiveSnapPickList";
+import { ActiveSnapPickList } from "./ActiveSnapPickList";
 
 afterEach(cleanup);
 
 describe("ActiveSnapPickList", () => {
   it("filters out activations whose closesAt has already passed", () => {
-    const expiredActivation: ActiveSnapPickActivationItem = {
+    const expiredActivation: ActiveSnapPickActivation = {
       snapPick: makeSnapPick({ id: "snap-expired", title: "Expired Pick" }),
       activation: makeSnapPickActivation({
         id: "act-expired",
         closesAt: new Date("2020-01-01T00:00:00.000Z"),
       }),
     };
-    const activeActivation: ActiveSnapPickActivationItem = {
+    const activeActivation: ActiveSnapPickActivation = {
       snapPick: makeSnapPick({ id: "snap-active", title: "Active Pick" }),
       activation: makeSnapPickActivation({
         id: "act-active",

--- a/src/app/groups/[id]/ActiveSnapPickList.tsx
+++ b/src/app/groups/[id]/ActiveSnapPickList.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 
 import type { Category } from "@/lib/types/category";
-import type { SnapPick, SnapPickActivation } from "@/lib/types/snap-pick";
+import type { ActiveSnapPickActivation } from "@/lib/types/snap-pick";
 
 import { ACTIVE_SNAP_PICK_LIST_COPY } from "./ActiveSnapPickList.copy";
 import {
@@ -11,14 +11,9 @@ import {
   ActiveSnapPickListView,
 } from "./ActiveSnapPickListView";
 
-export interface ActiveSnapPickActivationItem {
-  snapPick: SnapPick;
-  activation: SnapPickActivation;
-}
-
 interface ActiveSnapPickListProps {
   groupId: string;
-  activations: ActiveSnapPickActivationItem[];
+  activations: ActiveSnapPickActivation[];
   categories: Category[];
 }
 

--- a/src/app/groups/[id]/GroupDetailClient.tsx
+++ b/src/app/groups/[id]/GroupDetailClient.tsx
@@ -7,6 +7,7 @@ import type { Category } from "@/lib/types/category";
 import type { Group } from "@/lib/types/group";
 import { InviteMode } from "@/lib/types/invite";
 import type { GroupPick } from "@/lib/types/pick";
+import type { ActiveSnapPickActivation } from "@/lib/types/snap-pick";
 import {
   deleteGroup,
   leaveGroup,
@@ -17,7 +18,6 @@ import {
   updateGroupSettings,
 } from "@/services/groups";
 
-import type { ActiveSnapPickActivationItem } from "./ActiveSnapPickList";
 import { GROUP_DETAIL_COPY } from "./copy";
 import { GroupDetailView } from "./GroupDetailView";
 import type { MemberName } from "./MemberRow";
@@ -30,7 +30,7 @@ interface GroupDetailClientProps {
   initialInviteMode: InviteMode;
   memberNames: MemberName[];
   picksByCategory: Record<string, GroupPick[]>;
-  activeSnapPicks: ActiveSnapPickActivationItem[];
+  activeSnapPicks: ActiveSnapPickActivation[];
 }
 
 export function GroupDetailClient({

--- a/src/app/groups/[id]/GroupDetailView.tsx
+++ b/src/app/groups/[id]/GroupDetailView.tsx
@@ -10,8 +10,8 @@ import type { Category } from "@/lib/types/category";
 import type { Group } from "@/lib/types/group";
 import { InviteMode } from "@/lib/types/invite";
 import type { GroupPick } from "@/lib/types/pick";
+import type { ActiveSnapPickActivation } from "@/lib/types/snap-pick";
 
-import type { ActiveSnapPickActivationItem } from "./ActiveSnapPickList";
 import { ActiveSnapPickList } from "./ActiveSnapPickList";
 import { CategoryList } from "./categories/CategoryList";
 import { GROUP_DETAIL_COPY } from "./copy";
@@ -35,7 +35,7 @@ interface GroupDetailViewProps {
   initialInviteMode: InviteMode;
   memberNames: MemberName[];
   picksByCategory: Record<string, GroupPick[]>;
-  activeSnapPicks: ActiveSnapPickActivationItem[];
+  activeSnapPicks: ActiveSnapPickActivation[];
   onMakeAdmin?: (uid: string) => void;
   onRevokeAdmin?: (uid: string) => void;
   onTogglePicksRestricted: () => void;

--- a/src/lib/types/snap-pick.ts
+++ b/src/lib/types/snap-pick.ts
@@ -25,6 +25,13 @@ export interface SnapPickActivation {
   startedBy: string;
 }
 
+// A Snap Pick together with one of its currently-running activations. Surfaced
+// on the group activity view so members can jump straight into an open vote.
+export interface ActiveSnapPickActivation {
+  snapPick: SnapPick;
+  activation: SnapPickActivation;
+}
+
 // A resolved entry in a snap pick's history timeline: one past (closed)
 // activation with its winning option's title and how many members voted. The
 // winner title is resolved from the option pool at read time (options are

--- a/src/server/data/snap-picks.ts
+++ b/src/server/data/snap-picks.ts
@@ -9,6 +9,7 @@ import {
   snapPickToFirebase,
 } from "@/lib/firebase/schema/snap-pick";
 import type {
+  ActiveSnapPickActivation,
   SnapPick,
   SnapPickActivation,
   SnapPickOption,
@@ -69,13 +70,6 @@ export async function getSnapPickActivations(
   return Object.entries(data).map(([id, activationData]) =>
     firebaseToSnapPickActivation(id, activationData),
   );
-}
-
-// A Snap Pick together with one of its currently-running activations. Surfaced
-// on the group activity view so members can jump straight into an open vote.
-export interface ActiveSnapPickActivation {
-  snapPick: SnapPick;
-  activation: SnapPickActivation;
 }
 
 // An activation is "active" when it has not been explicitly closed and its


### PR DESCRIPTION
## Purpose

Consolidate the two structurally-identical definitions of the "a Snap Pick
plus one of its running activations" shape into a single canonical type, so a
future divergence on either side can no longer be silently accepted across the
server/client boundary.

## Changes

- Move the shared `{ snapPick, activation }` interface to `@/lib/types/snap-pick`
  as `ActiveSnapPickActivation`, alongside the existing `SnapPick` and
  `SnapPickActivation` types.
- Delete the two duplicates: the data-layer `ActiveSnapPickActivation` in
  `src/server/data/snap-picks.ts` and the `ActiveSnapPickActivationItem` alias in
  `ActiveSnapPickList.tsx`.
- Repoint every consumer (`snap-picks.ts`, `ActiveSnapPickList.tsx`,
  `GroupDetailView.tsx`, `GroupDetailClient.tsx`, and the component spec) to the
  canonical import.

**Reuse decision (reuse as-is):** no new type is introduced — the shared shape
moves into the module that already owns the snap-pick domain types, and both
sides import it.

Pure refactor: no behavior change. Format, lint, typecheck, and the full test
suite are green.

Closes #369

---
*Created by Claude Opus 4.8*
