### PR TITLE
perf(snap-picks): add getSnapPickOptionById for O(1) delete authorization

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.spec.ts
@@ -4,12 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockGetVerifiedUid,
   mockAuthorizeSnapPickMember,
-  mockGetSnapPickOptions,
+  mockGetSnapPickOptionById,
   mockRemoveSnapPickOption,
 } = vi.hoisted(() => ({
   mockGetVerifiedUid: vi.fn(),
   mockAuthorizeSnapPickMember: vi.fn(),
-  mockGetSnapPickOptions: vi.fn(),
+  mockGetSnapPickOptionById: vi.fn(),
   mockRemoveSnapPickOption: vi.fn(),
 }));
 
@@ -22,7 +22,7 @@ vi.mock("@/server/utils/snap-pick-auth", () => ({
 }));
 
 vi.mock("@/server/data/snap-picks", () => ({
-  getSnapPickOptions: mockGetSnapPickOptions,
+  getSnapPickOptionById: mockGetSnapPickOptionById,
   removeSnapPickOption: mockRemoveSnapPickOption,
 }));
 
@@ -49,7 +49,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockGetVerifiedUid.mockResolvedValue("user-1");
   mockAuthorizeSnapPickMember.mockResolvedValue(undefined);
-  mockGetSnapPickOptions.mockResolvedValue([makeOption()]);
+  mockGetSnapPickOptionById.mockResolvedValue(makeOption());
   mockRemoveSnapPickOption.mockResolvedValue({
     removedAt: new Date("2025-01-20T00:00:00Z"),
   });
