### PR TITLE
ci: add dependency release-age cooldown gate (POC)

### DIFF
--- a/.github/workflows/release-age.yml
+++ b/.github/workflows/release-age.yml
@@ -1,0 +1,40 @@
+name: Release Age
+
+# Dependency-cooldown gate (POC): fails a PR that introduces a package version
+# younger than the cooldown window (default 7 days). Enforces our "let releases
+# age before we adopt them" supply-chain policy at the layer we control, rather
+# than relying on Dependabot's own `cooldown` (advisory, with documented npm
+# reliability gaps). See scripts/check-release-age.mjs for why this inspects the
+# lockfile diff instead of setting pnpm's `minimum-release-age` (which would slow
+# Dependabot's own resolution to a crawl).
+#
+# pull_request only: the gate blocks a hot version from *landing*. Running it on
+# push-to-main would only fail an already-merged commit. Gated to runs that
+# change the lockfile (or the checker itself) — nothing else affects the result.
+on:
+  pull_request:
+    paths:
+      - "pnpm-lock.yaml"
+      - "scripts/check-release-age.mjs"
+      - ".github/workflows/release-age.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-release-age:
+    name: Check dependency release age
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      # fetch-depth: 0 so the base commit is present for `git show <base>:...`.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      # The check needs only Node + git + network (no dependency install).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+      - run: node scripts/check-release-age.mjs "$BASE_SHA"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "env:validate": "node scripts/validate-config.mjs",
     "pins:actions": "node scripts/check-action-pins.mjs",
     "pins:check": "node scripts/check-package-pins.mjs",
