### PR TITLE
fix!: pin jose to 5.x to restore the auth middleware (firebase-admin ESM require)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
       "esbuild",
       "playwright",
       "protobufjs"
-    ]
+    ],
+    "overrides": {
+      "jose": "^5.10.0"
+    }
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  jose: ^5.10.0
+
 importers:
 
   .:
@@ -4612,11 +4615,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@5.9.6:
-    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
-
-  jose@6.2.3:
-    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7828,7 +7828,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.30
-      jose: 6.2.3
+      jose: 5.10.0
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -9476,7 +9476,7 @@ snapshots:
       '@vercel/oidc': 3.2.0
       '@workflow/serde': 4.1.0-beta.2
       async-retry: 1.3.3
-      jose: 6.2.3
+      jose: 5.10.0
       jsonlines: 0.1.1
       ms: 2.1.3
       picocolors: 1.1.1
@@ -11174,9 +11174,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jose@5.9.6: {}
-
-  jose@6.2.3: {}
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -11246,7 +11244,7 @@ snapshots:
     dependencies:
       '@types/jsonwebtoken': 9.0.10
       debug: 4.4.3
-      jose: 6.2.3
+      jose: 5.10.0
       limiter: 1.1.5
       lru-cache: 11.5.1
       lru-memoizer: 3.0.0
@@ -12909,7 +12907,7 @@ snapshots:
       '@vercel/static-build': 2.11.4
       chokidar: 4.0.0
       esbuild: 0.27.0
-      jose: 5.9.6
+      jose: 5.10.0
       luxon: 3.7.2
       proxy-agent: 6.4.0
       sandbox: 3.1.2

--- a/src/lib/firebase/jose-cjs-guard.spec.ts
+++ b/src/lib/firebase/jose-cjs-guard.spec.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { execFileSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+// Regression guard for the jose v6 ESM-only production outage (route=/middleware):
+// src/middleware.ts is the Node-runtime auth gate — it calls
+// getAdminAuth().verifySessionCookie(...). firebase-admin's transitive
+// jwks-rsa/src/utils.js runs `const jose = require("jose")`. jose@6 is ESM-only,
+// so any runtime that cannot require() an ES module throws ERR_REQUIRE_ESM. On
+// Vercel that runtime is Turbopack's middleware external-module loader — which
+// does NOT use Node 24's native require(ESM) support, so the middleware crashed
+// on every request. We pin jose to the last CJS-capable major (5.x) via
+// pnpm.overrides in package.json.
+//
+// This test loads the exact failing module in a child Node process with
+// require(ESM) DISABLED (--no-experimental-require-module), faithfully
+// reproducing that "cannot require ESM" environment. It stays green while jose
+// is CJS-capable and goes RED the moment jose@6 re-enters the require path
+// (e.g. the override is dropped before jwks-rsa/firebase-admin load jose via
+// dynamic import). Red here = the override is still needed; green with the
+// override removed = it is finally safe to remove.
+describe("jose stays CommonJS-requireable for the firebase-admin auth path", () => {
+  it("jwks-rsa loads in a runtime where require(ESM) is unavailable", () => {
+    const script = [
+      'const { createRequire } = require("module");',
+      'const faReq = createRequire(require.resolve("firebase-admin"));',
+      'faReq("jwks-rsa/src/utils");',
+    ].join("\n");
+
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        ["--no-experimental-require-module", "-e", script],
+        { cwd: process.cwd(), stdio: "pipe" },
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
**Production outage fix.** Every request returned an Internal Server Error — Vercel runtime errors show one cluster on route `/middleware` (first seen 2026-07-06, still firing today). Same failure and fix as rmartz/trip-planner#438.

## Root cause

`src/middleware.ts` is the Node-runtime auth gate — it calls `getAdminAuth().verifySessionCookie(...)`. `firebase-admin`'s transitive `jwks-rsa@4.1.0/src/utils.js` runs `const jose = require("jose")`. The **firebase-admin 13→14 bump** pulled in `jwks-rsa@4.1.0`, whose `jose` dependency is **`jose@6`, which is ESM-only** — so a CommonJS `require()` throws:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../jose@6.2.3/.../jose/dist/webapi/index.js
from .../jwks-rsa@4.1.0/node_modules/jwks-rsa/src/utils.js not supported.
```

It broke only the middleware (not route handlers) because **Turbopack's middleware external-module loader doesn't use Node 24's native `require(ESM)` support** — regular Vercel Functions do, which is why firebase-admin works elsewhere and only `route=/middleware` errored.

## Fix

`pnpm.overrides` pins `jose` to the last CJS-capable major (`^5.10.0`), so the `require` resolves. `jose` 5→6 is essentially an ESM-only packaging change, so `jwks-rsa@4.1.0` works unchanged and `verifySessionCookie` (with its `checkRevoked` revocation check) is preserved exactly. After the override the whole tree resolves a single `jose@5.10.0`; `jose@6` is gone.

## Regression guard

`src/lib/firebase/jose-cjs-guard.spec.ts` loads `firebase-admin`'s `jwks-rsa/src/utils` in a child Node process with `require(ESM)` **disabled** (`--no-experimental-require-module`) — faithfully reproducing the Vercel/Turbopack "can't require ESM" runtime. Green while jose is CJS-capable, red the moment `jose@6` re-enters the require path — that red/green is the signal for when the override is safe to remove.

## Verified

- With the override, `jose` resolves to `5.10.0`; the guard loads the failing module OK under the no-`require(ESM)` runtime. The production `ERR_REQUIRE_ESM` on `jose@6.2.3` is the real-world red this guard reproduces.
- `pre-push-verify` green — format / lint / tsc / test (incl. the guard).

## Follow-up (separate issue)

The cleaner long-term fix is to drop `firebase-admin` from the middleware and verify the **session cookie** with Web Crypto (Edge-capable, no heavy Node SDK in the gate). This PR is the incident restore, not that refactor.

Closes #407

---
*Created by Claude Opus 4.8*
