### PR TITLE
feat(snap-picks)!: preference engine (v1) — global relevance rating to focus matchups

### DIFF
--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.spec.ts
@@ -98,6 +98,18 @@ describe("POST /api/.../activations/[activationId]/vote", () => {
     );
   });
 
+  it("returns 201 even when the preference model update throws", async () => {
+    mockUpdateSnapPickPreference.mockRejectedValue(new Error("Firebase error"));
+
+    const response = await POST(
+      makeRequest({ winnerId: "opt-a", loserId: "opt-b" }),
+      { params },
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockRecordSnapPickVote).toHaveBeenCalled();
+  });
+
   it("does not touch the preference model when the vote is rejected", async () => {
     mockGetOpenActivation.mockResolvedValue(undefined);
 

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.spec.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.spec.ts
@@ -6,12 +6,14 @@ const {
   mockGetOpenActivation,
   mockGetSnapPickVotesByMember,
   mockRecordSnapPickVote,
+  mockUpdateSnapPickPreference,
 } = vi.hoisted(() => ({
   mockGetVerifiedUid: vi.fn(),
   mockAuthorizeSnapPickMember: vi.fn(),
   mockGetOpenActivation: vi.fn(),
   mockGetSnapPickVotesByMember: vi.fn(),
   mockRecordSnapPickVote: vi.fn(),
+  mockUpdateSnapPickPreference: vi.fn(),
 }));
 
 vi.mock("@/server/utils/auth", () => ({
@@ -26,6 +28,10 @@ vi.mock("@/server/data/snap-pick-activations", () => ({
   getOpenActivation: mockGetOpenActivation,
   getSnapPickVotesByMember: mockGetSnapPickVotesByMember,
   recordSnapPickVote: mockRecordSnapPickVote,
+}));
+
+vi.mock("@/server/data/snap-pick-preferences", () => ({
+  updateSnapPickPreference: mockUpdateSnapPickPreference,
 }));
 
 const { POST } = await import("./route");
@@ -59,6 +65,7 @@ beforeEach(() => {
     votedAt: new Date("2025-03-21T11:00:00.000Z"),
     pairKey: "opt-a_opt-b",
   });
+  mockUpdateSnapPickPreference.mockResolvedValue(undefined);
 });
 
 describe("POST /api/.../activations/[activationId]/vote", () => {
@@ -76,6 +83,29 @@ describe("POST /api/.../activations/[activationId]/vote", () => {
       loserId: "opt-b",
       votedBy: "user-1",
     });
+  });
+
+  it("folds the cast vote into the member's global preference model", async () => {
+    await POST(makeRequest({ winnerId: "opt-a", loserId: "opt-b" }), {
+      params,
+    });
+
+    expect(mockUpdateSnapPickPreference).toHaveBeenCalledWith(
+      "snap-1",
+      "user-1",
+      "opt-a",
+      "opt-b",
+    );
+  });
+
+  it("does not touch the preference model when the vote is rejected", async () => {
+    mockGetOpenActivation.mockResolvedValue(undefined);
+
+    await POST(makeRequest({ winnerId: "opt-a", loserId: "opt-b" }), {
+      params,
+    });
+
+    expect(mockUpdateSnapPickPreference).not.toHaveBeenCalled();
   });
 
   it("returns 400 when winnerId and loserId are the same option", async () => {

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.ts
@@ -6,6 +6,7 @@ import {
   getSnapPickVotesByMember,
   recordSnapPickVote,
 } from "@/server/data/snap-pick-activations";
+import { updateSnapPickPreference } from "@/server/data/snap-pick-preferences";
 import { getVerifiedUid } from "@/server/utils/auth";
 import { authorizeSnapPickMember } from "@/server/utils/snap-pick-auth";
 
@@ -87,6 +88,15 @@ export async function POST(request: Request, { params }: RouteParams) {
     loserId: parsed.loserId,
     votedBy: uid,
   });
+
+  // Fold the cast vote into the member's global preference model (O(1) Elo
+  // update) so future activations focus matchups on the options they care about.
+  await updateSnapPickPreference(
+    snapPickId,
+    uid,
+    parsed.winnerId,
+    parsed.loserId,
+  );
 
   return NextResponse.json(
     { voteId: id, votedAt: votedAt.toISOString(), pairKey: key },

--- a/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.ts
+++ b/src/app/api/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/activations/[activationId]/vote/route.ts
@@ -91,12 +91,18 @@ export async function POST(request: Request, { params }: RouteParams) {
 
   // Fold the cast vote into the member's global preference model (O(1) Elo
   // update) so future activations focus matchups on the options they care about.
-  await updateSnapPickPreference(
-    snapPickId,
-    uid,
-    parsed.winnerId,
-    parsed.loserId,
-  );
+  // Errors are swallowed — the preference model is a soft derived signal and a
+  // transient failure must not return 500 after the vote is already committed.
+  try {
+    await updateSnapPickPreference(
+      snapPickId,
+      uid,
+      parsed.winnerId,
+      parsed.loserId,
+    );
+  } catch {
+    // non-critical
+  }
 
   return NextResponse.json(
     { voteId: id, votedAt: votedAt.toISOString(), pairKey: key },

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickDetailView.tsx
@@ -3,6 +3,7 @@ import type {
   SnapPickActivation,
   SnapPickHistoryEntry,
   SnapPickOption,
+  SnapPickRatings,
 } from "@/lib/types/snap-pick";
 
 import { SnapPickActivationPanel } from "./SnapPickActivationPanel";
@@ -24,6 +25,10 @@ interface SnapPickDetailViewProps {
   // Pair keys the current member has already voted on in the open activation, so
   // the voting screen resumes from their remaining matchup queue.
   votedPairKeys: string[];
+  // The current member's global preference model for this snap pick, used to
+  // focus the matchup queue on relevant options. Absent for a member with no
+  // vote history (every option is then treated as neutral / cold-start).
+  ratings?: SnapPickRatings;
   // Past (closed) runs with their winners and participant counts, newest first.
   historyEntries: SnapPickHistoryEntry[];
 }
@@ -39,6 +44,7 @@ export function SnapPickDetailView({
   activation,
   winnerTitle,
   votedPairKeys,
+  ratings,
   historyEntries,
 }: SnapPickDetailViewProps) {
   const activationInProgress =
@@ -93,6 +99,7 @@ export function SnapPickDetailView({
             activationId={activation.id}
             options={options}
             votedPairKeys={votedPairKeys}
+            ratings={ratings}
           />
         ) : (
           <p className="text-sm text-muted-foreground">

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickMatchup.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/SnapPickMatchup.tsx
@@ -2,8 +2,8 @@
 
 import { useMemo, useState } from "react";
 
-import { remainingMatchups } from "@/lib/snap-pick-pairing";
-import type { SnapPickOption } from "@/lib/types/snap-pick";
+import { relevantMatchups } from "@/lib/snap-pick-pairing";
+import type { SnapPickOption, SnapPickRatings } from "@/lib/types/snap-pick";
 import { recordSnapPickVote } from "@/services/snap-picks";
 
 import { SNAP_PICK_MATCHUP_COPY } from "./SnapPickMatchup.copy";
@@ -19,6 +19,10 @@ interface SnapPickMatchupProps {
   // Pair keys the current member has already voted on in this activation, so a
   // member who joins mid-run resumes from their own remaining queue.
   votedPairKeys: string[];
+  // The member's global preference model, used to prune clearly-low-relevance
+  // options from the queue. Absent (or empty) means no history — every option is
+  // neutral and the queue is the full round-robin.
+  ratings?: SnapPickRatings;
 }
 
 export function SnapPickMatchup({
@@ -28,6 +32,7 @@ export function SnapPickMatchup({
   activationId,
   options,
   votedPairKeys,
+  ratings,
 }: SnapPickMatchupProps) {
   const byId = useMemo(
     () => new Map(options.map((option) => [option.id, option])),
@@ -37,11 +42,12 @@ export function SnapPickMatchup({
   // pairs. total is the member's full share (already-voted plus remaining).
   const queue = useMemo(
     () =>
-      remainingMatchups(
+      relevantMatchups(
         options.map((option) => option.id),
+        ratings ?? {},
         votedPairKeys,
       ),
-    [options, votedPairKeys],
+    [options, ratings, votedPairKeys],
   );
   const total = queue.length + votedPairKeys.length;
 

--- a/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
+++ b/src/app/groups/[id]/categories/[categoryId]/snap-picks/[snapPickId]/page.tsx
@@ -8,6 +8,7 @@ import {
   getSnapPickVotesByMember,
   resolveActiveActivation,
 } from "@/server/data/snap-pick-activations";
+import { getSnapPickPreferences } from "@/server/data/snap-pick-preferences";
 import {
   getClosedActivations,
   getSnapPickById,
@@ -54,13 +55,16 @@ export default async function SnapPickDetailPage({
     (option) => option.removedAt === undefined,
   );
 
-  // While a run is open, load the current member's cast pairs so the voting
-  // screen resumes from their own remaining matchup queue rather than restarting.
   const activationInProgress =
     activation !== undefined && activation.closedAt === undefined;
-  const memberVotes = activationInProgress
-    ? await getSnapPickVotesByMember(activation.id, uid)
-    : [];
+  // While a run is open, load the member's cast pairs (to resume their queue) and
+  // their global preference model (to focus the matchup pool on relevant options).
+  const [memberVotes, ratings] = activationInProgress
+    ? await Promise.all([
+        getSnapPickVotesByMember(activation.id, uid),
+        getSnapPickPreferences(snapPickId, uid),
+      ])
+    : [[], {}];
   const votedPairKeys = memberVotes.map((vote) => vote.pairKey);
 
   // resolveActiveActivation may have just lazily closed the previously-open run
@@ -100,6 +104,7 @@ export default async function SnapPickDetailPage({
       activation={activation}
       winnerTitle={winnerTitle}
       votedPairKeys={votedPairKeys}
+      ratings={ratings}
       historyEntries={historyEntries}
     />
   );

--- a/src/lib/firebase/schema/snap-pick-preference.spec.ts
+++ b/src/lib/firebase/schema/snap-pick-preference.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  firebaseToSnapPickPreferences,
+  firebaseToSnapPickRating,
+  snapPickRatingToFirebase,
+} from "./snap-pick-preference";
+
+describe("snapPickRatingToFirebase", () => {
+  it("serializes a rating to its persisted shape", () => {
+    expect(snapPickRatingToFirebase({ rating: 1016, games: 3 })).toEqual({
+      rating: 1016,
+      games: 3,
+    });
+  });
+});
+
+describe("firebaseToSnapPickRating", () => {
+  it("parses a single persisted rating node", () => {
+    expect(firebaseToSnapPickRating({ rating: 984, games: 5 })).toEqual({
+      rating: 984,
+      games: 5,
+    });
+  });
+
+  it("throws on a malformed node missing games", () => {
+    expect(() => firebaseToSnapPickRating({ rating: 984 })).toThrow();
+  });
+});
+
+describe("firebaseToSnapPickPreferences", () => {
+  it("parses a user's whole rating vector keyed by option", () => {
+    const parsed = firebaseToSnapPickPreferences({
+      "opt-a": { rating: 1200, games: 4 },
+      "opt-b": { rating: 900, games: 4 },
+    });
+
+    expect(parsed).toEqual({
+      "opt-a": { rating: 1200, games: 4 },
+      "opt-b": { rating: 900, games: 4 },
+    });
+  });
+
+  it("throws when an option's rating is not a number", () => {
+    expect(() =>
+      firebaseToSnapPickPreferences({ "opt-a": { rating: "high", games: 4 } }),
+    ).toThrow();
+  });
+});

--- a/src/lib/firebase/schema/snap-pick-preference.ts
+++ b/src/lib/firebase/schema/snap-pick-preference.ts
@@ -1,0 +1,47 @@
+// Snap Pick preference schema boundary.
+//
+// A user's global preference model for one Snap Pick is stored at
+//   snap-pick-preferences/{snapPickId}/{userId}
+// as a flat map of optionId -> { rating, games } (see snap-pick-inference). This
+// is the O(N) rating vector — one entry per option the user has voted on — not
+// the O(N²) pairwise matrix. Domain and persisted shapes both use plain numbers,
+// so the converters are near-identity, but reads still parse so a malformed node
+// fails loudly instead of poisoning the model.
+
+import { z } from "zod";
+
+import type { SnapPickRating, SnapPickRatings } from "@/lib/types/snap-pick";
+
+export interface FirebaseSnapPickRating {
+  rating: number;
+  games: number;
+}
+
+export type FirebaseSnapPickPreferences = Record<
+  string,
+  FirebaseSnapPickRating
+>;
+
+const FirebaseSnapPickRatingSchema = z.object({
+  rating: z.number(),
+  games: z.number(),
+});
+
+const FirebaseSnapPickPreferencesSchema = z.record(
+  z.string(),
+  FirebaseSnapPickRatingSchema,
+);
+
+export function snapPickRatingToFirebase(
+  rating: SnapPickRating,
+): FirebaseSnapPickRating {
+  return { rating: rating.rating, games: rating.games };
+}
+
+export function firebaseToSnapPickRating(data: unknown): SnapPickRating {
+  return FirebaseSnapPickRatingSchema.parse(data);
+}
+
+export function firebaseToSnapPickPreferences(data: unknown): SnapPickRatings {
+  return FirebaseSnapPickPreferencesSchema.parse(data);
+}

--- a/src/lib/snap-pick-inference.spec.ts
+++ b/src/lib/snap-pick-inference.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyVote,
+  ELO_K,
+  focusRelevantOptions,
+  getRating,
+  isLowRelevance,
+  NEUTRAL_RATING,
+  pairUncertainty,
+  rankByRelevance,
+} from "./snap-pick-inference";
+
+describe("getRating", () => {
+  it("returns the stored rating for a known option", () => {
+    const ratings = { "opt-a": { rating: 1234, games: 7 } };
+
+    expect(getRating(ratings, "opt-a")).toEqual({ rating: 1234, games: 7 });
+  });
+
+  it("falls back to the neutral cold-start rating for an unknown option", () => {
+    expect(getRating({}, "opt-a")).toEqual({
+      rating: NEUTRAL_RATING,
+      games: 0,
+    });
+  });
+});
+
+describe("applyVote", () => {
+  it("moves an even matchup by half the K-factor and increments games", () => {
+    const updated = applyVote({}, "opt-a", "opt-b");
+
+    expect(updated).toEqual({
+      "opt-a": { rating: NEUTRAL_RATING + ELO_K / 2, games: 1 },
+      "opt-b": { rating: NEUTRAL_RATING - ELO_K / 2, games: 1 },
+    });
+  });
+
+  it("rewards an underdog win more than a favourite win", () => {
+    const ratings = {
+      strong: { rating: 1200, games: 10 },
+      weak: { rating: 800, games: 10 },
+    };
+
+    const upset = applyVote(ratings, "weak", "strong");
+    const expected = applyVote(ratings, "strong", "weak");
+
+    const upsetGain = getRating(upset, "weak").rating - 800;
+    const expectedGain = getRating(expected, "strong").rating - 1200;
+    expect(upsetGain).toBeGreaterThan(ELO_K / 2);
+    expect(expectedGain).toBeLessThan(ELO_K / 2);
+  });
+
+  it("conserves rating mass between the two options", () => {
+    const ratings = {
+      strong: { rating: 1200, games: 4 },
+      weak: { rating: 950, games: 4 },
+    };
+
+    const updated = applyVote(ratings, "strong", "weak");
+    const winnerGain = getRating(updated, "strong").rating - 1200;
+    const loserLoss = 950 - getRating(updated, "weak").rating;
+    expect(winnerGain).toBeCloseTo(loserLoss, 10);
+  });
+
+  it("touches only the winner and loser, leaving the rest of the pool untouched", () => {
+    const ratings = {
+      "opt-a": { rating: 1100, games: 3 },
+      "opt-b": { rating: 900, games: 3 },
+      "opt-c": { rating: 1000, games: 3 },
+    };
+
+    const updated = applyVote(ratings, "opt-a", "opt-b");
+
+    expect(updated["opt-c"]).toBeUndefined();
+    expect(Object.keys(updated)).toEqual(["opt-a", "opt-b"]);
+  });
+});
+
+describe("rankByRelevance", () => {
+  it("orders options from most to least relevant by rating", () => {
+    const ratings = {
+      low: { rating: 800, games: 5 },
+      high: { rating: 1300, games: 5 },
+      mid: { rating: 1000, games: 5 },
+    };
+
+    const ranked = rankByRelevance(["low", "high", "mid"], ratings);
+
+    expect(ranked.map((option) => option.optionId)).toEqual([
+      "high",
+      "mid",
+      "low",
+    ]);
+  });
+
+  it("exposes games played as the uncertainty signal alongside the rating", () => {
+    const ranked = rankByRelevance(["opt-a"], {
+      "opt-a": { rating: 1300, games: 9 },
+    });
+
+    expect(ranked[0]).toEqual({ optionId: "opt-a", rating: 1300, games: 9 });
+  });
+
+  it("treats unrated options as neutral cold-start and keeps input order on ties", () => {
+    const ranked = rankByRelevance(["opt-a", "opt-b"], {});
+
+    expect(ranked).toEqual([
+      { optionId: "opt-a", rating: NEUTRAL_RATING, games: 0 },
+      { optionId: "opt-b", rating: NEUTRAL_RATING, games: 0 },
+    ]);
+  });
+});
+
+describe("isLowRelevance", () => {
+  it("flags an option that is clearly below neutral with enough games", () => {
+    expect(isLowRelevance({ rating: 900, games: 6 })).toBe(true);
+  });
+
+  it("keeps a cold-start option even when its rating is low", () => {
+    expect(isLowRelevance({ rating: 900, games: 1 })).toBe(false);
+  });
+
+  it("keeps an option whose rating is only marginally below neutral", () => {
+    expect(isLowRelevance({ rating: NEUTRAL_RATING - 10, games: 6 })).toBe(
+      false,
+    );
+  });
+});
+
+describe("focusRelevantOptions", () => {
+  it("prunes clearly-low-relevance options and orders the rest by relevance", () => {
+    const ratings = {
+      margherita: { rating: 1200, games: 8 },
+      pepperoni: { rating: 1150, games: 8 },
+      eggplant: { rating: 850, games: 8 },
+    };
+
+    const focused = focusRelevantOptions(
+      ["margherita", "pepperoni", "eggplant"],
+      ratings,
+    );
+
+    expect(focused).toEqual(["margherita", "pepperoni"]);
+  });
+
+  it("keeps a cold-start option eligible even beside strong ones", () => {
+    const ratings = { strong: { rating: 1300, games: 8 } };
+
+    const focused = focusRelevantOptions(["strong", "newbie"], ratings);
+
+    expect(focused).toEqual(["strong", "newbie"]);
+  });
+
+  it("never prunes the pool below two options", () => {
+    const ratings = {
+      "opt-a": { rating: 900, games: 8 },
+      "opt-b": { rating: 850, games: 8 },
+      "opt-c": { rating: 800, games: 8 },
+    };
+
+    const focused = focusRelevantOptions(["opt-a", "opt-b", "opt-c"], ratings);
+
+    expect(focused).toEqual(["opt-a", "opt-b", "opt-c"]);
+  });
+});
+
+describe("pairUncertainty", () => {
+  it("reports the rating gap and the smaller of the two games counts", () => {
+    const ratings = {
+      "opt-a": { rating: 1200, games: 9 },
+      "opt-b": { rating: 950, games: 4 },
+    };
+
+    expect(pairUncertainty(ratings, "opt-a", "opt-b")).toEqual({
+      ratingGap: 250,
+      games: 4,
+    });
+  });
+
+  it("treats unrated options as neutral cold-start with zero games", () => {
+    expect(pairUncertainty({}, "opt-a", "opt-b")).toEqual({
+      ratingGap: 0,
+      games: 0,
+    });
+  });
+});

--- a/src/lib/snap-pick-inference.ts
+++ b/src/lib/snap-pick-inference.ts
@@ -1,0 +1,137 @@
+// Global per-user preference inference for Snap Picks (v1: relevance).
+//
+// The model is an Elo / Bradley-Terry rating vector: one scalar strength per
+// option per user per Snap Pick, learned from every vote the user has ever cast
+// across activations. It is deliberately *global* — an average over all past
+// runs — because that is exactly the right signal for **relevance**: an option a
+// user dislikes in every context stays low, so it can be pruned from future
+// matchups. It intentionally does not model intra-session mood (that is v2,
+// #371) and does not choose the next question by information gain (v3, #375).
+//
+// This module is the narrow interface those later phases layer on: it exposes
+// the raw rating *and* its uncertainty (games played, pairwise rating gap), not
+// a single thresholded confidence, so v2/v3 can build on the model without
+// touching it.
+
+import type { SnapPickRating, SnapPickRatings } from "@/lib/types/snap-pick";
+
+// The rating an option with no vote history starts at. A cold-start option sits
+// exactly here with zero games, so it is neither pruned nor de-prioritised and
+// stays fully eligible for matchups until real votes move it.
+export const NEUTRAL_RATING = 1000;
+
+// Elo sensitivity: how large a rating change one vote applies at even odds. At
+// equal ratings a vote moves winner and loser by ELO_K / 2 each.
+export const ELO_K = 32;
+
+// Logistic scale of the Bradley-Terry model — a 400-point gap means the stronger
+// option is expected to win ~10x as often (the classic Elo constant).
+export const ELO_SCALE = 400;
+
+// An option must have at least this many games before it can be pruned as
+// low-relevance: below it the rating is too noisy to confidently discard.
+export const PRUNE_MIN_GAMES = 3;
+
+// How far below neutral a (sufficiently-played) option must fall to count as
+// clearly-low relevance and be pruned from the matchup pool.
+export const PRUNE_RATING_MARGIN = 40;
+
+// The relevance of one option: its point strength plus the uncertainty around
+// it (games played). Callers rank on `rating` and gate on `games`.
+export interface OptionRelevance {
+  optionId: string;
+  rating: number;
+  games: number;
+}
+
+// The uncertainty of a pairwise comparison, for v2/v3: the magnitude of the
+// rating gap (how separated the two options are) and the smaller of the two
+// games counts (how much evidence backs the weaker-observed side).
+export interface PairUncertainty {
+  ratingGap: number;
+  games: number;
+}
+
+// The rating an option carries, defaulting to the cold-start neutral when the
+// user has no history for it.
+export function getRating(
+  ratings: SnapPickRatings,
+  optionId: string,
+): SnapPickRating {
+  return ratings[optionId] ?? { rating: NEUTRAL_RATING, games: 0 };
+}
+
+// Applies a single vote to the model and returns the two updated ratings — an
+// O(1) incremental Elo update touching only the winner and loser, never the rest
+// of the pool. The rating mass one option gains the other loses, so the update
+// is conservative.
+export function applyVote(
+  ratings: SnapPickRatings,
+  winnerId: string,
+  loserId: string,
+): SnapPickRatings {
+  const winner = getRating(ratings, winnerId);
+  const loser = getRating(ratings, loserId);
+  const expectedWinner =
+    1 / (1 + 10 ** ((loser.rating - winner.rating) / ELO_SCALE));
+  const change = ELO_K * (1 - expectedWinner);
+  return {
+    [winnerId]: { rating: winner.rating + change, games: winner.games + 1 },
+    [loserId]: { rating: loser.rating - change, games: loser.games + 1 },
+  };
+}
+
+// The relevance of every option, ranked most- to least-relevant. Ties (including
+// the all-cold-start case) keep the input order, so the ranking is deterministic.
+export function rankByRelevance(
+  optionIds: string[],
+  ratings: SnapPickRatings,
+): OptionRelevance[] {
+  return optionIds
+    .map((optionId) => {
+      const { rating, games } = getRating(ratings, optionId);
+      return { optionId, rating, games };
+    })
+    .sort((a, b) => b.rating - a.rating);
+}
+
+// Whether an option is confidently low-relevance: it has enough games to trust
+// the signal and its rating has fallen clearly below neutral. Cold-start options
+// (too few games) never qualify, so they are always kept.
+export function isLowRelevance(rating: SnapPickRating): boolean {
+  return (
+    rating.games >= PRUNE_MIN_GAMES &&
+    rating.rating < NEUTRAL_RATING - PRUNE_RATING_MARGIN
+  );
+}
+
+// The option pool to actually run matchups over: clearly-low-relevance options
+// pruned and the rest ordered most-relevant first, so matchups concentrate on
+// the contested set. Cold-start options are never pruned. Pruning never drops
+// the pool below two options (there would be no matchup left) — if it would, the
+// full pool is kept, still relevance-ordered.
+export function focusRelevantOptions(
+  optionIds: string[],
+  ratings: SnapPickRatings,
+): string[] {
+  const ranked = rankByRelevance(optionIds, ratings);
+  const kept = ranked.filter((option) => !isLowRelevance(option));
+  const focused = kept.length >= 2 ? kept : ranked;
+  return focused.map((option) => option.optionId);
+}
+
+// The uncertainty of comparing two options — exposed for v2 (mood) and v3
+// (information-gain question selection) to reason about which matchups are still
+// worth asking, without re-deriving the model.
+export function pairUncertainty(
+  ratings: SnapPickRatings,
+  optionA: string,
+  optionB: string,
+): PairUncertainty {
+  const a = getRating(ratings, optionA);
+  const b = getRating(ratings, optionB);
+  return {
+    ratingGap: Math.abs(a.rating - b.rating),
+    games: Math.min(a.games, b.games),
+  };
+}

--- a/src/lib/snap-pick-pairing.spec.ts
+++ b/src/lib/snap-pick-pairing.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { allMatchups, pairKey, remainingMatchups } from "./snap-pick-pairing";
+import {
+  allMatchups,
+  pairKey,
+  relevantMatchups,
+  remainingMatchups,
+} from "./snap-pick-pairing";
 
 describe("pairKey", () => {
   it("is identical regardless of argument order", () => {
@@ -60,5 +65,42 @@ describe("remainingMatchups", () => {
     const remaining = remainingMatchups(["a", "b"], [pairKey("a", "gone")]);
 
     expect(remaining).toEqual([{ a: "a", b: "b" }]);
+  });
+});
+
+describe("relevantMatchups", () => {
+  it("drops matchups for a clearly-low-relevance option", () => {
+    const ratings = {
+      a: { rating: 1200, games: 8 },
+      b: { rating: 1150, games: 8 },
+      c: { rating: 850, games: 8 },
+    };
+
+    const matchups = relevantMatchups(["a", "b", "c"], ratings, []);
+
+    expect(matchups).toEqual([{ a: "a", b: "b" }]);
+  });
+
+  it("keeps a cold-start option in the queue alongside rated ones", () => {
+    const ratings = { a: { rating: 1300, games: 8 } };
+
+    const matchups = relevantMatchups(["a", "b"], ratings, []);
+
+    expect(matchups).toEqual([{ a: "a", b: "b" }]);
+  });
+
+  it("falls back to the full round-robin when the model is empty", () => {
+    expect(relevantMatchups(["a", "b", "c"], {}, [])).toEqual(
+      allMatchups(["a", "b", "c"]),
+    );
+  });
+
+  it("still excludes pairs the member has already voted on", () => {
+    const matchups = relevantMatchups(["a", "b", "c"], {}, [pairKey("a", "b")]);
+
+    expect(matchups).toEqual([
+      { a: "a", b: "c" },
+      { a: "b", b: "c" },
+    ]);
   });
 });

--- a/src/lib/snap-pick-pairing.ts
+++ b/src/lib/snap-pick-pairing.ts
@@ -4,10 +4,13 @@
 // member still needs to vote on. Kept free of Firebase and React so it can be
 // unit-tested in isolation and shared by the API route and the voting UI.
 //
-// The seeding is intentionally simple for #259: options are compared in pool
-// order (round-robin), which surfaces every pair exactly once. The preference
-// inference engine (#260) will later reorder this queue to prioritise the most
-// informative matchups; this module exposes the queue it will refine.
+// The base seeding is intentionally simple: options are compared in pool order
+// (round-robin), which surfaces every pair exactly once. The #260 preference
+// engine layers on top via relevantMatchups, which focuses the pool on the
+// contested set (pruning clearly-low-relevance options) before pairing.
+
+import { focusRelevantOptions } from "@/lib/snap-pick-inference";
+import type { SnapPickRatings } from "@/lib/types/snap-pick";
 
 // An unordered pairing of two options. `a` is always the option that sorts first
 // so a pair has one canonical representation regardless of presentation order.
@@ -50,5 +53,22 @@ export function remainingMatchups(
   const cast = new Set(castPairKeys);
   return allMatchups(optionIds).filter(
     (pair) => !cast.has(pairKey(pair.a, pair.b)),
+  );
+}
+
+// The member's remaining queue focused by their global preference model: the
+// #260 relevance layer prunes clearly-low-relevance options and orders the rest
+// most-relevant first, so matchups concentrate on the contested set rather than
+// spending votes on options the member broadly doesn't care about. Cold-start
+// options (no history) fall back to neutral and stay eligible. With an empty
+// model every option is neutral, so this reduces to remainingMatchups.
+export function relevantMatchups(
+  optionIds: string[],
+  ratings: SnapPickRatings,
+  castPairKeys: Iterable<string>,
+): SnapPickPair[] {
+  return remainingMatchups(
+    focusRelevantOptions(optionIds, ratings),
+    castPairKeys,
   );
 }

--- a/src/lib/types/snap-pick.ts
+++ b/src/lib/types/snap-pick.ts
@@ -44,6 +44,21 @@ export interface SnapPickHistoryEntry {
   participantCount: number;
 }
 
+// One option's learned strength in a user's global preference model for a Snap
+// Pick (see snap-pick-inference). `rating` is the Elo-style scalar — higher means
+// the user broadly prefers this option across every past activation; `games` is
+// how many votes have touched it, the uncertainty signal (0 = cold-start, no
+// history, so the rating is the neutral default and carries no evidence yet).
+export interface SnapPickRating {
+  rating: number;
+  games: number;
+}
+
+// A user's whole global preference model for one Snap Pick: one rating per
+// option, keyed by optionId. Stored O(N) at snap-pick-preferences/{snapPickId}/
+// {userId} — not the O(N²) pairwise matrix. Absent keys are cold-start (neutral).
+export type SnapPickRatings = Record<string, SnapPickRating>;
+
 // A single head-to-head matchup result recorded during an activation. Votes are
 // stored under snap-pick-votes/{activationId}/{voteId} and are the source the
 // winner is computed from at close time. The head-to-head voting UI (#259) is

--- a/src/server/data/snap-pick-preferences.spec.ts
+++ b/src/server/data/snap-pick-preferences.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRef, mockGet, mockChild, mockUpdate } = vi.hoisted(() => ({
+  mockRef: vi.fn(),
+  mockGet: vi.fn(),
+  mockChild: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/admin", () => ({
+  getAdminApp: () => ({}),
+}));
+
+vi.mock("firebase-admin/database", () => ({
+  getDatabase: () => ({ ref: mockRef }),
+}));
+
+const { getSnapPickPreferences, updateSnapPickPreference } =
+  await import("./snap-pick-preferences");
+
+function snapshot(value: unknown) {
+  return {
+    exists: () => value !== undefined,
+    val: () => value,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getSnapPickPreferences", () => {
+  beforeEach(() => {
+    mockRef.mockReturnValue({ get: mockGet });
+  });
+
+  it("reads and converts the user's rating vector", async () => {
+    mockGet.mockResolvedValue(
+      snapshot({
+        "opt-a": { rating: 1200, games: 4 },
+        "opt-b": { rating: 900, games: 4 },
+      }),
+    );
+
+    const result = await getSnapPickPreferences("snap-1", "user-1");
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-preferences/snap-1/user-1");
+    expect(result).toEqual({
+      "opt-a": { rating: 1200, games: 4 },
+      "opt-b": { rating: 900, games: 4 },
+    });
+  });
+
+  it("returns an empty model when the user has no history", async () => {
+    mockGet.mockResolvedValue(snapshot(undefined));
+
+    expect(await getSnapPickPreferences("snap-1", "user-1")).toEqual({});
+  });
+});
+
+describe("updateSnapPickPreference", () => {
+  beforeEach(() => {
+    mockRef.mockReturnValue({ child: mockChild, update: mockUpdate });
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it("applies an even matchup as a half-K Elo swing from cold-start", async () => {
+    mockChild.mockReturnValue({
+      get: () => Promise.resolve(snapshot(undefined)),
+    });
+
+    await updateSnapPickPreference("snap-1", "user-1", "opt-a", "opt-b");
+
+    expect(mockRef).toHaveBeenCalledWith("snap-pick-preferences/snap-1/user-1");
+    expect(mockUpdate).toHaveBeenCalledWith({
+      "opt-a": { rating: 1016, games: 1 },
+      "opt-b": { rating: 984, games: 1 },
+    });
+  });
+
+  it("reads only the two contested options and folds their prior ratings in", async () => {
+    mockChild.mockImplementation((optionId: string) => ({
+      get: () =>
+        Promise.resolve(
+          snapshot(
+            optionId === "opt-a"
+              ? { rating: 1000, games: 5 }
+              : { rating: 1000, games: 5 },
+          ),
+        ),
+    }));
+
+    await updateSnapPickPreference("snap-1", "user-1", "opt-a", "opt-b");
+
+    expect(mockChild).toHaveBeenCalledWith("opt-a");
+    expect(mockChild).toHaveBeenCalledWith("opt-b");
+    expect(mockUpdate).toHaveBeenCalledWith({
+      "opt-a": { rating: 1016, games: 6 },
+      "opt-b": { rating: 984, games: 6 },
+    });
+  });
+});

--- a/src/server/data/snap-pick-preferences.ts
+++ b/src/server/data/snap-pick-preferences.ts
@@ -1,0 +1,62 @@
+import { getDatabase } from "firebase-admin/database";
+
+import { getAdminApp } from "@/lib/firebase/admin";
+import {
+  firebaseToSnapPickPreferences,
+  firebaseToSnapPickRating,
+  snapPickRatingToFirebase,
+} from "@/lib/firebase/schema/snap-pick-preference";
+import { applyVote, getRating } from "@/lib/snap-pick-inference";
+import type { SnapPickRatings } from "@/lib/types/snap-pick";
+
+// A user's whole global preference model for a Snap Pick — the O(N) rating
+// vector read on the vote-screen path so the pairing can focus the matchup pool.
+// An untouched model (no votes yet) reads as an empty map, which the relevance
+// layer treats as all cold-start (neutral).
+export async function getSnapPickPreferences(
+  snapPickId: string,
+  userId: string,
+): Promise<SnapPickRatings> {
+  const db = getDatabase(getAdminApp());
+  const snap = await db
+    .ref(`snap-pick-preferences/${snapPickId}/${userId}`)
+    .get();
+
+  if (!snap.exists()) return {};
+
+  return firebaseToSnapPickPreferences(snap.val());
+}
+
+// Applies one cast vote to the member's global preference model: an O(1)
+// incremental Elo update that reads only the two options' current ratings and
+// writes only those two back — the rest of the pool is never touched. Absent
+// ratings start at the cold-start neutral. Called on the vote path alongside
+// recording the vote itself.
+export async function updateSnapPickPreference(
+  snapPickId: string,
+  userId: string,
+  winnerId: string,
+  loserId: string,
+): Promise<void> {
+  const db = getDatabase(getAdminApp());
+  const base = db.ref(`snap-pick-preferences/${snapPickId}/${userId}`);
+
+  const [winnerSnap, loserSnap] = await Promise.all([
+    base.child(winnerId).get(),
+    base.child(loserId).get(),
+  ]);
+
+  const current: SnapPickRatings = {};
+  if (winnerSnap.exists()) {
+    current[winnerId] = firebaseToSnapPickRating(winnerSnap.val());
+  }
+  if (loserSnap.exists()) {
+    current[loserId] = firebaseToSnapPickRating(loserSnap.val());
+  }
+
+  const updated = applyVote(current, winnerId, loserId);
+  await base.update({
+    [winnerId]: snapPickRatingToFirebase(getRating(updated, winnerId)),
+    [loserId]: snapPickRatingToFirebase(getRating(updated, loserId)),
+  });
+}


### PR DESCRIPTION
## Purpose

Implements **v1 (relevance)** of the Snap Pick preference engine — the first of the three-phase design on the issue (v1 relevance → v2 mood #371 → v3 EIG selection #375). It learns a global per-user preference from past votes and uses it to focus matchups on the options a member actually cares about (_margherita vs pepperoni_, not _eggplant vs kale_), pruning clearly-low-relevance options from future rounds.

## Approach

Genuinely new — no existing rating/inference/preference code overlapped, so this adds a self-contained model behind a narrow interface, consistent with the existing snap-pick modules.

- **`src/lib/snap-pick-inference.ts`** (new) — the narrow model interface: an O(1) incremental Elo / Bradley-Terry update (`applyVote`), relevance ranking, low-relevance pruning (`focusRelevantOptions`, cold-start stays neutral and eligible), and **uncertainty exposure** (`rankByRelevance` surfaces games played; `pairUncertainty` surfaces the rating gap) so v2/v3 layer on without touching the model.
- **`src/lib/snap-pick-pairing.ts`** — adds `relevantMatchups`, which focuses the option pool by relevance before building the round-robin queue; degrades to the plain round-robin when the model is empty. Never prunes below two options.
- **Storage O(N)** — the rating vector persists at `snap-pick-preferences/{snapPickId}/{userId}` (one `{ rating, games }` per option, not the O(N²) pairwise matrix) through a new `firebaseTo…` / `…ToFirebase` converter.
- **Wiring** — the vote API route folds each cast vote into the model (O(1), reading only the two contested options); the vote-screen read path loads the member's ratings and threads them into the matchup queue.

## Tests

Thorough unit coverage of the pure logic: model update from a vote (even/upset/mass-conservation/isolation), ranking + uncertainty output, low-relevance pruning in pairing, and cold-start fallback; plus converter round-trip/validation, the data-layer read/update, and the vote-route model-update wiring. All local CI checks (format / lint / typecheck / test) pass.

## Acceptance criteria

- [x] Per-user, per-Snap-Pick global rating model with an uncertainty signal (games played)
- [x] Incremental O(1) update per cast vote, persisted through the schema-converter boundary
- [x] #259 pairing prunes/de-prioritises low-relevance options; cold-start falls back to neutral and stays eligible
- [x] Inference behind a narrow interface exposing uncertainty (rating gap + games), never just a thresholded confidence
- [x] Storage O(N) per user
- [x] Unit tests: model update, relevance output, pruning, cold-start

Closes #260

---
*Created by Claude Opus 4.8*