@@ -60,13 +60,17 @@ describe("DELETE /api/.../snap-picks/[snapPickId]/options/[optionId]", () => {
     const response = await DELETE(new Request("http://localhost"), { params });
 
     expect(response.status).toBe(200);
+    expect(mockGetSnapPickOptionById).toHaveBeenCalledWith(
+      "snap-1",
+      "option-1",
+    );
     expect(mockRemoveSnapPickOption).toHaveBeenCalledWith("snap-1", "option-1");
   });
 
   it("returns 403 when the caller does not own the option", async () => {
-    mockGetSnapPickOptions.mockResolvedValue([
+    mockGetSnapPickOptionById.mockResolvedValue(
       makeOption({ addedBy: "someone-else" }),
-    ]);
+    );
 
     const response = await DELETE(new Request("http://localhost"), { params });
 
@@ -75,7 +79,7 @@ describe("DELETE /api/.../snap-picks/[snapPickId]/options/[optionId]", () => {
   });
 
   it("returns 404 when the option does not exist", async () => {
-    mockGetSnapPickOptions.mockResolvedValue([]);
+    mockGetSnapPickOptionById.mockResolvedValue(undefined);
 
     const response = await DELETE(new Request("http://localhost"), { params });
 
@@ -83,9 +87,9 @@ describe("DELETE /api/.../snap-picks/[snapPickId]/options/[optionId]", () => {
   });
 
   it("returns 404 when the option is already removed", async () => {
-    mockGetSnapPickOptions.mockResolvedValue([
+    mockGetSnapPickOptionById.mockResolvedValue(
       makeOption({ removedAt: new Date("2025-01-15T00:00:00Z") }),
-    ]);
+    );
 
     const response = await DELETE(new Request("http://localhost"), { params });
 

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/options/[optionId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import {
-  getSnapPickOptions,
+  getSnapPickOptionById,
   removeSnapPickOption,
 } from "@/server/data/snap-picks";
 import { getVerifiedUid } from "@/server/utils/auth";
@@ -31,8 +31,7 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
   );
   if (denied) return denied;
 
-  const options = await getSnapPickOptions(snapPickId, true);
-  const option = options.find((o) => o.id === optionId);
+  const option = await getSnapPickOptionById(snapPickId, optionId);
 
   if (!option || option.removedAt !== undefined) {
     return NextResponse.json({ error: "Option not found" }, { status: 404 });

--- a/src/server/data/snap-pick-options.spec.ts
+++ b/src/server/data/snap-pick-options.spec.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet, mockRef, mockPush, mockSet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockRef: vi.fn(),
+  mockPush: vi.fn(),
+  mockSet: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/admin", () => ({
+  getAdminApp: () => ({}),
+}));
+
+vi.mock("firebase-admin/database", () => ({
+  getDatabase: () => ({
+    ref: mockRef,
+  }),
+}));
+
+const {
+  addSnapPickOption,
+  getSnapPickOptionById,
+  getSnapPickOptions,
+  removeSnapPickOption,
+} = await import("./snap-picks");
+
+const FIREBASE_OPTION = {
+  title: "Pizza",
+  addedBy: "user-1",
+  addedAt: 1_700_000_200_000,
+};
+
+function snapshot(value: unknown) {
+  return {
+    exists: () => value !== undefined,
+    val: () => value,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRef.mockReturnValue({ get: mockGet });
+});
+
+describe("addSnapPickOption", () => {
+  it("pushes a new option under snap-pick-options/{snapPickId} and returns the id", async () => {
+    mockRef.mockReturnValue({ push: mockPush });
+    mockPush.mockReturnValue({ key: "option-new", set: mockSet });
+    mockSet.mockResolvedValue(undefined);
+
+    const result = await addSnapPickOption("snap-1", {
+      title: "Pizza",
+      addedBy: "user-7",
+    });
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1");
+    expect(result.id).toBe("option-new");
+    expect(result.addedAt).toBeInstanceOf(Date);
+  });
+
+  it("persists the converted option to the pushed ref", async () => {
+    mockRef.mockReturnValue({ push: mockPush });
+    mockPush.mockReturnValue({ key: "option-new", set: mockSet });
+    mockSet.mockResolvedValue(undefined);
+
+    await addSnapPickOption("snap-1", { title: "Pizza", addedBy: "user-7" });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Pizza", addedBy: "user-7" }),
+    );
+  });
+});
+
+describe("removeSnapPickOption", () => {
+  it("soft-deletes by writing removedAt at the option's removedAt path", async () => {
+    mockRef.mockReturnValue({ set: mockSet });
+    mockSet.mockResolvedValue(undefined);
+
+    const result = await removeSnapPickOption("snap-1", "option-3");
+
+    expect(mockRef).toHaveBeenCalledWith(
+      "snap-pick-options/snap-1/option-3/removedAt",
+    );
+    expect(mockSet).toHaveBeenCalledWith(result.removedAt.getTime());
+  });
+});
+
+describe("getSnapPickOptions", () => {
+  it("reads snap-pick-options/{snapPickId} and converts each active entry", async () => {
+    mockGet.mockResolvedValue(snapshot({ "option-1": FIREBASE_OPTION }));
+
+    const result = await getSnapPickOptions("snap-1");
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("option-1");
+    expect(result[0]?.addedAt).toEqual(new Date(1_700_000_200_000));
+  });
+
+  it("excludes soft-removed options by default", async () => {
+    mockGet.mockResolvedValue(
+      snapshot({
+        "option-1": FIREBASE_OPTION,
+        "option-2": { ...FIREBASE_OPTION, removedAt: 1_700_000_300_000 },
+      }),
+    );
+
+    const result = await getSnapPickOptions("snap-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("option-1");
+  });
+
+  it("includes soft-removed options when includeRemoved is true", async () => {
+    mockGet.mockResolvedValue(
+      snapshot({
+        "option-1": FIREBASE_OPTION,
+        "option-2": { ...FIREBASE_OPTION, removedAt: 1_700_000_300_000 },
+      }),
+    );
+
+    const result = await getSnapPickOptions("snap-1", true);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns an empty array when the snap pick has no options", async () => {
+    mockGet.mockResolvedValue(snapshot(undefined));
+
+    expect(await getSnapPickOptions("snap-1")).toEqual([]);
+  });
+});
+
+describe("getSnapPickOptionById", () => {
+  it("reads snap-pick-options/{snapPickId}/{optionId} and converts the snapshot", async () => {
+    mockGet.mockResolvedValue(snapshot(FIREBASE_OPTION));
+
+    const result = await getSnapPickOptionById("snap-1", "option-1");
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1/option-1");
+    expect(result?.id).toBe("option-1");
+    expect(result?.title).toBe("Pizza");
+    expect(result?.addedBy).toBe("user-1");
+    expect(result?.addedAt).toEqual(new Date(1_700_000_200_000));
+  });
+
+  it("returns undefined when the option does not exist", async () => {
+    mockGet.mockResolvedValue(snapshot(undefined));
+
+    expect(await getSnapPickOptionById("snap-1", "missing")).toBeUndefined();
+  });
+});

--- a/src/server/data/snap-picks.spec.ts
+++ b/src/server/data/snap-picks.spec.ts
@@ -24,10 +24,6 @@ const {
   getSnapPickActivations,
   getSnapPickById,
   getSnapPicksByCategory,
-  addSnapPickOption,
-  removeSnapPickOption,
-  getSnapPickOptions,
-  getSnapPickOptionById,
 } = await import("./snap-picks");
 
 function snapshot(value: unknown) {
@@ -205,121 +201,6 @@ describe("createSnapPick", () => {
         defaultDurationMs: 300000,
       }),
     );
-  });
-});
-
-const FIREBASE_OPTION = {
-  title: "Pizza",
-  addedBy: "user-1",
-  addedAt: 1_700_000_200_000,
-};
-
-describe("addSnapPickOption", () => {
-  it("pushes a new option under snap-pick-options/{snapPickId} and returns the id", async () => {
-    mockRef.mockReturnValue({ push: mockPush });
-    mockPush.mockReturnValue({ key: "option-new", set: mockSet });
-    mockSet.mockResolvedValue(undefined);
-
-    const result = await addSnapPickOption("snap-1", {
-      title: "Pizza",
-      addedBy: "user-7",
-    });
-
-    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1");
-    expect(result.id).toBe("option-new");
-    expect(result.addedAt).toBeInstanceOf(Date);
-  });
-
-  it("persists the converted option to the pushed ref", async () => {
-    mockRef.mockReturnValue({ push: mockPush });
-    mockPush.mockReturnValue({ key: "option-new", set: mockSet });
-    mockSet.mockResolvedValue(undefined);
-
-    await addSnapPickOption("snap-1", { title: "Pizza", addedBy: "user-7" });
-
-    expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Pizza", addedBy: "user-7" }),
-    );
-  });
-});
-
-describe("removeSnapPickOption", () => {
-  it("soft-deletes by writing removedAt at the option's removedAt path", async () => {
-    mockRef.mockReturnValue({ set: mockSet });
-    mockSet.mockResolvedValue(undefined);
-
-    const result = await removeSnapPickOption("snap-1", "option-3");
-
-    expect(mockRef).toHaveBeenCalledWith(
-      "snap-pick-options/snap-1/option-3/removedAt",
-    );
-    expect(mockSet).toHaveBeenCalledWith(result.removedAt.getTime());
-  });
-});
-
-describe("getSnapPickOptions", () => {
-  it("reads snap-pick-options/{snapPickId} and converts each active entry", async () => {
-    mockGet.mockResolvedValue(snapshot({ "option-1": FIREBASE_OPTION }));
-
-    const result = await getSnapPickOptions("snap-1");
-
-    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1");
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("option-1");
-    expect(result[0]?.addedAt).toEqual(new Date(1_700_000_200_000));
-  });
-
-  it("excludes soft-removed options by default", async () => {
-    mockGet.mockResolvedValue(
-      snapshot({
-        "option-1": FIREBASE_OPTION,
-        "option-2": { ...FIREBASE_OPTION, removedAt: 1_700_000_300_000 },
-      }),
-    );
-
-    const result = await getSnapPickOptions("snap-1");
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("option-1");
-  });
-
-  it("includes soft-removed options when includeRemoved is true", async () => {
-    mockGet.mockResolvedValue(
-      snapshot({
-        "option-1": FIREBASE_OPTION,
-        "option-2": { ...FIREBASE_OPTION, removedAt: 1_700_000_300_000 },
-      }),
-    );
-
-    const result = await getSnapPickOptions("snap-1", true);
-
-    expect(result).toHaveLength(2);
-  });
-
-  it("returns an empty array when the snap pick has no options", async () => {
-    mockGet.mockResolvedValue(snapshot(undefined));
-
-    expect(await getSnapPickOptions("snap-1")).toEqual([]);
-  });
-});
-
-describe("getSnapPickOptionById", () => {
-  it("reads snap-pick-options/{snapPickId}/{optionId} and converts the snapshot", async () => {
-    mockGet.mockResolvedValue(snapshot(FIREBASE_OPTION));
-
-    const result = await getSnapPickOptionById("snap-1", "option-1");
-
-    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1/option-1");
-    expect(result?.id).toBe("option-1");
-    expect(result?.title).toBe("Pizza");
-    expect(result?.addedBy).toBe("user-1");
-    expect(result?.addedAt).toEqual(new Date(1_700_000_200_000));
-  });
-
-  it("returns undefined when the option does not exist", async () => {
-    mockGet.mockResolvedValue(snapshot(undefined));
-
-    expect(await getSnapPickOptionById("snap-1", "missing")).toBeUndefined();
   });
 });
 

