### PR TITLE
feat(snap-picks)!: breadcrumb nav with container title on Snap Pick detail

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.spec.tsx
@@ -1,6 +1,7 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { BREADCRUMBS_COPY } from "@/components/breadcrumbs";
 import {
   makeSnapPick,
   makeSnapPickActivation,
@@ -23,6 +24,8 @@ describe("renders the Snap Pick detail shell", () => {
       <SnapPickDetailView
         snapPick={makeSnapPick({ title: "Friday Lunch" })}
         groupId="group-1"
+        groupName="Team"
+        categoryName="Meals"
         currentUserId="user-1"
         options={[]}
         votedPairKeys={[]}
@@ -40,6 +43,8 @@ describe("renders the Snap Pick detail shell", () => {
       <SnapPickDetailView
         snapPick={makeSnapPick()}
         groupId="group-1"
+        groupName="Team"
+        categoryName="Meals"
         currentUserId="user-1"
         options={[]}
         votedPairKeys={[]}
@@ -64,6 +69,8 @@ describe("renders the Snap Pick detail shell", () => {
       <SnapPickDetailView
         snapPick={makeSnapPick()}
         groupId="group-1"
+        groupName="Team"
+        categoryName="Meals"
         currentUserId="user-1"
         options={[]}
         votedPairKeys={[]}
@@ -84,6 +91,8 @@ describe("renders the Snap Pick detail shell", () => {
       <SnapPickDetailView
         snapPick={makeSnapPick()}
         groupId="group-1"
+        groupName="Team"
+        categoryName="Meals"
         currentUserId="user-1"
         options={[]}
         activation={makeSnapPickActivation({ closedAt: undefined })}
@@ -95,5 +104,63 @@ describe("renders the Snap Pick detail shell", () => {
     expect(
       screen.getByText(SNAP_PICK_DETAIL_COPY.optionPoolActivationNotice),
     ).toBeDefined();
+  });
+});
+
+describe("breadcrumb trail", () => {
+  it("renders a Group → Category → Snap Pick breadcrumb trail", () => {
+    render(
+      <SnapPickDetailView
+        snapPick={makeSnapPick({
+          id: "snap-1",
+          categoryId: "cat-1",
+          title: "Friday Lunch",
+        })}
+        groupId="group-1"
+        groupName="Team"
+        categoryName="Meals"
+        currentUserId="user-1"
+        options={[]}
+        votedPairKeys={[]}
+        historyEntries={[]}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", {
+      name: BREADCRUMBS_COPY.navLabel,
+    });
+
+    const groupCrumb = within(nav).getByRole("link", { name: "Team" });
+    expect(groupCrumb.getAttribute("href")).toBe("/groups/group-1");
+
+    const categoryCrumb = within(nav).getByRole("link", { name: "Meals" });
+    expect(categoryCrumb.getAttribute("href")).toBe(
+      "/groups/group-1/categories/cat-1",
+    );
+
+    const snapPickCrumb = within(nav).getByText("Friday Lunch");
+    expect(snapPickCrumb.getAttribute("aria-current")).toBe("page");
+    expect(snapPickCrumb.getAttribute("href")).toBeNull();
+  });
+
+  it("omits the category crumb when no category name is supplied", () => {
+    render(
+      <SnapPickDetailView
+        snapPick={makeSnapPick({ categoryId: "cat-1", title: "Friday Lunch" })}
+        groupId="group-1"
+        groupName="Team"
+        currentUserId="user-1"
+        options={[]}
+        votedPairKeys={[]}
+        historyEntries={[]}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", {
+      name: BREADCRUMBS_COPY.navLabel,
+    });
+
+    expect(within(nav).getByRole("link", { name: "Team" })).toBeDefined();
+    expect(within(nav).queryByText("Meals")).toBeNull();
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.stories.tsx
@@ -18,6 +18,8 @@ const meta = {
   args: {
     snapPick: makeSnapPick({ title: "Friday Lunch" }),
     groupId: "group-1",
+    groupName: "Lunch Crew",
+    categoryName: "Weekday Meals",
     currentUserId: "user-1",
     votedPairKeys: [],
     historyEntries: [

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumbs } from "@/components/breadcrumbs";
 import type {
   SnapPick,
   SnapPickActivation,
@@ -14,6 +15,8 @@ import { SnapPickOptionList } from "./SnapPickOptionList";
 interface SnapPickDetailViewProps {
   snapPick: SnapPick;
   groupId: string;
+  groupName: string;
+  categoryName?: string;
   currentUserId: string;
   options: SnapPickOption[];
   // The most recent activation for this snap pick, if one has ever run. Open
@@ -34,6 +37,8 @@ interface SnapPickDetailViewProps {
 export function SnapPickDetailView({
   snapPick,
   groupId,
+  groupName,
+  categoryName,
   currentUserId,
   options,
   activation,
@@ -44,9 +49,25 @@ export function SnapPickDetailView({
   const activationInProgress =
     activation !== undefined && activation.closedAt === undefined;
   const activeClosesAt = activationInProgress ? activation.closesAt : undefined;
+  const breadcrumbs = [
+    { label: groupName, href: `/groups/${groupId}` },
+    ...(categoryName
+      ? [
+          {
+            label: categoryName,
+            href: `/groups/${groupId}/categories/${snapPick.categoryId}`,
+          },
+        ]
+      : []),
+    {
+      label: snapPick.title,
+      href: `/groups/${groupId}/categories/${snapPick.categoryId}/snap-picks/${snapPick.id}`,
+    },
+  ];
   return (
     <main className="mx-auto max-w-2xl p-4">
-      <h1 className="text-2xl font-bold">{snapPick.title}</h1>
+      <Breadcrumbs crumbs={breadcrumbs} />
+      <h1 className="mt-4 text-2xl font-bold">{snapPick.title}</h1>
 
       <section className="mt-6" data-slot="option-pool">
         <h2 className="text-lg font-semibold">

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
@@ -96,6 +96,8 @@ export default async function SnapPickDetailPage({
     <SnapPickDetailView
       snapPick={snapPick}
       groupId={id}
+      groupName={group.name}
+      categoryName={category.name}
       currentUserId={uid}
       options={activeOptions}
       activation={activation}


### PR DESCRIPTION
## Purpose

Adds breadcrumb navigation to the Snap Pick detail page, giving members a **Group → Category → Snap Pick (container title)** trail so they can orient and jump back up the hierarchy — the deferred acceptance criterion 6 of #262.

Closes #366.

## Changes

- **Reuse (not new):** wires the existing reusable `Breadcrumbs` primitive (`src/components/breadcrumbs/`, from #368) into `SnapPickDetailView`, mirroring exactly how `PickDetailView` builds and renders its crumb trail. No new breadcrumb infrastructure was introduced.
- `SnapPickDetailView` gains `groupName` (required) and `categoryName` (optional) props and builds the data-driven `Crumb[]` trail; the category crumb is omitted when no category name is supplied, matching the pick-detail pattern.
- `page.tsx` supplies `group.name` and `category.name` to the view (both already fetched and guarded).
- Updated the view's spec (breadcrumb trail + category-omission cases, existing renders given the new prop) and Storybook args.

## Criteria

All derived acceptance criteria pass: the trail renders Group → Category → Snap Pick; group/category crumbs link to their routes while the container-title crumb is marked the current page; the page wires the names through. Local `pre-push-verify` (format / lint / typecheck / test) is green.

---
*Created by Claude Opus 4.8*