### PR TITLE
ci(screenshots): post Before/After renders for changed stories

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -194,6 +194,13 @@ jobs:
       - name: List changed files
         run: |
           git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.sha }}" > changed-files.txt
+          # For the base render, also emit the *old* path of any renamed story file so
+          # capture-screenshots.mjs can match it against the base index.json (which
+          # still references the old path before the rename).
+          { cat changed-files.txt; \
+            git diff --name-status "${{ github.event.pull_request.base.sha }}...${{ github.sha }}" \
+              | awk 'BEGIN{FS="\t"} /^R/ { print $2 }'; } \
+            | sort -u > changed-files-base.txt
       # No step-level continue-on-error here (unlike the setup step): a non-zero
       # exit from the head capture must surface as a `failure` so it routes to
       # fix-review. The job-level continue-on-error above keeps that failure
@@ -222,15 +229,19 @@ jobs:
           # in the base index, so it is simply absent from before/ (After-only in
           # the comment). Any failure here degrades to After-only; it must never
           # fail the advisory job or lose the head screenshots.
+          # changed-files-base.txt includes the old paths of renamed story files
+          # so they match the base index.json (which uses pre-rename paths).
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          BEFORE_AVAILABLE=false
           if git worktree add --detach ../sb-base "$BASE_SHA" \
             && pnpm -C ../sb-base install --frozen-lockfile \
             && pnpm -C ../sb-base build-storybook \
             && node scripts/capture-screenshots.mjs \
                  --static-dir=../sb-base/storybook-static \
                  --out=before \
-                 --changed-files=changed-files.txt; then
+                 --changed-files=changed-files-base.txt; then
             echo "Base render captured $(ls before/*.png 2>/dev/null | wc -l) before image(s)."
+            BEFORE_AVAILABLE=true
           else
             echo "Base render failed; posting After-only."
             rm -rf before
@@ -254,7 +265,8 @@ jobs:
             "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$SS_BRANCH"
           node scripts/post-screenshots-comment.mjs \
             --pr="$PR" --branch="$SS_BRANCH" --sha="$HEAD_SHA" \
-            --before-dir=before --after-dir=after
+            --before-dir=before --after-dir=after \
+            --before-available="$BEFORE_AVAILABLE"
 
   build:
     name: Build

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -170,8 +170,12 @@ jobs:
     # resort, not the only way the job goes non-green.
     continue-on-error: true
     # Backstop cap; the capture script's deadline and the step timeout both fire
-    # first, as failures rather than a job cancellation.
-    timeout-minutes: 8
+    # first, as failures rather than a job cancellation. Raised from 8→14 for
+    # the Before/After feature (#403): the job now builds Storybook twice (the
+    # PR render plus the base/`main` render), so it needs roughly double the
+    # wall-clock. This is a capacity increase matched to deliberately-added
+    # work, not a timeout masking a slow operation.
+    timeout-minutes: 14
     permissions:
       contents: write
       pull-requests: write
@@ -191,31 +195,56 @@ jobs:
         run: |
           git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.sha }}" > changed-files.txt
       # No step-level continue-on-error here (unlike the setup step): a non-zero
-      # exit from the capture script must surface as a `failure` so it routes to
+      # exit from the head capture must surface as a `failure` so it routes to
       # fix-review. The job-level continue-on-error above keeps that failure
       # non-blocking (advisory, never a merge gate — #339). The step timeout is a
       # backstop; the script's own wall-clock deadline exits non-zero first.
       # Capture reuses the Chromium installed by the setup action.
-      - name: Capture and publish screenshots
-        timeout-minutes: 6
+      - name: Capture and publish before/after screenshots
+        timeout-minutes: 12
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Head (PR) render — the authoritative capture. A failure here must
+          # surface as a job failure, so it is not guarded.
           pnpm build-storybook
           node scripts/capture-screenshots.mjs \
             --static-dir=storybook-static \
-            --out=screenshots \
+            --out=after \
             --changed-files=changed-files.txt