--- a/src/server/data/snap-picks.spec.ts
+++ b/src/server/data/snap-picks.spec.ts
@@ -27,6 +27,7 @@ const {
   addSnapPickOption,
   removeSnapPickOption,
   getSnapPickOptions,
+  getSnapPickOptionById,
 } = await import("./snap-picks");
 
 function snapshot(value: unknown) {
@@ -299,6 +300,26 @@ describe("getSnapPickOptions", () => {
     mockGet.mockResolvedValue(snapshot(undefined));
 
     expect(await getSnapPickOptions("snap-1")).toEqual([]);
+  });
+});
+
+describe("getSnapPickOptionById", () => {
+  it("reads snap-pick-options/{snapPickId}/{optionId} and converts the snapshot", async () => {
+    mockGet.mockResolvedValue(snapshot(FIREBASE_OPTION));
+
+    const result = await getSnapPickOptionById("snap-1", "option-1");
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-options/snap-1/option-1");
+    expect(result?.id).toBe("option-1");
+    expect(result?.title).toBe("Pizza");
+    expect(result?.addedBy).toBe("user-1");
+    expect(result?.addedAt).toEqual(new Date(1_700_000_200_000));
+  });
+
+  it("returns undefined when the option does not exist", async () => {
+    mockGet.mockResolvedValue(snapshot(undefined));
+
+    expect(await getSnapPickOptionById("snap-1", "missing")).toBeUndefined();
   });
 });
 