+    "deps:release-age": "node scripts/check-release-age.mjs",
     "seed:debug": "node --env-file-if-exists=.env.local scripts/seed-debug-users.mjs"
   },
   "pnpm": {

--- a/scripts/check-release-age.mjs
+++ b/scripts/check-release-age.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Dependency-cooldown gate (POC). Fails a PR that introduces a package version
+ * younger than RELEASE_AGE_MIN_DAYS (default 7). This enforces the "let a
+ * release age before we adopt it" supply-chain policy deterministically, at the
+ * layer we control — independent of Dependabot's own `cooldown`, which is
+ * advisory at PR-creation time and has documented reliability gaps for npm.
+ *
+ * Why this shape and not pnpm's `minimum-release-age`: putting that setting in
+ * committed pnpm config makes Dependabot's own lockfile regeneration honor it,
+ * which forces pnpm to fetch publish-time metadata for the whole candidate tree
+ * on every update — the full-metadata storm that causes multi-minute/hour
+ * Dependabot timeouts on large repos. This gate never touches Dependabot's
+ * resolver: it inspects the *result* (the lockfile diff) and queries the
+ * registry for only the handful of newly-introduced versions.
+ *
+ * Usage:  node scripts/check-release-age.mjs [baseRef]
+ *   baseRef  git ref to diff against (default: origin/main). The base
+ *            pnpm-lock.yaml is read via `git show <baseRef>:pnpm-lock.yaml`;
+ *            the head lockfile is read from ./pnpm-lock.yaml in the working
+ *            tree. Only versions present in head but not base are checked.
+ *
+ * Exits 0 if every newly-introduced version is at least the threshold old (or
+ * could not be resolved on the public registry — private/workspace/tarball
+ * specifiers are skipped). Exits 1 listing each too-young version. Registry
+ * fetch failures are warned and skipped (fail-open) so a flaky registry does
+ * not produce a spurious red build; a confirmed too-young version always fails.
+ */
+
+import { execFileSync } from "child_process";
+import { readFileSync } from "fs";
+
+const baseRef = process.argv[2] ?? "origin/main";
+const minDays = Number(process.env.RELEASE_AGE_MIN_DAYS ?? "7");
+const minMs = minDays * 24 * 60 * 60 * 1000;
+
+const SEMVER_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+/**
+ * Collect the `name@version` keys from the top-level `packages:` block of a
+ * pnpm v9 lockfile. That block lists each resolved package canonically, without
+ * the peer-dependency suffixes that appear in `snapshots:`, so its keys are
+ * exactly the `name@version` pairs we want. Returns a Set of "name@version".
+ */
+function lockedPackages(lockfileText) {
+  const packages = new Set();
+  let inPackages = false;
+  for (const rawLine of lockfileText.split("\n")) {
+    const topLevel = /^(\S.*):\s*$/.exec(rawLine);
+    if (topLevel) {
+      inPackages = topLevel[1] === "packages";
+      continue;
+    }
+    if (!inPackages) continue;
+    // A package key is indented exactly two spaces and ends with a colon.
+    const entry = /^ {2}(\S.*):\s*$/.exec(rawLine);
+    if (entry) packages.add(entry[1].replace(/^['"]|['"]$/g, ""));
+  }
+  return packages;
+}
+
+/** Split a `name@version` key into its name and semver version, else undefined. */
+function parseKey(key) {
+  const at = key.lastIndexOf("@");
+  if (at <= 0) return undefined;
+  const name = key.slice(0, at);
+  const version = key.slice(at + 1).split("(")[0];
+  if (!SEMVER_VERSION.test(version)) return undefined;
+  return { name, version };
+}
+
+/** Publish timestamp (ms) for name@version, or undefined if unresolvable. */
+async function publishedAt(name, version) {
+  const url = `https://registry.npmjs.org/${name.replace("/", "%2F")}`;
+  const res = await fetch(url);
+  if (!res.ok) return undefined;
+  const time = (await res.json()).time?.[version];
+  return time ? Date.parse(time) : undefined;
+}
+
+const headLock = readFileSync("pnpm-lock.yaml", "utf8");
+const baseLock = execFileSync("git", ["show", `${baseRef}:pnpm-lock.yaml`], {
+  encoding: "utf8",
+});
+
+const basePackages = lockedPackages(baseLock);
+const introduced = [...lockedPackages(headLock)]
+  .filter((key) => !basePackages.has(key))
+  .map(parseKey)
+  .filter((parsed) => parsed !== undefined);
+
+const now = Date.now();
+const violations = [];
+for (const { name, version } of introduced) {
+  let published;
+  try {
+    published = await publishedAt(name, version);
+  } catch (err) {
+    console.warn(
+      `  warning: could not check ${name}@${version}: ${err.message}`,
+    );
+    continue;
+  }
+  if (published === undefined) continue; // private / workspace / unpublished
+  const ageDays = (now - published) / (24 * 60 * 60 * 1000);
+  if (now - published < minMs) {
+    violations.push(`  ${name}@${version} — ${ageDays.toFixed(1)} days old`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    `pnpm-lock.yaml — ${violations.length} newly-introduced version(s) younger than the ${minDays}-day cooldown:`,
+  );
+  for (const v of violations) console.error(v);
+  console.error(
+    "\nHold the update until the version ages past the cooldown, then re-run this\n" +
+      "check. Malicious releases are typically caught and yanked within days.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `pnpm-lock.yaml — all newly-introduced versions are at least ${minDays} days old. OK`,
+);

--- a/scripts/check-release-age.mjs
+++ b/scripts/check-release-age.mjs
@@ -30,8 +30,14 @@
 import { execFileSync } from "child_process";
 import { readFileSync } from "fs";
 
-const baseRef = process.argv[2] ?? "origin/main";
+const baseRef = process.argv[2] || "origin/main";
 const minDays = Number(process.env.RELEASE_AGE_MIN_DAYS ?? "7");
+if (!Number.isFinite(minDays) || minDays <= 0) {
+  console.error(
+    `RELEASE_AGE_MIN_DAYS must be a positive number; got: ${process.env.RELEASE_AGE_MIN_DAYS ?? "(unset)"}`,
+  );
+  process.exit(2);
+}
 const minMs = minDays * 24 * 60 * 60 * 1000;
 
 const SEMVER_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
@@ -73,7 +79,12 @@ function parseKey(key) {
 async function publishedAt(name, version) {
   const url = `https://registry.npmjs.org/${name.replace("/", "%2F")}`;
   const res = await fetch(url);
-  if (!res.ok) return undefined;
+  if (!res.ok) {
+    console.warn(
+      `  warning: could not check ${name}@${version}: HTTP ${res.status} from registry`,
+    );
+    return undefined;
+  }
   const time = (await res.json()).time?.[version];
   return time ? Date.parse(time) : undefined;
 }


### PR DESCRIPTION
## Purpose

POC for a **deterministic dependency-cooldown gate**: fail any PR that introduces a package version younger than a cooldown window (default 7 days). This enforces our "let releases age before we adopt them" supply-chain policy at a layer we control, rather than relying on Dependabot's own `cooldown` — which is advisory at PR-creation time and has [documented reliability gaps for the npm ecosystem](https://github.com/dependabot/dependabot-core/issues/12677). Models rmartz/hidden-role-game#828, and follows directly from the Dependabot-gap discussion in #412.

## How it works

- `scripts/check-release-age.mjs` diffs the PR's `pnpm-lock.yaml` against the base, collects only the **newly-introduced** `name@version` entries (direct **and** transitive), and queries the registry publish date for each. Fails listing any younger than `RELEASE_AGE_MIN_DAYS` (default 7).
- `.github/workflows/release-age.yml` runs it on PRs that change the lockfile. `pull_request`-only (the gate blocks a hot version from *landing*; running on `main` would only fail an already-merged commit), full-history checkout so it can read the base lockfile, Node-only setup (no `pnpm install`).

## Verified locally

Diffing the current tree against `3786033` (2026-06-30), the gate **correctly caught 14 sub-window versions that had actually slipped past Dependabot's 7-day cooldown** — e.g. `postcss@8.5.19` (2.7d), `hono@4.12.30` (3.1d), `tar@7.5.20` (3.9d), `nanoid@3.3.16` (3.8d) — including transitive bumps (`browserslist`, `caniuse-lite`, `es-module-lexer`). That's the exact slippage this gate closes. Both exit paths confirmed: `OK`/exit 0 when all aged, exit 1 listing violations otherwise.

- `format` / `lint` / `tsc` / `test` pass (`pre-push-verify`); action pins pass `pnpm pins:actions`. No dependency or lockfile changes.

## Technical considerations

- **Why not pnpm `minimum-release-age` in committed config:** that setting is read by Dependabot's own lockfile regeneration, forcing pnpm to fetch publish-time metadata for the whole candidate tree on every update — a full-metadata storm that causes multi-minute/hour Dependabot timeouts. This gate never touches Dependabot's resolver; it inspects the *result* and queries only the handful of changed versions.
- Diffing the **lockfile** (not just `package.json`) catches fresh **transitive** bumps too.
- Registry fetch failures are warned-and-skipped (fail-open) so a flaky registry doesn't produce spurious red builds; a confirmed too-young version always fails.

## POC scope / follow-ups

- Make it a **required** status check (branch protection) so it actually blocks merge — reported-only here.
- Coordinator should **re-run** the check (not close the PR) once a held version ages past the window, so the PR flips green and flows normally.
- Optional: a unit test around the lockfile parser / age logic (would require exporting the pure helpers and guarding top-level execution).

Closes #412

---
*Created by Claude Opus 4.8*