-          if ! ls screenshots/*.png >/dev/null 2>&1; then
+          if ! ls after/*.png >/dev/null 2>&1; then
             echo "No screenshots captured; nothing to publish."
             exit 0
+          fi
+          # Base (`main`) render — best-effort "before" (#403). Built from the
+          # PR's base SHA in a detached worktree. A story new in this PR is not
+          # in the base index, so it is simply absent from before/ (After-only in
+          # the comment). Any failure here degrades to After-only; it must never
+          # fail the advisory job or lose the head screenshots.
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if git worktree add --detach ../sb-base "$BASE_SHA" \
+            && pnpm -C ../sb-base install --frozen-lockfile \
+            && pnpm -C ../sb-base build-storybook \
+            && node scripts/capture-screenshots.mjs \
+                 --static-dir=../sb-base/storybook-static \
+                 --out=before \
+                 --changed-files=changed-files.txt; then
+            echo "Base render captured $(ls before/*.png 2>/dev/null | wc -l) before image(s)."
+          else
+            echo "Base render failed; posting After-only."
+            rm -rf before
           fi
           PR="${{ github.event.pull_request.number }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           SS_BRANCH="gh-screenshots-pr-${PR}"
           PUBDIR="$(mktemp -d)"
-          cp screenshots/*.png "$PUBDIR"/
+          mkdir -p "$PUBDIR/after"
+          cp after/*.png "$PUBDIR/after"/
+          if ls before/*.png >/dev/null 2>&1; then
+            mkdir -p "$PUBDIR/before"
+            cp before/*.png "$PUBDIR/before"/
+          fi
           git -C "$PUBDIR" init -q -b "$SS_BRANCH"
           git -C "$PUBDIR" config user.email "github-actions[bot]@users.noreply.github.com"
           git -C "$PUBDIR" config user.name "github-actions[bot]"
@@ -224,7 +253,8 @@ jobs:
           git -C "$PUBDIR" push -f \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$SS_BRANCH"
           node scripts/post-screenshots-comment.mjs \
-            --pr="$PR" --branch="$SS_BRANCH" --sha="$HEAD_SHA" --dir=screenshots
+            --pr="$PR" --branch="$SS_BRANCH" --sha="$HEAD_SHA" \
+            --before-dir=before --after-dir=after
 
   build:
     name: Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,8 @@ Public (non-secret) environment config lives in `deployment/{env}.yml` and is va
 ### Storybook screenshots in CI
 
 - When a PR changes a `*.stories.*` file, the `Storybook Screenshots` job captures a PNG per changed story and posts them inline in a single sticky PR comment — a **visual acceptance aid** to eyeball an intended UI change (it is **advisory**, never a merge gate; the always-on `Storybook Tests` suite is what catches regressions). View them directly in the PR comment; no download needed.
-- Mechanics (see #339): capture is self-hosted (`scripts/capture-screenshots.mjs` drives the Storybook static build in the Chromium the workflow already installs); images are published to a **per-PR** `gh-screenshots-pr-<N>` branch (deleted on PR close by `screenshots-cleanup.yml`) — never a branch shared across PRs, so concurrent PRs can never cancel each other.
+- **Before / After (see #403):** the job renders each changed story twice — the PR version (`after/`) and the base/`main` version (`before/`, built from the PR's base SHA in a throwaway worktree) — and the comment shows them side by side. A story new in this PR (absent from the base index) shows After-only; a deleted story shows Before-only. The base render is best-effort: if it fails, the comment degrades to After-only and the job stays green. No baselines are committed to `main`; both renders are ephemeral, computed per PR. The tradeoff is that the job builds Storybook twice, so its wall-clock roughly doubles (job timeout raised 8→14 min to match).
+- Mechanics (see #339): capture is self-hosted (`scripts/capture-screenshots.mjs` drives the Storybook static build in the Chromium the workflow already installs); images are published to a **per-PR** `gh-screenshots-pr-<N>` branch under `before/` and `after/` (deleted on PR close by `screenshots-cleanup.yml`) — never a branch shared across PRs, so concurrent PRs can never cancel each other.
 
 ## Component Tests
 

--- a/scripts/post-screenshots-comment.d.mts
+++ b/scripts/post-screenshots-comment.d.mts
@@ -39,4 +39,5 @@ export declare function buildBody(
   sha: string,
   beforeFiles: string[],
   afterFiles: string[],
+  beforeAvailable?: boolean,
 ): string;

--- a/scripts/post-screenshots-comment.d.mts
+++ b/scripts/post-screenshots-comment.d.mts
@@ -20,3 +20,23 @@ export interface FindMarkerCommentOptions {
 export declare function findMarkerComment(
   options: FindMarkerCommentOptions,
 ): Promise<MarkerComment | undefined>;
+
+export interface ScreenshotPair {
+  file: string;
+  name: string;
+  hasBefore: boolean;
+  hasAfter: boolean;
+}
+
+export declare function pairScreenshots(
+  beforeFiles: string[],
+  afterFiles: string[],
+): ScreenshotPair[];
+
+export declare function buildBody(
+  repo: string,
+  branch: string,
+  sha: string,
+  beforeFiles: string[],
+  afterFiles: string[],
+): string;

--- a/scripts/post-screenshots-comment.mjs
+++ b/scripts/post-screenshots-comment.mjs
@@ -1,29 +1,37 @@
 #!/usr/bin/env node
 
-// Upsert a single sticky PR comment with inline Storybook screenshots (#339).
-// Images are referenced from the per-PR `gh-screenshots-pr-<N>` branch via
+// Upsert a single sticky PR comment with Before / After Storybook screenshots
+// (#339, #403). For each changed story the job publishes two renders to the
+// per-PR `gh-screenshots-pr-<N>` branch: `before/<story>.png` (the base/`main`
+// render) and `after/<story>.png` (this PR's render). Images are referenced via
 // raw.githubusercontent.com (the repo is public). A `?v=<sha>` cache-buster
 // makes GitHub's image proxy refetch on each new commit. The comment is found
 // and updated by a hidden marker so each run replaces the previous one.
 //
+// A story present in both renders is shown side by side; a story new in this PR
+// (absent from the base index) is shown After-only; a deleted story is
+// Before-only.
+//
 // Usage:
 //   node scripts/post-screenshots-comment.mjs \
-//     --pr=<number> --branch=<gh-screenshots-pr-N> --sha=<head-sha> --dir=screenshots
+//     --pr=<number> --branch=<gh-screenshots-pr-N> --sha=<head-sha> \
+//     [--before-dir=before] [--after-dir=after]
 //
 // Requires env: GITHUB_REPOSITORY (owner/repo) and GITHUB_TOKEN.
 
-import { readdirSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 export const MARKER = "<!-- storybook-screenshots -->";
 
 function parseArgs(argv) {
-  const args = { dir: "screenshots" };
+  const args = { beforeDir: "before", afterDir: "after" };
   for (const arg of argv) {
     if (arg.startsWith("--pr=")) args.pr = arg.slice(5);
     else if (arg.startsWith("--branch=")) args.branch = arg.slice(9);
     else if (arg.startsWith("--sha=")) args.sha = arg.slice(6);
-    else if (arg.startsWith("--dir=")) args.dir = arg.slice(6);
+    else if (arg.startsWith("--before-dir=")) args.beforeDir = arg.slice(13);
+    else if (arg.startsWith("--after-dir=")) args.afterDir = arg.slice(12);
   }
   return args;
 }
@@ -84,27 +92,76 @@ export async function findMarkerComment({
   return undefined;
 }
 
-function buildBody(repo, branch, sha, files) {
+// Pair the before/after PNG filenames by story id (the filename is
+// `<story.id>.png`), producing one sorted entry per story with flags for which
+// renders exist. A modified story has both; a new story has only `after`; a
+// deleted story has only `before`.
+export function pairScreenshots(beforeFiles, afterFiles) {
+  const before = new Set(beforeFiles);
+  const after = new Set(afterFiles);
+  const files = [...new Set([...beforeFiles, ...afterFiles])].sort();
+  return files.map((file) => ({
+    file,
+    name: file.replace(/\.png$/, ""),
+    hasBefore: before.has(file),
+    hasAfter: after.has(file),
+  }));
+}
+
+function renderStory(repo, branch, sha, { file, name, hasBefore, hasAfter }) {
+  const beforeUrl = `https://raw.githubusercontent.com/${repo}/${branch}/before/${file}?v=${sha}`;
+  const afterUrl = `https://raw.githubusercontent.com/${repo}/${branch}/after/${file}?v=${sha}`;
+
+  if (hasBefore && hasAfter) {
+    return [
+      "<details open>",
+      `<summary><code>${name}</code></summary>`,
+      "",
+      "| Before | After |",
+      "| --- | --- |",
+      `| ![before](${beforeUrl}) | ![after](${afterUrl}) |`,
+      "",
+      "</details>",
+    ].join("\n");
+  }
+
+  const label = hasAfter ? "new" : "removed";
+  const alt = hasAfter ? "after" : "before";
+  const url = hasAfter ? afterUrl : beforeUrl;
+  return [
+    "<details open>",
+    `<summary><code>${name}</code> — ${label}</summary>`,
+    "",
+    `![${alt}](${url})`,
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+export function buildBody(repo, branch, sha, beforeFiles, afterFiles) {
   const shortSha = sha.slice(0, 7);
-  const images = files
-    .map((file) => {
-      const url = `https://raw.githubusercontent.com/${repo}/${branch}/${file}?v=${sha}`;
-      const name = file.replace(/\.png$/, "");
-      return `<details open>\n<summary><code>${name}</code></summary>\n\n![${name}](${url})\n\n</details>`;
-    })
+  const blocks = pairScreenshots(beforeFiles, afterFiles)
+    .map((story) => renderStory(repo, branch, sha, story))
     .join("\n\n");
 
   return [
     MARKER,
     "## 📸 Storybook screenshots",
     "",
-    `Visual acceptance aid for the changed stories at commit \`${shortSha}\` — advisory, not a gate.`,
+    `Before / after of the changed stories at commit \`${shortSha}\` — advisory, not a gate. "Before" is \`main\`'s render; a story new in this PR shows After only.`,
     "",
-    images,
+    blocks,
     "",
     "---",
     "_Updated by the Storybook Screenshots job (see #339)._",
   ].join("\n");
+}
+
+function readPngs(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".png"))
+    .sort();
 }
 
 async function main() {
@@ -117,15 +174,14 @@ async function main() {
     throw new Error("--pr, --branch and --sha are required.");
   }
 
-  const files = readdirSync(args.dir)
-    .filter((f) => f.endsWith(".png"))
-    .sort();
-  if (files.length === 0) {
+  const beforeFiles = readPngs(args.beforeDir);
+  const afterFiles = readPngs(args.afterDir);
+  if (beforeFiles.length === 0 && afterFiles.length === 0) {
     console.log("No screenshots to post.");
     return;
   }
 
-  const body = buildBody(repo, args.branch, args.sha, files);
+  const body = buildBody(repo, args.branch, args.sha, beforeFiles, afterFiles);
   const existing = await findMarkerComment({
     repo,
     pr: args.pr,

--- a/scripts/post-screenshots-comment.mjs
+++ b/scripts/post-screenshots-comment.mjs
@@ -25,7 +25,11 @@ import { fileURLToPath } from "node:url";
 export const MARKER = "<!-- storybook-screenshots -->";
 
 function parseArgs(argv) {
-  const args = { beforeDir: "before", afterDir: "after", beforeAvailable: true };
+  const args = {
+    beforeDir: "before",
+    afterDir: "after",
+    beforeAvailable: true,
+  };
   for (const arg of argv) {
     if (arg.startsWith("--pr=")) args.pr = arg.slice(5);
     else if (arg.startsWith("--branch=")) args.branch = arg.slice(9);
@@ -136,11 +140,7 @@ function renderStory(
   // When the base render was unavailable, after-only stories may be modified
   // stories whose before image is simply missing — label them "after-only" to
   // distinguish from stories that are genuinely new in this PR.
-  const label = hasAfter
-    ? beforeAvailable
-      ? "new"
-      : "after-only"
-    : "removed";
+  const label = hasAfter ? (beforeAvailable ? "new" : "after-only") : "removed";
   const alt = hasAfter ? "after" : "before";
   const url = hasAfter ? afterUrl : beforeUrl;
   return [
@@ -170,7 +170,17 @@ export function buildBody(
     ? `Before / after of the changed stories at commit \`${shortSha}\` — advisory, not a gate. "Before" is \`main\`'s render; a story new in this PR shows After only.`
     : `After-only screenshots at commit \`${shortSha}\` — advisory, not a gate. The base render was unavailable; modified stories show the PR version only.`;
 
-  return [MARKER, "## 📸 Storybook screenshots", "", desc, "", blocks, "", "---", "_Updated by the Storybook Screenshots job (see #339)._"].join("\n");
+  return [
+    MARKER,
+    "## 📸 Storybook screenshots",
+    "",
+    desc,
+    "",
+    blocks,
+    "",
+    "---",
+    "_Updated by the Storybook Screenshots job (see #339)._",
+  ].join("\n");
 }
 
 function readPngs(dir) {

--- a/scripts/post-screenshots-comment.mjs
+++ b/scripts/post-screenshots-comment.mjs
@@ -25,13 +25,15 @@ import { fileURLToPath } from "node:url";
 export const MARKER = "<!-- storybook-screenshots -->";
 
 function parseArgs(argv) {
-  const args = { beforeDir: "before", afterDir: "after" };
+  const args = { beforeDir: "before", afterDir: "after", beforeAvailable: true };
   for (const arg of argv) {
     if (arg.startsWith("--pr=")) args.pr = arg.slice(5);
     else if (arg.startsWith("--branch=")) args.branch = arg.slice(9);
     else if (arg.startsWith("--sha=")) args.sha = arg.slice(6);
     else if (arg.startsWith("--before-dir=")) args.beforeDir = arg.slice(13);
     else if (arg.startsWith("--after-dir=")) args.afterDir = arg.slice(12);
+    else if (arg.startsWith("--before-available="))
+      args.beforeAvailable = arg.slice(19) !== "false";
   }
   return args;
 }
@@ -108,7 +110,13 @@ export function pairScreenshots(beforeFiles, afterFiles) {
   }));
 }
 
-function renderStory(repo, branch, sha, { file, name, hasBefore, hasAfter }) {
+function renderStory(
+  repo,
+  branch,
+  sha,
+  { file, name, hasBefore, hasAfter },
+  beforeAvailable,
+) {
   const beforeUrl = `https://raw.githubusercontent.com/${repo}/${branch}/before/${file}?v=${sha}`;
   const afterUrl = `https://raw.githubusercontent.com/${repo}/${branch}/after/${file}?v=${sha}`;
 
@@ -125,7 +133,14 @@ function renderStory(repo, branch, sha, { file, name, hasBefore, hasAfter }) {
     ].join("\n");
   }
 
-  const label = hasAfter ? "new" : "removed";
+  // When the base render was unavailable, after-only stories may be modified
+  // stories whose before image is simply missing — label them "after-only" to
+  // distinguish from stories that are genuinely new in this PR.
+  const label = hasAfter
+    ? beforeAvailable
+      ? "new"
+      : "after-only"
+    : "removed";
   const alt = hasAfter ? "after" : "before";
   const url = hasAfter ? afterUrl : beforeUrl;
   return [
@@ -138,23 +153,24 @@ function renderStory(repo, branch, sha, { file, name, hasBefore, hasAfter }) {
   ].join("\n");
 }
 
-export function buildBody(repo, branch, sha, beforeFiles, afterFiles) {
+export function buildBody(
+  repo,
+  branch,
+  sha,
+  beforeFiles,
+  afterFiles,
+  beforeAvailable = true,
+) {
   const shortSha = sha.slice(0, 7);
   const blocks = pairScreenshots(beforeFiles, afterFiles)
-    .map((story) => renderStory(repo, branch, sha, story))
+    .map((story) => renderStory(repo, branch, sha, story, beforeAvailable))
     .join("\n\n");
 
-  return [
-    MARKER,
-    "## 📸 Storybook screenshots",
-    "",
-    `Before / after of the changed stories at commit \`${shortSha}\` — advisory, not a gate. "Before" is \`main\`'s render; a story new in this PR shows After only.`,
-    "",
-    blocks,
-    "",
-    "---",
-    "_Updated by the Storybook Screenshots job (see #339)._",
-  ].join("\n");
+  const desc = beforeAvailable
+    ? `Before / after of the changed stories at commit \`${shortSha}\` — advisory, not a gate. "Before" is \`main\`'s render; a story new in this PR shows After only.`
+    : `After-only screenshots at commit \`${shortSha}\` — advisory, not a gate. The base render was unavailable; modified stories show the PR version only.`;
+
+  return [MARKER, "## 📸 Storybook screenshots", "", desc, "", blocks, "", "---", "_Updated by the Storybook Screenshots job (see #339)._"].join("\n");
 }
 
 function readPngs(dir) {
@@ -181,7 +197,14 @@ async function main() {
     return;
   }
 
-  const body = buildBody(repo, args.branch, args.sha, beforeFiles, afterFiles);
+  const body = buildBody(
+    repo,
+    args.branch,
+    args.sha,
+    beforeFiles,
+    afterFiles,
+    args.beforeAvailable,
+  );
   const existing = await findMarkerComment({
     repo,
     pr: args.pr,

--- a/src/scripts/post-screenshots-comment.spec.ts
+++ b/src/scripts/post-screenshots-comment.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildBody,
   findMarkerComment,
   MARKER,
+  pairScreenshots,
   parseNextLink,
 } from "../../scripts/post-screenshots-comment.mjs";
 
@@ -49,6 +51,91 @@ describe("parseNextLink: extract the rel=next URL", () => {
 
   it("returns undefined for a missing header", () => {
     expect(parseNextLink(null)).toBeUndefined();
+  });
+});
+
+describe("pairScreenshots: match before/after renders by story id", () => {
+  it("flags a story present in both renders as having before and after", () => {
+    const pairs = pairScreenshots(["a--modified.png"], ["a--modified.png"]);
+    expect(pairs).toEqual([
+      {
+        file: "a--modified.png",
+        name: "a--modified",
+        hasBefore: true,
+        hasAfter: true,
+      },
+    ]);
+  });
+
+  it("flags a story only in after (new in this PR) as after-only", () => {
+    const pairs = pairScreenshots([], ["b--new.png"]);
+    expect(pairs).toEqual([
+      { file: "b--new.png", name: "b--new", hasBefore: false, hasAfter: true },
+    ]);
+  });
+
+  it("flags a story only in before (deleted) as before-only", () => {
+    const pairs = pairScreenshots(["c--gone.png"], []);
+    expect(pairs).toEqual([
+      {
+        file: "c--gone.png",
+        name: "c--gone",
+        hasBefore: true,
+        hasAfter: false,
+      },
+    ]);
+  });
+
+  it("sorts the union of before and after story ids", () => {
+    const pairs = pairScreenshots(["z--old.png"], ["a--new.png", "m--mid.png"]);
+    expect(pairs.map((p) => p.name)).toEqual(["a--new", "m--mid", "z--old"]);
+  });
+});
+
+describe("buildBody: render Before/After pairs", () => {
+  const repo = "o/r";
+  const branch = "gh-screenshots-pr-7";
+  const sha = "abcdef1234567890";
+
+  it("renders a two-column Before | After table for a modified story", () => {
+    const body = buildBody(
+      repo,
+      branch,
+      sha,
+      ["a--modified.png"],
+      ["a--modified.png"],
+    );
+    expect(body).toContain("| Before | After |");
+    expect(body).toContain(
+      `https://raw.githubusercontent.com/${repo}/${branch}/before/a--modified.png?v=${sha}`,
+    );
+    expect(body).toContain(
+      `https://raw.githubusercontent.com/${repo}/${branch}/after/a--modified.png?v=${sha}`,
+    );
+  });
+
+  it("renders a new story as After-only with no before image", () => {
+    const body = buildBody(repo, branch, sha, [], ["b--new.png"]);
+    expect(body).toContain("<code>b--new</code> — new");
+    expect(body).toContain(
+      `https://raw.githubusercontent.com/${repo}/${branch}/after/b--new.png?v=${sha}`,
+    );
+    expect(body).not.toContain("/before/b--new.png");
+    expect(body).not.toContain("| Before | After |");
+  });
+
+  it("renders a deleted story as Before-only", () => {
+    const body = buildBody(repo, branch, sha, ["c--gone.png"], []);
+    expect(body).toContain("<code>c--gone</code> — removed");
+    expect(body).toContain(
+      `https://raw.githubusercontent.com/${repo}/${branch}/before/c--gone.png?v=${sha}`,
+    );
+    expect(body).not.toContain("/after/c--gone.png");
+  });
+
+  it("includes the sticky marker so the comment can be upserted", () => {
+    const body = buildBody(repo, branch, sha, ["a.png"], ["a.png"]);
+    expect(body.startsWith(MARKER)).toBe(true);
   });
 });
 

--- a/src/scripts/post-screenshots-comment.spec.ts
+++ b/src/scripts/post-screenshots-comment.spec.ts
@@ -133,6 +133,21 @@ describe("buildBody: render Before/After pairs", () => {
     expect(body).not.toContain("/after/c--gone.png");
   });
 
+  it("labels an after-only story as 'after-only' when base render was unavailable", () => {
+    const body = buildBody(repo, branch, sha, [], ["b--modified.png"], false);
+    expect(body).toContain("<code>b--modified</code> — after-only");
+    expect(body).toContain(
+      `https://raw.githubusercontent.com/${repo}/${branch}/after/b--modified.png?v=${sha}`,
+    );
+    expect(body).not.toContain("— new");
+  });
+
+  it("uses the unavailable-base description when beforeAvailable is false", () => {
+    const body = buildBody(repo, branch, sha, [], ["a.png"], false);
+    expect(body).toContain("base render was unavailable");
+    expect(body).not.toContain('"Before" is');
+  });
+
   it("includes the sticky marker so the comment can be upserted", () => {
     const body = buildBody(repo, branch, sha, ["a.png"], ["a.png"]);
     expect(body.startsWith(MARKER)).toBe(true);


### PR DESCRIPTION
POC for a **Before / After** view in the advisory Storybook Screenshots comment. For each changed story the job now renders both the PR version and the base (`main`) version and shows them side by side, so a reviewer can see what a story change actually did — not just its new state.

## How it works

- The screenshots job builds Storybook **twice**: the PR render → `after/` (the existing capture) and the base render → `before/`, built from the PR's base SHA in a throwaway `git worktree` and captured by the same `capture-screenshots.mjs`.
- Both dirs are published to the per-PR `gh-screenshots-pr-<N>` branch under `before/` and `after/`, and `post-screenshots-comment.mjs` pairs them by story id (the stable `{story.id}.png` filename): a modified story renders in a two-column `Before | After` table; a story new in this PR (absent from the base index) renders After-only; a deleted story renders Before-only.
- **No baselines are committed to `main`** — both renders are ephemeral, computed per PR. This deliberately avoids the binary-history bloat, render-nondeterminism churn, and binary merge conflicts a committed-baseline approach brings.
- The base render is **best-effort**: any failure (worktree, install, build, capture) degrades the comment to After-only and the job stays green — it never fails the advisory job or loses the head screenshots.

## Technical considerations

- The second Storybook build roughly doubles the job's wall-clock, so the job timeout is raised 8→14 min. This is capacity matched to deliberately-added work, not a timeout masking a slow operation (documented in-line).
- `buildBody` is refactored around a pure `pairScreenshots(before, after)` helper; both are exported and unit-tested for the modified / new / deleted cases.

## Acceptance criteria

- [x] Job captures both base and head renders of each changed story, keyed by stable story id
- [x] Comment shows Before | After for a modified story; After-only for a new story; Before-only for a deleted story
- [x] No PNGs committed to `main`; the "before" is rendered from the base SHA at PR time
- [x] Job stays advisory / non-gating and only runs on `stories_changed`
- [x] Pairing / comment-building logic is unit-tested

## Validating the POC

This PR itself doesn't change a `*.stories.*` file, so the screenshots job won't fire here. Real validation wants a follow-up PR that tweaks one story (or a temporary story edit) to see the Before/After comment render end to end, plus a read on the actual added wall-clock.

Closes #403

---
*Created by Claude Opus 4.8*