--- a/src/server/data/snap-picks.ts
+++ b/src/server/data/snap-picks.ts
@@ -170,3 +170,17 @@ export async function getSnapPickOptions(
     ? options
     : options.filter((option) => option.removedAt === undefined);
 }
+
+export async function getSnapPickOptionById(
+  snapPickId: string,
+  optionId: string,
+): Promise<SnapPickOption | undefined> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db
+    .ref(`snap-pick-options/${snapPickId}/${optionId}`)
+    .get();
+
+  if (!snap.exists()) return undefined;
+
+  return firebaseToSnapPickOption(optionId, snap.val());
+}


### PR DESCRIPTION
## Purpose

The snap-pick option DELETE handler authorized deletes by fetching the entire option pool (`getSnapPickOptions(snapPickId, true)`) and scanning it with `.find()` to locate one option and check ownership — O(N) in the pool size. This adds a direct single-node read so authorization is O(1) regardless of pool size.

## Changes

- Add `getSnapPickOptionById(snapPickId, optionId)` in `src/server/data/snap-picks.ts` — a single RTDB read of `snap-pick-options/{snapPickId}/{optionId}`, mirroring the existing `getSnapPickById` converter/read convention (returns `undefined` when the node is absent).
- Use it in the option DELETE route's ownership check in place of the full-pool scan; the not-found, already-removed, and forbidden guards are unchanged.
- Add unit tests for the new data function and update the delete route spec to mock the single-read function.

## Reuse decision

Genuinely new — no existing data function performed a single-option read; the parallel reads (`getSnapPickById`) were the exemplar the new function mirrors.

Closes #360

---
*Created by Claude Opus 4.8*
