### PR TITLE
chore(deployment): remove committed Firebase Web API key (secret-scanning false positive)

### DIFF
--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -12,8 +12,11 @@
 environment: production
 
 variables:
-  # Firebase Client SDK — safe to expose; access control is enforced by Firebase security rules
-  NEXT_PUBLIC_FIREBASE_API_KEY: "AIzaSyByPe_aFNea6TWv1MY77agwSVyuE7Ze0RM"
+  # Firebase Client SDK — safe to expose; access control is enforced by Firebase security rules.
+  # NEXT_PUBLIC_FIREBASE_API_KEY is a public Firebase Web API key (not a secret), but its "AIza…"
+  # shape trips GitHub secret scanning, so its value is set directly in Vercel and left blank here.
+  # The remaining values are plain identifiers with no secret-pattern shape and stay committed.
+  NEXT_PUBLIC_FIREBASE_API_KEY: ""
   NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "group-picks.firebaseapp.com"
   NEXT_PUBLIC_FIREBASE_PROJECT_ID: "group-picks"
   NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "group-picks.firebasestorage.app"

--- a/deployment/staging.yml
+++ b/deployment/staging.yml
@@ -12,8 +12,11 @@
 environment: staging
 
 variables:
-  # Firebase Client SDK — safe to expose; access control is enforced by Firebase security rules
-  NEXT_PUBLIC_FIREBASE_API_KEY: "AIzaSyBECVyfSZAlCbpq8PhXMO7ibrobmthnwGQ"
+  # Firebase Client SDK — safe to expose; access control is enforced by Firebase security rules.
+  # NEXT_PUBLIC_FIREBASE_API_KEY is a public Firebase Web API key (not a secret), but its "AIza…"
+  # shape trips GitHub secret scanning, so its value is set directly in Vercel and left blank here.
+  # The remaining values are plain identifiers with no secret-pattern shape and stay committed.
+  NEXT_PUBLIC_FIREBASE_API_KEY: ""
   NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "group-picks-staging.firebaseapp.com"
   NEXT_PUBLIC_FIREBASE_PROJECT_ID: "group-picks-staging"
   NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "group-picks-staging.firebasestorage.app"


### PR DESCRIPTION
Removes the committed `NEXT_PUBLIC_FIREBASE_API_KEY` values from `deployment/production.yml` and `deployment/staging.yml` — GitHub secret scanning flags their `AIza…` shape as a Google API key.

## Why this is a false positive

These are **Firebase Web API keys**, which are public by design: Next.js bundles every `NEXT_PUBLIC_*` value into client JavaScript, so the key already ships to every browser that loads the app. Access control is enforced by Firebase security rules, not by keeping the key private. So there is no secret to leak — only a scanner pattern-match to silence.

## Why this is safe for deployment

The build gets its env from **Vercel's own project settings** (`vercel pull` + `vercel build`), not from these YAMLs — the old YAML→Vercel `sync-env` was removed and `env:validate` only schema-checks **keys**, not values. The real API key already lives in Vercel (production Firebase client init works today), so blanking the committed copy does not change what the build uses.

The value is set to `""` with a comment, mirroring how the file already documents Vercel-managed values (`SENTRY_DSN` / `SENTRY_AUTH_TOKEN`). The remaining Firebase values (authDomain, projectId, appId, sender ID) are plain identifiers with no secret-pattern shape and stay committed.

## Verification

- No `AIza…` literal remains in any tracked file (`.env.example` keeps a truncated placeholder that doesn't match the pattern).
- `pnpm run env:validate` passes; `pre-push-verify` green (format / lint / tsc / test).

## Notes / out of scope

- The key remains in **git history**. Since it's a public Firebase key, rotation is optional and the existing GitHub alert can be dismissed as a false positive; history rewriting is destructive and not done here.

Closes #410

---
*Created by Claude Opus 4.8*
