### PR TITLE
fix(snap-picks)!: clarify winner display when activation closes with no votes

### DIFF
--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanel.copy.ts
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanel.copy.ts
@@ -12,6 +12,6 @@ export const SNAP_PICK_ACTIVATION_COPY = {
   inProgressHeading: "Voting is open",
   closesAtPrefix: "Closes",
   winnerHeading: "Winner",
-  noWinnerMessage: "No winner was recorded for the last run.",
+  noVotesMessage: "No votes cast — no winner this round.",
   errorDefault: "Something went wrong. Please try again.",
 } as const;

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanelView.spec.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanelView.spec.tsx
@@ -100,11 +100,19 @@ describe("Winner display after close", () => {
     expect(screen.getByText("Tacos")).toBeDefined();
   });
 
-  it("shows a no-winner message when a closed run recorded none", () => {
+  it("shows an explicit no-votes message when a closed run had no winner", () => {
     renderView({ hasClosedRun: true, lastWinnerTitle: undefined });
 
     expect(
-      screen.getByText(SNAP_PICK_ACTIVATION_COPY.noWinnerMessage),
+      screen.getByText(SNAP_PICK_ACTIVATION_COPY.noVotesMessage),
     ).toBeDefined();
+  });
+
+  it("omits the winner heading when a closed run had no votes", () => {
+    renderView({ hasClosedRun: true, lastWinnerTitle: undefined });
+
+    expect(
+      screen.queryByText(SNAP_PICK_ACTIVATION_COPY.winnerHeading),
+    ).toBeNull();
   });
 });

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanelView.stories.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanelView.stories.tsx
@@ -45,7 +45,7 @@ export const ClosedWithWinner: Story = {
   },
 };
 
-export const ClosedNoWinner: Story = {
+export const ClosedNoVotes: Story = {
   args: {
     hasClosedRun: true,
     lastWinnerTitle: undefined,

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanelView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickActivationPanelView.tsx
@@ -59,16 +59,21 @@ export function SnapPickActivationPanelView({
         </div>
       ) : (
         <div className="space-y-3">
-          {hasClosedRun && (
-            <div className="rounded-md border border-primary/40 bg-primary/5 p-3">
-              <p className="text-sm font-semibold">
-                {SNAP_PICK_ACTIVATION_COPY.winnerHeading}
-              </p>
-              <p className="text-lg font-bold">
-                {lastWinnerTitle ?? SNAP_PICK_ACTIVATION_COPY.noWinnerMessage}
-              </p>
-            </div>
-          )}
+          {hasClosedRun &&
+            (lastWinnerTitle !== undefined ? (
+              <div className="rounded-md border border-primary/40 bg-primary/5 p-3">
+                <p className="text-sm font-semibold">
+                  {SNAP_PICK_ACTIVATION_COPY.winnerHeading}
+                </p>
+                <p className="text-lg font-bold">{lastWinnerTitle}</p>
+              </div>
+            ) : (
+              <div className="rounded-md border p-3">
+                <p className="text-sm text-muted-foreground">
+                  {SNAP_PICK_ACTIVATION_COPY.noVotesMessage}
+                </p>
+              </div>
+            ))}
 
           <div className="space-y-2">
             <Label htmlFor="snap-pick-duration">

--- a/src/lib/snap-pick-activation.spec.ts
+++ b/src/lib/snap-pick-activation.spec.ts
@@ -115,8 +115,8 @@ describe("computeSnapPickWinner", () => {
     );
   });
 
-  it("returns the first option when there are no votes", () => {
-    expect(computeSnapPickWinner([], ["opt-x", "opt-y"])).toBe("opt-x");
+  it("returns undefined when there are no votes even if options exist", () => {
+    expect(computeSnapPickWinner([], ["opt-x", "opt-y"])).toBeUndefined();
   });
 
   it("returns undefined when there are no votes and no options", () => {

--- a/src/lib/snap-pick-activation.ts
+++ b/src/lib/snap-pick-activation.ts
@@ -67,12 +67,16 @@ export function isPastDeadline(closesAt: Date, now: Date): boolean {
 
 // Tallies head-to-head wins per option and returns the option id with the most
 // wins. `optionIds` establishes a stable order used to break ties (earliest
-// option wins) and to keep the result deterministic. Returns undefined when
-// there are no votes and no options to fall back on.
+// option wins) and to keep the result deterministic. Returns undefined when no
+// votes were cast: a run that closed without a single vote has no winner, and
+// returning the first option by tie-break order would misrepresent that unvoted
+// run as a decided one.
 export function computeSnapPickWinner(
   votes: SnapPickVote[],
   optionIds: string[],
 ): string | undefined {
+  if (votes.length === 0) return undefined;
+
   // Preserve option order for deterministic tie-breaking: options not present in
   // `optionIds` (e.g. removed after voting) are appended in first-seen vote order.
   const orderedIds = [...optionIds];


### PR DESCRIPTION
## Purpose

When a Snap Pick activation closed with zero votes cast, `computeSnapPickWinner` returned the first option in the pool (by tie-break order), which was then persisted and shown under the "Winner" heading — misleading users into thinking that option had actually won a vote. This makes the no-votes case explicit.

## Changes

- **Root fix**: `computeSnapPickWinner` now returns `undefined` when no votes were cast, so an unvoted run never persists an arbitrary winner (`winnerId` stays absent).
- **View + copy**: `SnapPickActivationPanelView` renders a distinct "No votes cast — no winner this round." state (new `noVotesMessage` copy string, replacing the ambiguous `noWinnerMessage`) instead of a blank/arbitrary winner display, and omits the "Winner" heading in that state.
- Updated the view spec, `computeSnapPickWinner` spec, and the `ClosedNoVotes` story to cover the no-votes state.

**Reuse decision**: extended existing code — the fix lives in the existing `computeSnapPickWinner` (the logic boundary that produces the persisted `winnerId`) plus the existing view/copy, with no new modules.

All derived acceptance criteria pass; `pre-push-verify` (format/lint/typecheck/test) is green.

Closes #359

---
*Created by Claude Opus 4.8*
