### PR TITLE
perf(snap-picks)!: replace full-activation vote scan with per-member query

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.spec.ts
@@ -4,13 +4,13 @@ const {
   mockGetVerifiedUid,
   mockAuthorizeSnapPickMember,
   mockGetOpenActivation,
-  mockGetSnapPickVotes,
+  mockGetSnapPickVotesByMember,
   mockRecordSnapPickVote,
 } = vi.hoisted(() => ({
   mockGetVerifiedUid: vi.fn(),
   mockAuthorizeSnapPickMember: vi.fn(),
   mockGetOpenActivation: vi.fn(),
-  mockGetSnapPickVotes: vi.fn(),
+  mockGetSnapPickVotesByMember: vi.fn(),
   mockRecordSnapPickVote: vi.fn(),
 }));
 
@@ -24,7 +24,7 @@ vi.mock("@/server/utils/snap-pick-auth", () => ({
 
 vi.mock("@/server/data/snap-pick-activations", () => ({
   getOpenActivation: mockGetOpenActivation,
-  getSnapPickVotes: mockGetSnapPickVotes,
+  getSnapPickVotesByMember: mockGetSnapPickVotesByMember,
   recordSnapPickVote: mockRecordSnapPickVote,
 }));
 
@@ -53,7 +53,7 @@ beforeEach(() => {
   mockGetVerifiedUid.mockResolvedValue("user-1");
   mockAuthorizeSnapPickMember.mockResolvedValue(undefined);
   mockGetOpenActivation.mockResolvedValue({ id: "act-1" });
-  mockGetSnapPickVotes.mockResolvedValue([]);
+  mockGetSnapPickVotesByMember.mockResolvedValue([]);
   mockRecordSnapPickVote.mockResolvedValue({
     id: "vote-new",
     votedAt: new Date("2025-03-21T11:00:00.000Z"),
@@ -112,8 +112,8 @@ describe("POST /api/.../activations/[activationId]/vote", () => {
   });
 
   it("returns 409 when the member has already voted on the matchup", async () => {
-    mockGetSnapPickVotes.mockResolvedValue([
-      { votedBy: "user-1", pairKey: "opt-a_opt-b" },
+    mockGetSnapPickVotesByMember.mockResolvedValue([
+      { pairKey: "opt-a_opt-b" },
     ]);
 
     const response = await POST(
@@ -125,10 +125,8 @@ describe("POST /api/.../activations/[activationId]/vote", () => {
     expect(mockRecordSnapPickVote).not.toHaveBeenCalled();
   });
 
-  it("allows a different member to vote on a pair another member decided", async () => {
-    mockGetSnapPickVotes.mockResolvedValue([
-      { votedBy: "user-2", pairKey: "opt-a_opt-b" },
-    ]);
+  it("scopes the duplicate-vote check to the current member's votes only", async () => {
+    mockGetSnapPickVotesByMember.mockResolvedValue([]);
 
     const response = await POST(
       makeRequest({ winnerId: "opt-a", loserId: "opt-b" }),
@@ -136,6 +134,10 @@ describe("POST /api/.../activations/[activationId]/vote", () => {
     );
 
     expect(response.status).toBe(201);
+    expect(mockGetSnapPickVotesByMember).toHaveBeenCalledWith(
+      "act-1",
+      "user-1",
+    );
   });
 
   it("returns 403 when authorization is denied", async () => {

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { pairKey } from "@/lib/snap-pick-pairing";
 import {
   getOpenActivation,
-  getSnapPickVotes,
+  getSnapPickVotesByMember,
   recordSnapPickVote,
 } from "@/server/data/snap-pick-activations";
 import { getVerifiedUid } from "@/server/utils/auth";
@@ -73,10 +73,8 @@ export async function POST(request: Request, { params }: RouteParams) {
   // Reject a second vote on the same matchup from the same member: the pair is
   // already decided for them, so accepting another would double-count it.
   const key = pairKey(parsed.winnerId, parsed.loserId);
-  const votes = await getSnapPickVotes(activationId);
-  const alreadyVoted = votes.some(
-    (vote) => vote.votedBy === uid && vote.pairKey === key,
-  );
+  const memberVotes = await getSnapPickVotesByMember(activationId, uid);
+  const alreadyVoted = memberVotes.some((vote) => vote.pairKey === key);
   if (alreadyVoted) {
     return NextResponse.json(
       { error: "You have already voted on this matchup" },

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
@@ -5,6 +5,7 @@ import { getCategoryById } from "@/server/data/categories";
 import { getGroupById } from "@/server/data/groups";
 import {
   getSnapPickVotes,
+  getSnapPickVotesByMember,
   resolveActiveActivation,
 } from "@/server/data/snap-pick-activations";
 import {
@@ -57,12 +58,10 @@ export default async function SnapPickDetailPage({
   // screen resumes from their own remaining matchup queue rather than restarting.
   const activationInProgress =
     activation !== undefined && activation.closedAt === undefined;
-  const votes = activationInProgress
-    ? await getSnapPickVotes(activation.id)
+  const memberVotes = activationInProgress
+    ? await getSnapPickVotesByMember(activation.id, uid)
     : [];
-  const votedPairKeys = votes
-    .filter((vote) => vote.votedBy === uid)
-    .map((vote) => vote.pairKey);
+  const votedPairKeys = memberVotes.map((vote) => vote.pairKey);
 
   // resolveActiveActivation may have just lazily closed the previously-open run
   // on this read; getClosedActivations ran concurrently and would miss it, so

--- a/src/server/data/snap-pick-activations.spec.ts
+++ b/src/server/data/snap-pick-activations.spec.ts
@@ -1,11 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockRef, mockGet, mockPush, mockSet, mockUpdate } = vi.hoisted(() => ({
+const {
+  mockRef,
+  mockGet,
+  mockPush,
+  mockSet,
+  mockUpdate,
+  mockOrderByChild,
+  mockEqualTo,
+} = vi.hoisted(() => ({
   mockRef: vi.fn(),
   mockGet: vi.fn(),
   mockPush: vi.fn(),
   mockSet: vi.fn(),
   mockUpdate: vi.fn(),
+  mockOrderByChild: vi.fn(),
+  mockEqualTo: vi.fn(),
 }));
 
 const { mockGetSnapPickActivations, mockGetSnapPickOptions } = vi.hoisted(
@@ -33,6 +43,7 @@ const {
   closeSnapPickActivation,
   recordSnapPickVote,
   getSnapPickVotes,
+  getSnapPickVotesByMember,
   getOpenActivation,
   resolveActiveActivation,
 } = await import("./snap-pick-activations");
@@ -162,6 +173,42 @@ describe("getSnapPickVotes", () => {
     mockGet.mockResolvedValue(snapshot(undefined));
 
     expect(await getSnapPickVotes("act-1")).toEqual([]);
+  });
+});
+
+describe("getSnapPickVotesByMember", () => {
+  beforeEach(() => {
+    mockRef.mockReturnValue({ orderByChild: mockOrderByChild });
+    mockOrderByChild.mockReturnValue({ equalTo: mockEqualTo });
+    mockEqualTo.mockReturnValue({ get: mockGet });
+  });
+
+  it("queries only the given member's votes at the votedBy index", async () => {
+    mockGet.mockResolvedValue(
+      snapshot({
+        "vote-1": {
+          winnerId: "opt-a",
+          loserId: "opt-b",
+          votedBy: "user-1",
+          votedAt: 1_700_000_000_000,
+          pairKey: "opt-a_opt-b",
+        },
+      }),
+    );
+
+    const result = await getSnapPickVotesByMember("act-1", "user-1");
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-votes/act-1");
+    expect(mockOrderByChild).toHaveBeenCalledWith("votedBy");
+    expect(mockEqualTo).toHaveBeenCalledWith("user-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.pairKey).toBe("opt-a_opt-b");
+  });
+
+  it("returns an empty array when the member has cast no votes", async () => {
+    mockGet.mockResolvedValue(snapshot(undefined));
+
+    expect(await getSnapPickVotesByMember("act-1", "user-1")).toEqual([]);
   });
 });
 

--- a/src/server/data/snap-pick-activations.ts
+++ b/src/server/data/snap-pick-activations.ts
@@ -1,4 +1,4 @@
-import { getDatabase } from "firebase-admin/database";
+import { type DataSnapshot, getDatabase } from "firebase-admin/database";
 
 import { getAdminApp } from "@/lib/firebase/admin";
 import {
@@ -59,18 +59,43 @@ export async function recordSnapPickVote(
   return { id, votedAt, pairKey: key };
 }
 
-export async function getSnapPickVotes(
-  activationId: string,
-): Promise<SnapPickVote[]> {
-  const db = getDatabase(getAdminApp());
-  const snap = await db.ref(`snap-pick-votes/${activationId}`).get();
-
+function snapshotToVotes(snap: DataSnapshot): SnapPickVote[] {
   if (!snap.exists()) return [];
 
   const data = snap.val() as Record<string, unknown>;
   return Object.entries(data).map(([id, voteData]) =>
     firebaseToSnapPickVote(id, voteData),
   );
+}
+
+// Reads every vote cast in an activation. Used where the full set is needed —
+// winner computation and per-activation participant counts — since those must
+// aggregate across all members.
+export async function getSnapPickVotes(
+  activationId: string,
+): Promise<SnapPickVote[]> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db.ref(`snap-pick-votes/${activationId}`).get();
+
+  return snapshotToVotes(snap);
+}
+
+// Reads only the votes a single member cast in an activation, filtering at the
+// Firestore query layer so only their votes cross the network. Used for the
+// member's own resume queue and the duplicate-vote guard, which never need any
+// other member's votes.
+export async function getSnapPickVotesByMember(
+  activationId: string,
+  votedBy: string,
+): Promise<SnapPickVote[]> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db
+    .ref(`snap-pick-votes/${activationId}`)
+    .orderByChild("votedBy")
+    .equalTo(votedBy)
+    .get();
+
+  return snapshotToVotes(snap);
 }
 
 // Returns the single open (not-yet-closed) activation for a snap pick, if any.

--- a/src/server/data/snap-pick-activations.ts
+++ b/src/server/data/snap-pick-activations.ts
@@ -81,7 +81,7 @@ export async function getSnapPickVotes(
 }
 
 // Reads only the votes a single member cast in an activation, filtering at the
-// Firestore query layer so only their votes cross the network. Used for the
+// Realtime Database query layer so only their votes cross the network. Used for the
 // member's own resume queue and the duplicate-vote guard, which never need any
 // other member's votes.
 export async function getSnapPickVotesByMember(


### PR DESCRIPTION
## Purpose

During a Snap Pick activation, the vote API duplicate-check and the detail page's resume queue each fetched **all** votes for the activation over the network and filtered for one member in memory — O(total_votes) reads per request. This replaces those lookups with a scoped per-member query.

## Changes

- Add `getSnapPickVotesByMember(activationId, votedBy)` to `snap-pick-activations.ts`, filtering at the RTDB query layer (`orderByChild("votedBy").equalTo(votedBy)`) so only the requesting member's votes cross the network.
- Wire the vote route's duplicate-vote guard and the detail page's `votedPairKeys` resume queue to the scoped read.
- **Preserve the full-read path** where aggregation across all members is required: `getSnapPickVotes` still backs `computeSnapPickWinner` (winner computation) and the history participant counts.
- Extract a shared `snapshotToVotes` converter reused by both reads (reuse decision: **extend** the existing data layer, no parallel module).
- Extend the data-layer and route tests to cover the scoped query and its member-scoped semantics.

## Technical considerations

The scoped query targets the existing `snap-pick-votes/{activationId}/…` shape; no schema change. The vote schema converters are untouched. This is the follow-up optimization the issue flagged for growing activation vote counts. Issue #367 (batch history vote reads) will stack on this branch, so the changes are kept cohesive in the vote data layer.

Closes #363

---
*Created by Claude Opus 4.8*
